### PR TITLE
fix(upgrade): use in-place compose for AGENTS.md

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -336,31 +336,34 @@ regenerate_agents_md() {
     return 0
   fi
 
-  # Backup existing
+  # Backup existing (compose writes in-place to the registered location)
   if [ -f "$AGENTS_MD" ]; then
     cp "$AGENTS_MD" "$BACKUP"
     log "  Backup: $BACKUP"
   fi
 
-  # Compose into a temp file so we can diff
-  local TMP_AGENTS
-  TMP_AGENTS=$(mktemp)
-  if (cd "$SITE_PATH" && $WP_CMD datamachine agent compose "$TMP_AGENTS" $WP_ROOT_FLAG 2>/dev/null); then
-    if [ -f "$AGENTS_MD" ] && cmp -s "$TMP_AGENTS" "$AGENTS_MD"; then
+  # `datamachine agent compose AGENTS.md` writes in-place to the registered
+  # composable file path. It does NOT accept an arbitrary output path —
+  # the filename must be a registered MemoryFileRegistry entry.
+  if (cd "$SITE_PATH" && $WP_CMD datamachine agent compose AGENTS.md $WP_ROOT_FLAG >/dev/null 2>&1); then
+    if [ -f "$BACKUP" ] && cmp -s "$BACKUP" "$AGENTS_MD"; then
       log "  AGENTS.md unchanged"
-      rm -f "$TMP_AGENTS" "$BACKUP" 2>/dev/null || true
+      rm -f "$BACKUP" 2>/dev/null || true
     else
-      if [ -f "$AGENTS_MD" ]; then
-        log "  Changes detected:"
-        diff -u "$AGENTS_MD" "$TMP_AGENTS" 2>/dev/null | head -40 | sed 's/^/    /' || true
-      fi
-      mv "$TMP_AGENTS" "$AGENTS_MD"
       log "  AGENTS.md regenerated"
+      if [ -f "$BACKUP" ]; then
+        log "  Diff (first 40 lines):"
+        diff -u "$BACKUP" "$AGENTS_MD" 2>/dev/null | head -40 | sed 's/^/    /' || true
+      fi
       UPDATED_ITEMS+=("AGENTS.md")
     fi
   else
-    rm -f "$TMP_AGENTS"
     warn "  datamachine agent compose failed — AGENTS.md unchanged"
+    # Restore from backup if compose wrote a partial file
+    if [ -f "$BACKUP" ] && [ -f "$AGENTS_MD" ] && ! cmp -s "$BACKUP" "$AGENTS_MD"; then
+      cp "$BACKUP" "$AGENTS_MD"
+      warn "  Restored AGENTS.md from backup"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Bug

Phase 4 of upgrade.sh was failing on live runs:

```
[wp-coding-agents] Phase 4: Regenerating AGENTS.md...
[wp-coding-agents]   Backup: /var/www/.../AGENTS.md.backup.<ts>
[wp-coding-agents]   datamachine agent compose failed — AGENTS.md unchanged
```

## Root cause

`datamachine agent compose <filename>` does NOT accept an arbitrary output path — it writes **in-place** to the registered `MemoryFileRegistry` entry for that filename. Passing `mktemp` as the target produced:

```
Error: File "/tmp/tmp.XXX" is not registered in the MemoryFileRegistry.
```

## Fix

- Call `compose AGENTS.md` so DM writes to its registered location
- Diff against the timestamped backup instead of a temp file (same UX, correct mechanics)
- Redirect compose stdout so `Success: Regenerated AGENTS.md...` doesn't leak into upgrade.sh output
- Added restore-from-backup safety in case compose partially writes

## Tested

On chubes.net — phase 4 now correctly regenerates AGENTS.md and picks up the worktree discipline section added by commit 2362145. Idempotent re-run reports `AGENTS.md unchanged`.