### PR TITLE
Fix: install composer/npm deps for pre-cloned plugins

### DIFF
--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -32,18 +32,20 @@ install_plugin() {
 
   if [ ! -d "$plugin_dir" ] || [ "$DRY_RUN" = true ]; then
     run_cmd git clone "$repo_url" "$plugin_dir"
-    if [ -f "$plugin_dir/composer.json" ] || [ "$DRY_RUN" = true ]; then
-      run_cmd env COMPOSER_ALLOW_SUPERUSER=1 composer install \
-        --no-dev --no-interaction --working-dir="$plugin_dir" || \
-        warn "Composer failed, some $slug features may not work"
-    fi
-    if [ -f "$plugin_dir/package.json" ] || [ "$DRY_RUN" = true ]; then
-      log "Building $slug JS assets..."
-      run_cmd npm install --prefix "$plugin_dir" || \
-        warn "npm install failed for $slug"
-      run_cmd npm run build --prefix "$plugin_dir" || \
-        warn "npm build failed for $slug — admin pages may not work"
-    fi
+  fi
+
+  # Install dependencies even if plugin was pre-cloned.
+  if [ -f "$plugin_dir/composer.json" ] && { [ ! -d "$plugin_dir/vendor" ] || [ "$DRY_RUN" = true ]; }; then
+    run_cmd env COMPOSER_ALLOW_SUPERUSER=1 composer install \
+      --no-dev --no-interaction --working-dir="$plugin_dir" || \
+      warn "Composer failed, some $slug features may not work"
+  fi
+  if [ -f "$plugin_dir/package.json" ] && { [ ! -d "$plugin_dir/node_modules" ] || [ "$DRY_RUN" = true ]; }; then
+    log "Building $slug JS assets..."
+    run_cmd npm install --prefix "$plugin_dir" || \
+      warn "npm install failed for $slug"
+    run_cmd npm run build --prefix "$plugin_dir" || \
+      warn "npm build failed for $slug — admin pages may not work"
   fi
 
   activate_plugin "$slug"


### PR DESCRIPTION
## Summary

- `install_plugin` in `lib/wordpress.sh` skipped `composer install` and `npm install` when the plugin directory already existed on disk
- This broke `EXTRA_PLUGINS` entries that were pre-cloned by downstream scripts (e.g. intelligence's `a8c-setup.sh`) — `vendor/` was never created
- Separates "clone if missing" from "install deps if missing" so any plugin with a `composer.json` or `package.json` gets its dependencies regardless of how it arrived on disk

## Test plan

- [ ] Run setup with an `EXTRA_PLUGINS` entry that has a `composer.json` and is already cloned — verify `composer install` runs
- [ ] Run setup with a fresh `EXTRA_PLUGINS` entry — verify clone + deps still work as before
- [ ] Run setup twice — verify deps aren't re-installed when `vendor/` already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)