### PR TITLE
fix(kimaki-plugin): strip worktree conflicts + low-value sections from agent context

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Kimaki plugin: strip `--worktree` / `--cwd` examples and the per-turn "## worktree" block from the agent context. Data Machine Code owns the workspace and creates its own worktrees; leaving Kimaki's worktree language in the prompt caused the agent to try running work inside a Kimaki worktree instead of the DM Code workspace.
+
 ## [0.2.1] - 2026-04-07
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-### Fixed
-- Kimaki plugin: strip `--worktree` / `--cwd` examples and the per-turn "## worktree" block from the agent context. Data Machine Code owns the workspace and creates its own worktrees; leaving Kimaki's worktree language in the prompt caused the agent to try running work inside a Kimaki worktree instead of the DM Code workspace.
-
-### Changed
-- Kimaki plugin: also strip `## permissions` (Discord role metadata the agent can't act on) and `## upgrading kimaki` (the `/upgrade-and-restart` slash-command playbook — the user invokes it directly). `## debugging kimaki issues` is intentionally kept so the agent can find `kimaki.log` when Kimaki itself misbehaves.
-
 ## [0.2.1] - 2026-04-07
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Kimaki plugin: strip `--worktree` / `--cwd` examples and the per-turn "## worktree" block from the agent context. Data Machine Code owns the workspace and creates its own worktrees; leaving Kimaki's worktree language in the prompt caused the agent to try running work inside a Kimaki worktree instead of the DM Code workspace.
 
+### Changed
+- Kimaki plugin: also strip `## permissions` (Discord role metadata the agent can't act on) and `## upgrading kimaki` (the `/upgrade-and-restart` slash-command playbook — the user invokes it directly). `## debugging kimaki issues` is intentionally kept so the agent can find `kimaki.log` when Kimaki itself misbehaves.
+
 ## [0.2.1] - 2026-04-07
 
 ### Changed

--- a/kimaki/plugins/dm-context-filter.ts
+++ b/kimaki/plugins/dm-context-filter.ts
@@ -11,11 +11,19 @@
 // 4. Worktree creation — ~150 tokens. We use feature branches in workspace repos.
 // 5. Cross-project commands — ~200 tokens. Single-project fleet servers.
 // 6. Waiting for sessions — ~150 tokens. Rarely used, discoverable via --help.
+// 7. Worktree conflicts — inline --worktree/--cwd examples in "starting new
+//    sessions from CLI", the orphan "Worktrees are useful..." lead-in, and the
+//    per-turn "## worktree" section. Data Machine Code manages its own
+//    workspace and worktrees; keeping Kimaki's worktree language around causes
+//    the agent to try using Kimaki worktrees instead of DM Code's workspace.
 //
 // What it removes from chat message injection:
-// 7. MEMORY.md injection — Kimaki reads MEMORY.md from the project directory and
+// 8. MEMORY.md injection — Kimaki reads MEMORY.md from the project directory and
 //    injects a condensed TOC. Conflicts with Data Machine's own memory files.
-// 8. "Update MEMORY.md" time-gap reminder — Redundant with external memory system.
+// 9. "Update MEMORY.md" time-gap reminder — Redundant with external memory system.
+// 10. Worktree system-reminder — Kimaki injects a <system-reminder> telling the
+//     agent to operate inside its worktree and not touch the main repo. This
+//     overrides Data Machine Code's workspace, which is the real working dir.
 //
 // Total savings: ~2,400+ tokens per session.
 //
@@ -34,6 +42,7 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "## scheduled sends and task management");
         result = stripSection(result, "## running dev servers with tunnel access");
         result = stripSection(result, "## creating worktrees");
+        result = stripSection(result, "## worktree");
         result = stripSection(result, "## cross-project commands");
         result = stripSection(result, "## waiting for a session to finish");
         result = stripSection(result, "## showing diffs");
@@ -41,13 +50,15 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "### always show diff at end of session");
         result = stripSection(result, "### fetching user comments from critique diffs");
         result = stripSection(result, "### reviewing diffs with AI");
+        result = stripWorktreeInlines(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");
         return result;
       });
     },
 
