### PR TITLE
refactor: delegate AGENTS.md generation to SectionRegistry compose

### DIFF
--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -229,6 +229,16 @@ runtime_generate_instructions() {
 
   log "Generating AGENTS.md..."
 
+  # When Data Machine is installed, compose from registered sections.
+  if [ "$INSTALL_DATA_MACHINE" = true ] && [ "$DRY_RUN" = false ]; then
+    if wp_cmd datamachine agent compose AGENTS.md 2>/dev/null; then
+      log "AGENTS.md composed from SectionRegistry"
+      return
+    fi
+    warn "Compose failed — falling back to static template"
+  fi
+
+  # Fallback: minimal template for non-DM installs or dry-run.
   local agents_tmpl="$SCRIPT_DIR/workspace/AGENTS.md"
   if [ ! -f "$agents_tmpl" ]; then
     error "AGENTS.md template not found at $agents_tmpl"
@@ -243,16 +253,6 @@ runtime_generate_instructions() {
 
   local agents_md
   agents_md=$(sed "s|{{WP_CLI_CMD}}|$WP_CLI_DISPLAY|g" "$agents_tmpl")
-
-  # Remove Data Machine sections if DM not installed
-  if [ "$INSTALL_DATA_MACHINE" = false ]; then
-    agents_md=$(echo "$agents_md" | awk '/^### (Data Machine|Workspace)/{skip=1; next} /^### /{skip=0} /^## /{skip=0} !skip')
-  fi
-
-  # Remove multisite section for single-site installs
-  if [ "$MULTISITE" != true ]; then
-    agents_md=$(echo "$agents_md" | awk '/^### Multisite/{skip=1; next} /^### /{skip=0} /^## /{skip=0} !skip')
-  fi
 
   write_file "$SITE_PATH/AGENTS.md" "$agents_md"
   log "Generated AGENTS.md at $SITE_PATH/AGENTS.md"

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -231,48 +231,42 @@ runtime_generate_config() {
 }
 
 runtime_generate_instructions() {
-  # Generate AGENTS.md (skip if already exists — may have been customized)
   if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/AGENTS.md" ]; then
     log "Phase 8: AGENTS.md already exists — skipping (delete to regenerate)"
-  else
-    log "Phase 8: Generating AGENTS.md..."
-
-    local agents_tmpl="$SCRIPT_DIR/workspace/AGENTS.md"
-    if [ ! -f "$agents_tmpl" ]; then
-      error "AGENTS.md template not found at $agents_tmpl"
-    fi
-
-    local wp_cli_display="wp"
-    if [ "$IS_STUDIO" = true ]; then
-      wp_cli_display="studio wp"
-    elif [ "$LOCAL_MODE" = false ]; then
-      wp_cli_display="wp $WP_ROOT_FLAG --path=$SITE_PATH"
-    fi
-    if [ "$DRY_RUN" = true ]; then
-      echo -e "${BLUE}[dry-run]${NC} Would generate AGENTS.md from template"
-    else
-      sed "s|{{WP_CLI_CMD}}|$wp_cli_display|g" "$agents_tmpl" > "$SITE_PATH/AGENTS.md"
-    fi
-
-    # Remove Data Machine sections if DM not installed
-    if [ "$INSTALL_DATA_MACHINE" = false ] && [ -f "$SITE_PATH/AGENTS.md" ]; then
-      log "Removing Data Machine references from AGENTS.md..."
-      awk '/^### (Data Machine|Workspace)/{skip=1; next} /^### /{skip=0} /^## /{skip=0} !skip' \
-        "$SITE_PATH/AGENTS.md" > "$SITE_PATH/AGENTS.md.tmp" 2>/dev/null || true
-      mv "$SITE_PATH/AGENTS.md.tmp" "$SITE_PATH/AGENTS.md"
-    fi
-
-    # Remove multisite section for single-site installs
-    if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/AGENTS.md" ]; then
-      IS_MULTISITE="${IS_MULTISITE:-no}"
-      if [ "$IS_MULTISITE" != "yes" ]; then
-        awk '/^### Multisite/{skip=1; next} /^### /{skip=0} /^## /{skip=0} !skip' \
-          "$SITE_PATH/AGENTS.md" > "$SITE_PATH/AGENTS.md.tmp" 2>/dev/null || true
-        mv "$SITE_PATH/AGENTS.md.tmp" "$SITE_PATH/AGENTS.md"
-      fi
-    fi
+    return
   fi
 
+  log "Phase 8: Generating AGENTS.md..."
+
+  # When Data Machine is installed, compose from registered sections.
+  # This handles WP-CLI prefix resolution, multisite detection, and plugin
+  # sections (intelligence, etc.) automatically at runtime.
+  if [ "$INSTALL_DATA_MACHINE" = true ] && [ "$DRY_RUN" = false ]; then
+    if wp_cmd datamachine agent compose AGENTS.md 2>/dev/null; then
+      log "AGENTS.md composed from SectionRegistry"
+      return
+    fi
+    warn "Compose failed — falling back to static template"
+  fi
+
+  # Fallback: minimal template for non-DM installs or dry-run.
+  local agents_tmpl="$SCRIPT_DIR/workspace/AGENTS.md"
+  if [ ! -f "$agents_tmpl" ]; then
+    error "AGENTS.md template not found at $agents_tmpl"
+  fi
+
+  local wp_cli_display="wp"
+  if [ "$IS_STUDIO" = true ]; then
+    wp_cli_display="studio wp"
+  elif [ "$LOCAL_MODE" = false ]; then
+    wp_cli_display="wp $WP_ROOT_FLAG --path=$SITE_PATH"
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would generate AGENTS.md from template"
+  else
+    sed "s|{{WP_CLI_CMD}}|$wp_cli_display|g" "$agents_tmpl" > "$SITE_PATH/AGENTS.md"
+  fi
 }
 
 runtime_merge_mcp_servers() {

--- a/runtimes/studio-code.sh
+++ b/runtimes/studio-code.sh
@@ -272,6 +272,16 @@ runtime_generate_instructions() {
 
   log "Generating AGENTS.md..."
 
+  # When Data Machine is installed, compose from registered sections.
+  if [ "$INSTALL_DATA_MACHINE" = true ] && [ "$DRY_RUN" = false ]; then
+    if wp_cmd datamachine agent compose AGENTS.md 2>/dev/null; then
+      log "AGENTS.md composed from SectionRegistry"
+      return
+    fi
+    warn "Compose failed — falling back to static template"
+  fi
+
+  # Fallback: minimal template for non-DM installs or dry-run.
   local agents_tmpl="$SCRIPT_DIR/workspace/AGENTS.md"
   if [ ! -f "$agents_tmpl" ]; then
     error "AGENTS.md template not found at $agents_tmpl"
@@ -279,16 +289,6 @@ runtime_generate_instructions() {
 
   local agents_md
   agents_md=$(sed "s|{{WP_CLI_CMD}}|studio wp|g" "$agents_tmpl")
-
-  # Remove Data Machine sections if DM not installed
-  if [ "$INSTALL_DATA_MACHINE" = false ]; then
-    agents_md=$(echo "$agents_md" | awk '/^### (Data Machine|Workspace)/{skip=1; next} /^### /{skip=0} /^## /{skip=0} !skip')
-  fi
-
-  # Remove multisite section for single-site installs
-  if [ "$MULTISITE" != true ]; then
-    agents_md=$(echo "$agents_md" | awk '/^### Multisite/{skip=1; next} /^### /{skip=0} /^## /{skip=0} !skip')
-  fi
 
   write_file "$SITE_PATH/AGENTS.md" "$agents_md"
   log "Generated AGENTS.md at $SITE_PATH/AGENTS.md"

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -1,35 +1,6 @@
-# AGENTS.md
+# AI Instructions
 
 WP-CLI: `{{WP_CLI_CMD}}`
-
-### Data Machine
-
-Data Machine is your operating layer — memory, automation, and orchestration via WP-CLI.
-
-**Memory:** Persistent files across sessions. Discover yours: `{{WP_CLI_CMD}} datamachine agent paths`
-- Read/write/search memory: `{{WP_CLI_CMD}} datamachine agent read|write|search`
-- Update MEMORY.md when you learn something persistent — read it first, append new info.
-
-**Automation:** Self-scheduling workflows that run without human intervention.
-- Flows: `{{WP_CLI_CMD}} datamachine flow create|run|list` — scheduled or on-demand tasks
-- Pipelines: `{{WP_CLI_CMD}} datamachine pipeline create|list` — multi-step processing chains
-- Jobs: `{{WP_CLI_CMD}} datamachine jobs list|retry|summary` — monitor queued work
-- Discover available step types: `{{WP_CLI_CMD}} datamachine step-types list`
-- Discover available handlers: `{{WP_CLI_CMD}} datamachine handlers list`
-
-**Code (data-machine-code):** Managed git workspace and GitHub integration.
-- Workspace: `{{WP_CLI_CMD}} datamachine-code workspace clone|read|write|edit|git`
-- GitHub: `{{WP_CLI_CMD}} datamachine-code github issues|pulls|repos|comment`
-
-**System:** `{{WP_CLI_CMD}} datamachine system health|prompts|run`
-
-Use `--help` on any command to discover options and subcommands.
-
-### Abilities
-
-WordPress Abilities are the universal tool surface. Plugins register abilities that are automatically available via WP-CLI, REST API, MCP, and chat. Discover what's available: `{{WP_CLI_CMD}} help abilities`
-
-The tool surface grows as plugins are installed — always discover before assuming what's available.
 
 ### WordPress Source
 
@@ -37,11 +8,3 @@ Direct reference material — grep it as needed:
 - `wp-content/plugins/` — all plugin source
 - `wp-content/themes/` — all theme source
 - `wp-includes/` — WordPress core (read-only)
-
-### Multisite
-
-This is a WordPress multisite. Use `--url` to target specific sites:
-```
-{{WP_CLI_CMD}} --url=site.example.com <command>
-```
-Without `--url`, commands default to the main site.


### PR DESCRIPTION
## Summary

Closes Extra-Chill/data-machine-code#15 — moves AGENTS.md content ownership from bash templates to Data Machine's `SectionRegistry`.

### What changed

**All 3 runtimes** (opencode, claude-code, studio-code) now call `wp datamachine agent compose AGENTS.md` when Data Machine is installed, instead of doing `sed` substitution + `awk` stripping on the static template.

**Template reduced** from 47 lines to 10 — just a header with `{{WP_CLI_CMD}}` and a `WordPress Source` pointer. Only used as fallback when DM is not installed.

**Removed:**
- All `awk` conditional stripping (Data Machine sections, Workspace sections, Multisite sections)
- Duplicated template content that now lives in `data-machine-code` SectionRegistry callbacks

### How it works

```
DM installed?
  ├─ YES → wp datamachine agent compose AGENTS.md
  │         ├─ Resolves WP-CLI prefix dynamically (--allow-root, --path)
  │         ├─ Includes plugin-registered sections (intelligence, etc.)
  │         ├─ Conditionally includes multisite section
  │         └─ Writes to site root via convention_path
  └─ NO  → sed template fallback (minimal: header + WordPress Source)
```

### Depends on

- Extra-Chill/data-machine-code#16 (merged) — registered full AGENTS.md sections with `datamachine_code_resolve_wp_cli_cmd()` helper