### PR TITLE
Rename launchd service prefix from com.extrachill to com.wp

### DIFF
--- a/lib/chat-bridge.sh
+++ b/lib/chat-bridge.sh
@@ -39,7 +39,7 @@ _install_kimaki() {
 }
 
 _install_kimaki_launchd() {
-  KIMAKI_PLIST_LABEL="com.extrachill.kimaki"
+  KIMAKI_PLIST_LABEL="com.wp.kimaki"
   KIMAKI_PLIST_DIR="$HOME/Library/LaunchAgents"
   KIMAKI_PLIST="$KIMAKI_PLIST_DIR/$KIMAKI_PLIST_LABEL.plist"
 
@@ -189,7 +189,7 @@ working_directory = \"$SITE_PATH\""
 }
 
 _install_cc_connect_launchd() {
-  CC_PLIST_LABEL="com.extrachill.cc-connect"
+  CC_PLIST_LABEL="com.wp.cc-connect"
   CC_PLIST_DIR="$HOME/Library/LaunchAgents"
   CC_PLIST="$CC_PLIST_DIR/$CC_PLIST_LABEL.plist"
 
@@ -363,8 +363,8 @@ LOG_LEVEL=info"
 }
 
 _install_telegram_launchd() {
-  SERVE_PLIST_LABEL="com.extrachill.opencode-serve"
-  TELEGRAM_PLIST_LABEL="com.extrachill.opencode-telegram"
+  SERVE_PLIST_LABEL="com.wp.opencode-serve"
+  TELEGRAM_PLIST_LABEL="com.wp.opencode-telegram"
   PLIST_DIR="$HOME/Library/LaunchAgents"
   SERVE_PLIST="$PLIST_DIR/$SERVE_PLIST_LABEL.plist"
   TELEGRAM_PLIST="$PLIST_DIR/$TELEGRAM_PLIST_LABEL.plist"

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -119,34 +119,34 @@ _print_local_next_steps() {
   if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$PLATFORM" = "mac" ]; then
     if [ -n "$KIMAKI_BOT_TOKEN" ]; then
       echo "  Kimaki (launchd service):"
-      echo "    Start:  launchctl kickstart gui/$(id -u)/com.extrachill.kimaki"
-      echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.extrachill.kimaki"
+      echo "    Start:  launchctl kickstart gui/$(id -u)/com.wp.kimaki"
+      echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.wp.kimaki"
     else
       echo "  Kimaki setup:"
       echo "    1. Run onboarding:  cd $SITE_PATH && kimaki"
-      echo "    2. Enable service:  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.extrachill.kimaki.plist"
+      echo "    2. Enable service:  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.kimaki.plist"
     fi
     echo "    Logs:   tail -f $KIMAKI_DATA_DIR/kimaki.log"
     echo ""
   elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "cc-connect" ] && [ "$PLATFORM" = "mac" ]; then
     echo "  cc-connect (launchd service):"
-    echo "    Start:  launchctl kickstart gui/$(id -u)/com.extrachill.cc-connect"
-    echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.extrachill.cc-connect"
+    echo "    Start:  launchctl kickstart gui/$(id -u)/com.wp.cc-connect"
+    echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.wp.cc-connect"
     echo "    Logs:   tail -f ${CC_DATA_DIR:-$SERVICE_HOME/.cc-connect}/cc-connect.log"
     echo ""
   elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "telegram" ] && [ "$PLATFORM" = "mac" ]; then
     if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_ALLOWED_USER_ID" ]; then
       echo "  Telegram (launchd services):"
-      echo "    Start:  launchctl kickstart gui/$(id -u)/com.extrachill.opencode-serve"
-      echo "            launchctl kickstart gui/$(id -u)/com.extrachill.opencode-telegram"
-      echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.extrachill.opencode-serve"
-      echo "            launchctl kill SIGTERM gui/$(id -u)/com.extrachill.opencode-telegram"
+      echo "    Start:  launchctl kickstart gui/$(id -u)/com.wp.opencode-serve"
+      echo "            launchctl kickstart gui/$(id -u)/com.wp.opencode-telegram"
+      echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.wp.opencode-serve"
+      echo "            launchctl kill SIGTERM gui/$(id -u)/com.wp.opencode-telegram"
     else
       echo "  Telegram setup:"
       echo "    1. Add tokens to $SERVICE_HOME/.config/opencode-telegram-bot/.env"
       echo "    2. Enable services:"
-      echo "       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.extrachill.opencode-serve.plist"
-      echo "       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.extrachill.opencode-telegram.plist"
+      echo "       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.opencode-serve.plist"
+      echo "       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.opencode-telegram.plist"
     fi
     echo "    Logs:   tail -f $SERVICE_HOME/.config/opencode-telegram-bot/opencode-serve.log"
     echo "            tail -f $SERVICE_HOME/.config/opencode-telegram-bot/opencode-telegram.log"

--- a/skills/wp-coding-agents-setup/SKILL.md
+++ b/skills/wp-coding-agents-setup/SKILL.md
@@ -253,8 +253,8 @@ systemctl enable kimaki
 **Local (macOS — launchd):**
 ```bash
 # Set KIMAKI_BOT_TOKEN in the plist if not already configured
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.extrachill.kimaki.plist
-launchctl kickstart gui/$(id -u)/com.extrachill.kimaki
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.kimaki.plist
+launchctl kickstart gui/$(id -u)/com.wp.kimaki
 ```
 
 ### cc-connect
@@ -267,8 +267,8 @@ systemctl enable cc-connect
 
 **Local (macOS — launchd):**
 ```bash
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.extrachill.cc-connect.plist
-launchctl kickstart gui/$(id -u)/com.extrachill.cc-connect
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.cc-connect.plist
+launchctl kickstart gui/$(id -u)/com.wp.cc-connect
 ```
 
 ### Telegram
@@ -288,8 +288,8 @@ systemctl enable opencode-serve opencode-telegram
 
 **Local (macOS — launchd):**
 ```bash
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.extrachill.opencode-serve.plist
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.extrachill.opencode-telegram.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.opencode-serve.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.opencode-telegram.plist
 ```
 
 3. **Verify:** Send a message to your bot on Telegram — it should respond via OpenCode.


### PR DESCRIPTION
Closes #33

## Summary

- Replace all `com.extrachill.*` launchd service labels with `com.wp.*`
- Affects `lib/chat-bridge.sh` (4 labels), `lib/summary.sh` (12 echo statements), and `skills/.../SKILL.md` (6 doc references)
- The `extrachill` prefix is confusing for users outside that org — `com.wp` matches the project name (wp-coding-agents)

## Test plan

- [ ] Run setup with `--runtime=claude-code` on macOS — verify plist is created as `com.wp.cc-connect.plist`
- [ ] Run setup with kimaki — verify plist is `com.wp.kimaki.plist`
- [ ] Verify `launchctl list | grep com.wp` shows the services
- [ ] Verify summary output references `com.wp` labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)