-    // Filter out Kimaki's MEMORY.md injection and time-gap MEMORY.md reminders.
+    // Filter out Kimaki's MEMORY.md injection, time-gap MEMORY.md reminders,
+    // and worktree system-reminders.
     "chat.message": async (_input, output) => {
       // Walk backwards so splice indices stay valid.
       for (let i = output.parts.length - 1; i >= 0; i--) {
@@ -66,6 +77,13 @@ const fleetContextFilter: Plugin = async () => {
 
         // Remove "update MEMORY.md" time-gap reminder.
         if (text.includes("update MEMORY.md before starting the new task")) {
+          output.parts.splice(i, 1);
+          continue;
+        }
+
+        // Remove Kimaki's worktree system-reminder. Data Machine Code manages
+        // the real working directory; Kimaki's reminder conflicts with it.
+        if (text.includes("running inside a git worktree")) {
           output.parts.splice(i, 1);
           continue;
         }
@@ -94,6 +112,57 @@ function stripSection(block: string, heading: string): string {
     `${escaped}[\\s\\S]*?(?=${stopPattern}|$)`
   );
   return block.replace(pattern, "");
+}
+
+/**
+ * Remove inline worktree/--worktree/--cwd content that lives inside sections
+ * we otherwise want to keep (like "## starting new sessions from CLI") or
+ * as standalone paragraphs between sections.
+ *
+ * These exist because Kimaki assumes worktrees are a first-class feature, but
+ * Data Machine Code owns the workspace and worktrees on DM-managed sites.
+ * Leaving the language in causes the agent to try `kimaki send --worktree`
+ * or treat a Kimaki worktree as its working directory instead of using the
+ * DM Code workspace.
+ */
+function stripWorktreeInlines(block: string): string {
+  let result = block;
+
+  // Standalone lead-in paragraph that sits above the (stripped) "## creating
+  // worktrees" section. After the section is stripped, this line is orphaned.
+  result = result.replace(
+    /\n+Worktrees are useful for handing off parallel tasks[^\n]*\n/g,
+    "\n"
+  );
+
+  // Inline "IMPORTANT: NEVER use --worktree" warning inside
+  // "## starting new sessions from CLI".
+  result = result.replace(
+    /\n+IMPORTANT: NEVER use `--worktree`[^\n]*\n/g,
+    "\n"
+  );
+
+  // "Use --worktree to create a git worktree for the session..." example block.
+  // Covers the intro line, the code example, and trailing blank line.
+  result = result.replace(
+    /\n+Use --worktree to create a git worktree[\s\S]*?--worktree [^\n]*\n/g,
+    "\n"
+  );
+
+  // "Use --cwd to start a session in an existing git worktree..." example block.
+  result = result.replace(
+    /\n+Use --cwd to start a session in an existing git worktree[\s\S]*?--cwd [^\n]*\n/g,
+    "\n"
+  );
+
+  // "Important:" bullet list about --worktree that follows the examples above.
+  // Only strip if the list is clearly about worktrees (first bullet mentions it).
+  result = result.replace(
+    /\n+Important:\n(?:- [^\n]*\n)*?- NEVER use `--worktree`[^\n]*\n(?:- [^\n]*\n)*/g,
+    "\n"
+  );
+
+  return result;
 }
 
 export default fleetContextFilter;

--- a/kimaki/plugins/dm-context-filter.ts
+++ b/kimaki/plugins/dm-context-filter.ts
@@ -16,6 +16,13 @@
 //    per-turn "## worktree" section. Data Machine Code manages its own
 //    workspace and worktrees; keeping Kimaki's worktree language around causes
 //    the agent to try using Kimaki worktrees instead of DM Code's workspace.
+// 8. Permissions — ~80 tokens describing which Discord roles can message the
+//    bot. The agent has no capability to act on this; pure metadata leakage.
+// 9. Upgrading kimaki — ~80 tokens of /upgrade-and-restart playbook. The user
+//    runs the slash command themselves when they want to upgrade.
+//
+// NOTE: "## debugging kimaki issues" is intentionally kept — when Kimaki itself
+// throws errors, the agent needs the kimaki.log path to investigate.
 //
 // What it removes from chat message injection:
 // 8. MEMORY.md injection — Kimaki reads MEMORY.md from the project directory and
@@ -39,6 +46,8 @@ const fleetContextFilter: Plugin = async () => {
     "experimental.chat.system.transform": async (_input, output) => {
       output.system = output.system.map((block) => {
         let result = block;
+        result = stripSection(result, "## permissions");
+        result = stripSection(result, "## upgrading kimaki");
         result = stripSection(result, "## scheduled sends and task management");
         result = stripSection(result, "## running dev servers with tunnel access");
         result = stripSection(result, "## creating worktrees");


### PR DESCRIPTION
## Summary

Clean up the Kimaki system prompt injected into every OpenCode session on DM-managed VPSes. Main driver: Data Machine Code now manages its own git workspace and worktrees, so Kimaki's worktree language causes the agent to operate in the wrong directory. Also strips two sections with near-zero agent value.

## Changes

**`kimaki/plugins/dm-context-filter.ts`**

### Worktree conflict fixes (primary)
- Strip the `## worktree` per-turn section Kimaki injects when a session is in a Kimaki-managed worktree — this was the biggest conflict source, since it explicitly told the agent to edit files in the Kimaki worktree and not touch the main repo.
- New `stripWorktreeInlines()` helper strips `--worktree` / `--cwd` paragraphs *inside* `## starting new sessions from CLI` while preserving `--notify-only`, `--user`, `--agent` examples in that same section.
- Strip the orphan "Worktrees are useful for handing off parallel tasks..." lead-in.
- Strip the standalone "IMPORTANT: NEVER use --worktree" warning line.
- Strip the `<system-reminder>` "This session is running inside a git worktree" synthetic part at the `chat.message` layer.

### Additional low-value sections
- Strip `## permissions` — lists Discord roles that can message the bot. Pure metadata the agent has no capability to act on.
- Strip `## upgrading kimaki` — describes `/upgrade-and-restart` and `kimaki upgrade`. The user invokes these directly; no reason to inject the playbook every session.
- **Keep** `## debugging kimaki issues` — when Kimaki itself throws errors, the agent needs the `kimaki.log` path to find root causes. Real use case given known Kimaki bugs.

## Verification

Tested filter regexes against fixture prompts for both the latest kimaki source (`/var/lib/datamachine/workspace/kimaki/discord/src/system-message.ts`) and the version currently deployed on the VPS. In both cases:

- All `--worktree`, `--cwd`, and "running inside a git worktree" references removed.
- `## permissions` and `## upgrading kimaki` cleanly removed without eating adjacent sections.
- `## starting new sessions from CLI` (minus worktree bits), `## debugging kimaki issues`, `## uploading files to discord`, `## archiving the current thread`, `## markdown formatting`, etc. all intact.

## Notes

- Total new savings: ~450 tokens per session on top of the existing ~2,400.
- No manual changelog edit — `homeboy release wp-coding-agents` handles the version bump + changelog generation from commit messages.