### PR TITLE
fix(upgrade): make upgrade.sh + skill env-agnostic for local installs

### DIFF
--- a/kimaki/post-upgrade.sh
+++ b/kimaki/post-upgrade.sh
@@ -1,9 +1,29 @@
 #!/usr/bin/env bash
 # post-upgrade.sh — Remove unwanted bundled Kimaki skills.
-# Called by ExecStartPre in kimaki.service on each crew VPS.
+#
+# Invoked two ways:
+#   VPS:   ExecStartPre in kimaki.service (runs on every service start).
+#   Local: upgrade.sh runs it inline after copying plugins (no launchd hook).
+#
+# Skills dir resolution priority:
+#   1. KIMAKI_SKILLS_DIR env var (explicit override)
+#   2. $(npm root -g)/kimaki/skills (works on macOS + Linux when npm is on PATH)
+#   3. /usr/lib/node_modules/kimaki/skills (Linux VPS fallback when npm absent)
 set -euo pipefail
 
-SKILLS_DIR="/usr/lib/node_modules/kimaki/skills"
+if [[ -n "${KIMAKI_SKILLS_DIR:-}" ]]; then
+  SKILLS_DIR="$KIMAKI_SKILLS_DIR"
+elif command -v npm &>/dev/null; then
+  NPM_ROOT="$(npm root -g 2>/dev/null || true)"
+  if [[ -n "$NPM_ROOT" ]]; then
+    SKILLS_DIR="$NPM_ROOT/kimaki/skills"
+  else
+    SKILLS_DIR="/usr/lib/node_modules/kimaki/skills"
+  fi
+else
+  SKILLS_DIR="/usr/lib/node_modules/kimaki/skills"
+fi
+
 KILL_LIST="$(dirname "$0")/skills-kill-list.txt"
 
 if [[ ! -d "$SKILLS_DIR" ]]; then

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -1,61 +1,138 @@
 ---
 name: upgrade-wp-coding-agents
-description: "Safely upgrade wp-coding-agents infrastructure on a live VPS without touching user state. Syncs plugins, skills, AGENTS.md, systemd unit, and re-applies the claude-auth PascalCase patch."
-compatibility: "Requires wp-coding-agents repo clone and an existing setup. Works on VPS (systemd) and local installs."
+description: "Safely upgrade wp-coding-agents on a live install — VPS or local — without touching user state. Syncs plugins, skills, AGENTS.md, systemd unit (VPS), and re-applies the claude-auth PascalCase patch."
+compatibility: "Requires a wp-coding-agents repo clone and an existing setup. Works on VPS (systemd) and local installs (macOS launchd or manual)."
 ---
 
 # Upgrade wp-coding-agents
 
-**Purpose:** Pull the latest wp-coding-agents improvements onto a live install — new plugin versions, updated skills, regenerated AGENTS.md, systemd template fixes, and the opencode-claude-auth patch — without touching opencode config, WordPress, or agent memory.
+**Purpose:** Pull the latest wp-coding-agents improvements onto a live install — new plugin versions, updated skills, regenerated AGENTS.md, systemd template fixes (VPS), and the opencode-claude-auth patch — without touching opencode config, WordPress, or agent memory.
+
+The same `upgrade.sh` script handles both environments. It auto-detects and branches internally; you do not need to memorise paths.
 
 ## When to use
 
 The user says something like:
 - "Upgrade wp-coding-agents"
-- "Pull the latest plugin fixes to this VPS"
+- "Pull the latest plugin fixes onto this install"
 - "My dm-context-filter.ts is out of date"
 - "Regenerate AGENTS.md from the latest template"
 
-## Steps
+## Step 1 — Detect the environment
 
-1. **Pull latest wp-coding-agents code.**
-   ```bash
-   cd /var/lib/datamachine/workspace/wp-coding-agents
-   git pull origin main
-   ```
+Before running anything, identify which side you are on. The script auto-detects, but you should know too so you can give the user the right restart instructions.
 
-2. **Preview with a dry run.** This never modifies anything — it just shows you what would change.
-   ```bash
-   ./upgrade.sh --dry-run
-   ```
-   Review the diff output. If anything looks wrong (wrong runtime detected, unexpected kimaki.service rewrite, etc.), stop and investigate.
+| Signal | VPS | Local |
+|---|---|---|
+| `/etc/systemd/system/kimaki.service` exists | yes | no |
+| `command -v studio` succeeds | usually no | usually yes |
+| Platform | Linux | macOS or Linux |
+| Plugins land at | `/opt/kimaki-config/plugins` | `$(npm root -g)/kimaki/plugins` |
+| Restart command | `systemctl restart kimaki` | `launchctl kickstart -k gui/$(id -u)/com.wp.kimaki` (launchd) or "stop the kimaki process" (manual) |
 
-3. **Run the upgrade for real.**
-   ```bash
-   ./upgrade.sh
-   ```
-   Backups of `/opt/kimaki-config`, `AGENTS.md`, and `kimaki.service` are written alongside the originals with a timestamp suffix.
+**On macOS the script auto-enables `--local`.** On Linux without `--local`, the script assumes VPS.
 
-4. **Verify.**
-   ```bash
-   diff -u /opt/kimaki-config/plugins/dm-context-filter.ts \
-           /var/lib/datamachine/workspace/wp-coding-agents/kimaki/plugins/dm-context-filter.ts
-   head -20 /var/www/*/AGENTS.md
-   ls /root/.kimaki/projects/*/skills 2>/dev/null || ls /var/www/*/.opencode/skills
-   systemctl status kimaki
-   ```
+## Step 2 — Resolve the repo path
 
-5. **Tell the user to restart kimaki when ready.** The upgrade script never restarts the service automatically — active Discord sessions would be killed.
-   > "Restart kimaki when ready: `systemctl restart kimaki` (active sessions will die)."
+Never hardcode the workspace path. Use whichever clone the user has on disk:
+
+```bash
+# Inside the wp-coding-agents clone:
+cd "$(git rev-parse --show-toplevel)"
+
+# Or from a known checkout:
+cd /path/to/wp-coding-agents
+```
+
+Then pull latest:
+
+```bash
+git pull origin main
+```
+
+> If the user maintains a fork or a feature branch, ask before pulling. Default is `origin/main`.
+
+## Step 3 — Dry run
+
+Always dry-run first on a live install. The dry-run never modifies anything.
+
+**VPS:**
+```bash
+./upgrade.sh --dry-run
+```
+
+**Local:**
+```bash
+./upgrade.sh --dry-run --wp-path "/path/to/site"
+# --local is auto on macOS; pass it explicitly on Linux local installs.
+```
+
+Review the diff output. If anything looks wrong (wrong runtime detected, unexpected unit rewrite, plugin paths point somewhere weird), stop and investigate before proceeding.
+
+## Step 4 — Run the upgrade
+
+Drop `--dry-run`:
+
+**VPS:**
+```bash
+./upgrade.sh
+```
+
+**Local:**
+```bash
+./upgrade.sh --wp-path "/path/to/site"
+```
+
+Backups are written next to each touched file with a timestamp suffix. On VPS that means `/opt/kimaki-config.backup.<ts>`, `AGENTS.md.backup.<ts>`, `kimaki.service.backup.<ts>`. On local, the kimaki-config backup lands under `$KIMAKI_DATA_DIR/backups/` (defaults to `~/.kimaki/backups/`).
+
+On local, `upgrade.sh` also runs `post-upgrade.sh` inline to enforce the skills kill list against the npm-installed kimaki package — VPS gets this on the next `systemctl restart kimaki` via the unit's `ExecStartPre`.
+
+## Step 5 — Verify
+
+The script's summary block prints the right verify commands for the detected environment. Run them and sanity-check.
+
+**VPS verify:**
+```bash
+systemctl status kimaki
+diff -u /opt/kimaki-config/plugins/dm-context-filter.ts \
+        "$(git -C /path/to/wp-coding-agents rev-parse --show-toplevel)/kimaki/plugins/dm-context-filter.ts"
+head -20 /var/www/*/AGENTS.md
+```
+
+**Local verify:**
+```bash
+# launchd (auto-installed on macOS):
+launchctl print "gui/$(id -u)/com.wp.kimaki" | head -20
+# or, if running kimaki manually:
+pgrep -fl kimaki
+
+NPM_ROOT="$(npm root -g)"
+diff -u "$NPM_ROOT/kimaki/plugins/dm-context-filter.ts" \
+        "$(git -C /path/to/wp-coding-agents rev-parse --show-toplevel)/kimaki/plugins/dm-context-filter.ts"
+head -20 /path/to/site/AGENTS.md
+```
+
+## Step 6 — Tell the user to restart kimaki
+
+The upgrade script never restarts the chat bridge automatically — active Discord sessions would die mid-turn. Hand the right command to the user based on what was detected:
+
+- **VPS:** `systemctl restart kimaki`
+- **Local launchd (macOS):** `launchctl kickstart -k gui/$(id -u)/com.wp.kimaki`
+- **Local manual:** stop the running kimaki process and re-launch with `cd <site> && kimaki`
+
+> Always say something like: *"Restart kimaki when ready — active sessions will die."* Let the user pick the moment.
 
 ## Scope flags
 
-- `--kimaki-only` — only sync `/opt/kimaki-config` (plugins, post-upgrade.sh, kill list)
-- `--skills-only` — only refresh agent skills from WordPress/agent-skills + Extra-Chill/data-machine-skills
+These work in both VPS and local mode:
+
+- `--kimaki-only` — only sync the kimaki config + plugins
+- `--skills-only` — only refresh agent skills (WordPress/agent-skills + Extra-Chill/data-machine-skills)
 - `--agents-md-only` — only regenerate AGENTS.md via `datamachine agent compose`
 
 ## Never do
 
-- Never restart the kimaki service automatically. Always let the user decide.
-- Never touch `opencode.json`, WordPress DB, nginx, SSL certs, `~/.kimaki/` auth state, `/var/lib/datamachine/workspace/` cloned repos, or agent memory files (SOUL.md / MEMORY.md / USER.md).
-- Never run without a dry-run first on a live VPS.
+- Never restart kimaki automatically. Always let the user decide.
+- Never touch `opencode.json`, the WordPress DB, nginx, SSL certs, `~/.kimaki/` auth state and OAuth tokens, the DM workspace cloned repos, or agent memory files (`SOUL.md` / `MEMORY.md` / `USER.md`).
+- Never run without a dry-run first on a live install.
+- Never hardcode `/var/lib/...`, `/opt/...`, `/var/www/...`, or `/root/...` paths in the steps you give the user. Use `git rev-parse --show-toplevel`, `$(npm root -g)`, `$KIMAKI_DATA_DIR`, and the script's auto-detection.

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -4,23 +4,28 @@
 # Safely upgrade a live wp-coding-agents install without touching user state.
 #
 # Phases:
-#   1. Detect environment
-#   2. Sync kimaki-config (plugins, post-upgrade.sh, skills-kill-list)
+#   1. Detect environment (auto-detects local vs VPS, runtime, chat bridge)
+#   2. Sync kimaki config + plugins
+#        VPS:   /opt/kimaki-config (plugins + post-upgrade.sh + kill list)
+#        Local: $(npm root -g)/kimaki/plugins for plugins,
+#               $KIMAKI_DATA_DIR/kimaki-config/ for post-upgrade.sh + kill list,
+#               and runs post-upgrade.sh inline (no launchd ExecStartPre hook).
 #   3. Sync agent skills (WordPress + Data Machine)
 #   4. Regenerate AGENTS.md via Data Machine compose
-#   5. Smart systemd update (merges host-specific Environment= lines)
+#   5. Smart systemd update (VPS only; merges host-specific Environment= lines)
 #   6. Re-apply opencode-claude-auth PascalCase patch
 #   7. Summary
 #
 # Usage:
-#   ./upgrade.sh                 # run all phases
+#   ./upgrade.sh                 # run all phases (auto-detects environment)
 #   ./upgrade.sh --dry-run       # preview without changes
-#   ./upgrade.sh --kimaki-only   # only sync /opt/kimaki-config
+#   ./upgrade.sh --kimaki-only   # only sync kimaki config + plugins
 #   ./upgrade.sh --skills-only   # only sync skills
 #   ./upgrade.sh --agents-md-only  # only regenerate AGENTS.md
+#   ./upgrade.sh --local --wp-path <path>  # local install (auto on macOS)
 #
 # Safety: NEVER touches opencode.json, WordPress DB, nginx, SSL,
-#   ~/.kimaki/ auth state, /var/lib/datamachine/workspace/ repos,
+#   ~/.kimaki/ auth state, the DM workspace cloned repos,
 #   agent memory files, or the running kimaki service.
 #
 
@@ -88,20 +93,24 @@ wp-coding-agents upgrade script
 Safely upgrade a live install without touching user state.
 
 USAGE:
-  ./upgrade.sh                  Run all phases
+  ./upgrade.sh                  Run all phases (auto-detects local vs VPS)
   ./upgrade.sh --dry-run        Preview what would change
-  ./upgrade.sh --kimaki-only    Only sync /opt/kimaki-config
+  ./upgrade.sh --kimaki-only    Only sync kimaki config + plugins
   ./upgrade.sh --skills-only    Only sync agent skills
   ./upgrade.sh --agents-md-only Only regenerate AGENTS.md
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
   ./upgrade.sh --wp-path <path> Override detected WordPress path
-  ./upgrade.sh --local          Local mode (no systemd, no service user)
+  ./upgrade.sh --local          Local mode (no systemd; auto-on on macOS)
+
+PLUGIN INSTALL TARGETS:
+  VPS:   /opt/kimaki-config/plugins
+  Local: \$(npm root -g)/kimaki/plugins
 
 NEVER TOUCHED:
   - opencode.json / CLAUDE.md runtime config
   - WordPress database, nginx, SSL certs
   - ~/.kimaki/ auth state and OAuth tokens
-  - /var/lib/datamachine/workspace/ cloned repos
+  - DM workspace cloned repos
   - Agent memory files (SOUL.md, MEMORY.md, USER.md, etc.)
   - Running kimaki service (never restarted automatically)
 HELP
@@ -155,13 +164,21 @@ if [ ! -f "$RUNTIME_FILE" ]; then
 fi
 source "$RUNTIME_FILE"
 
-# Detect chat bridge from installed services
-if [ -f "/etc/systemd/system/kimaki.service" ]; then
-  CHAT_BRIDGE="kimaki"
-elif [ -f "/etc/systemd/system/cc-connect.service" ]; then
-  CHAT_BRIDGE="cc-connect"
-elif [ -f "/etc/systemd/system/opencode-telegram.service" ]; then
-  CHAT_BRIDGE="telegram"
+# Detect chat bridge from installed services / installed binaries.
+# VPS: systemd unit files are the source of truth.
+# Local: no systemd — fall back to launchd plist (macOS) or `command -v kimaki`.
+if [ "$LOCAL_MODE" = true ]; then
+  if [ -f "$HOME/Library/LaunchAgents/com.wp.kimaki.plist" ] || command -v kimaki &>/dev/null; then
+    CHAT_BRIDGE="kimaki"
+  fi
+else
+  if [ -f "/etc/systemd/system/kimaki.service" ]; then
+    CHAT_BRIDGE="kimaki"
+  elif [ -f "/etc/systemd/system/cc-connect.service" ]; then
+    CHAT_BRIDGE="cc-connect"
+  elif [ -f "/etc/systemd/system/opencode-telegram.service" ]; then
+    CHAT_BRIDGE="telegram"
+  fi
 fi
 
 # Run detect_environment — populates SITE_PATH, SERVICE_USER, etc.
@@ -213,79 +230,141 @@ sync_kimaki_config() {
     return 0
   fi
 
-  log "Phase 2: Syncing /opt/kimaki-config..."
+  # Resolve paths per environment.
+  #   VPS:   plugins live at /opt/kimaki-config/plugins (referenced by opencode.json,
+  #          and by ExecStartPre in kimaki.service). Config dir holds plugins +
+  #          post-upgrade.sh + skills-kill-list.txt.
+  #   Local: opencode.json points at $(npm root -g)/kimaki/plugins (mirrors what
+  #          setup.sh / runtimes/opencode.sh writes). post-upgrade.sh + kill list
+  #          have no launchd ExecStartPre hook on macOS, so we stash them at
+  #          $KIMAKI_DATA_DIR/kimaki-config/ and execute post-upgrade.sh inline
+  #          to enforce the kill list against the npm-installed kimaki skills.
+  local KIMAKI_CONFIG_DIR
+  local KIMAKI_PLUGINS_DIR
+  local BACKUP_DIR
+  if [ "$LOCAL_MODE" = true ]; then
+    KIMAKI_CONFIG_DIR="${KIMAKI_DATA_DIR}/kimaki-config"
+    local NPM_ROOT
+    NPM_ROOT="$(npm root -g 2>/dev/null)"
+    if [ -z "$NPM_ROOT" ]; then
+      warn "  npm root -g not available — cannot resolve local plugins dir"
+      return 0
+    fi
+    KIMAKI_PLUGINS_DIR="${NPM_ROOT}/kimaki/plugins"
+    BACKUP_DIR="${KIMAKI_DATA_DIR}/backups/kimaki-config.$TIMESTAMP"
+    log "Phase 2: Syncing kimaki config (local mode)..."
+    log "  Config dir:  $KIMAKI_CONFIG_DIR"
+    log "  Plugins dir: $KIMAKI_PLUGINS_DIR (npm-managed)"
+  else
+    KIMAKI_CONFIG_DIR="/opt/kimaki-config"
+    KIMAKI_PLUGINS_DIR="/opt/kimaki-config/plugins"
+    BACKUP_DIR="/opt/kimaki-config.backup.$TIMESTAMP"
+    log "Phase 2: Syncing /opt/kimaki-config..."
+  fi
 
-  local KIMAKI_CONFIG_DIR="/opt/kimaki-config"
-  local BACKUP_DIR="/opt/kimaki-config.backup.$TIMESTAMP"
-
-  if [ ! -d "$KIMAKI_CONFIG_DIR" ]; then
+  # On local, the kimaki npm package must be installed for plugins to land
+  # somewhere opencode actually loads from. On VPS, /opt/kimaki-config is
+  # created by setup.sh — refuse to bootstrap it here.
+  if [ "$LOCAL_MODE" = false ] && [ ! -d "$KIMAKI_CONFIG_DIR" ]; then
     warn "  $KIMAKI_CONFIG_DIR does not exist — nothing to sync"
     return 0
   fi
-
-  # Backup current state
-  if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} Would backup $KIMAKI_CONFIG_DIR → $BACKUP_DIR"
-  else
-    cp -r "$KIMAKI_CONFIG_DIR" "$BACKUP_DIR"
-    log "  Backup created: $BACKUP_DIR"
+  if [ "$LOCAL_MODE" = true ] && [ ! -d "$(dirname "$KIMAKI_PLUGINS_DIR")" ]; then
+    warn "  Kimaki npm package not found at $(dirname "$KIMAKI_PLUGINS_DIR") — install with 'npm install -g kimaki'"
+    return 0
   fi
 
-  # Copy plugins
+  # Backup current state (only if there's something to back up).
+  if [ -d "$KIMAKI_CONFIG_DIR" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo -e "${BLUE}[dry-run]${NC} Would backup $KIMAKI_CONFIG_DIR → $BACKUP_DIR"
+    else
+      mkdir -p "$(dirname "$BACKUP_DIR")"
+      cp -r "$KIMAKI_CONFIG_DIR" "$BACKUP_DIR"
+      log "  Backup created: $BACKUP_DIR"
+    fi
+  fi
+
+  # Copy plugins to KIMAKI_PLUGINS_DIR (the path opencode.json actually loads from).
   if [ -d "$SCRIPT_DIR/kimaki/plugins" ]; then
-    mkdir -p "$KIMAKI_CONFIG_DIR/plugins" 2>/dev/null || true
+    if [ "$DRY_RUN" = false ]; then
+      mkdir -p "$KIMAKI_PLUGINS_DIR" 2>/dev/null || true
+    fi
     for plugin_file in "$SCRIPT_DIR"/kimaki/plugins/*.ts; do
       [ -f "$plugin_file" ] || continue
       local name
       name=$(basename "$plugin_file")
       if [ "$DRY_RUN" = true ]; then
-        if ! cmp -s "$plugin_file" "$KIMAKI_CONFIG_DIR/plugins/$name" 2>/dev/null; then
-          echo -e "${BLUE}[dry-run]${NC} Would update plugins/$name"
+        if ! cmp -s "$plugin_file" "$KIMAKI_PLUGINS_DIR/$name" 2>/dev/null; then
+          echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_PLUGINS_DIR/$name"
         else
-          echo -e "${BLUE}[dry-run]${NC} plugins/$name: unchanged"
+          echo -e "${BLUE}[dry-run]${NC} $name: unchanged"
         fi
       else
-        if ! cmp -s "$plugin_file" "$KIMAKI_CONFIG_DIR/plugins/$name" 2>/dev/null; then
-          cp "$plugin_file" "$KIMAKI_CONFIG_DIR/plugins/$name"
-          log "  Updated plugins/$name"
-          UPDATED_ITEMS+=("kimaki-config/plugins/$name")
+        if ! cmp -s "$plugin_file" "$KIMAKI_PLUGINS_DIR/$name" 2>/dev/null; then
+          cp "$plugin_file" "$KIMAKI_PLUGINS_DIR/$name"
+          log "  Updated $KIMAKI_PLUGINS_DIR/$name"
+          UPDATED_ITEMS+=("kimaki plugins/$name")
         fi
       fi
     done
   fi
 
-  # Copy post-upgrade.sh
+  # Stage post-upgrade.sh and skills-kill-list.txt in KIMAKI_CONFIG_DIR.
+  # On VPS this is read by ExecStartPre. On local we execute it inline below.
+  if [ "$DRY_RUN" = false ]; then
+    mkdir -p "$KIMAKI_CONFIG_DIR" 2>/dev/null || true
+  fi
+
   if [ -f "$SCRIPT_DIR/kimaki/post-upgrade.sh" ]; then
     if [ "$DRY_RUN" = true ]; then
       if ! cmp -s "$SCRIPT_DIR/kimaki/post-upgrade.sh" "$KIMAKI_CONFIG_DIR/post-upgrade.sh" 2>/dev/null; then
-        echo -e "${BLUE}[dry-run]${NC} Would update post-upgrade.sh"
+        echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_CONFIG_DIR/post-upgrade.sh"
       fi
     else
       if ! cmp -s "$SCRIPT_DIR/kimaki/post-upgrade.sh" "$KIMAKI_CONFIG_DIR/post-upgrade.sh" 2>/dev/null; then
         cp "$SCRIPT_DIR/kimaki/post-upgrade.sh" "$KIMAKI_CONFIG_DIR/post-upgrade.sh"
         chmod +x "$KIMAKI_CONFIG_DIR/post-upgrade.sh"
-        log "  Updated post-upgrade.sh"
+        log "  Updated $KIMAKI_CONFIG_DIR/post-upgrade.sh"
         UPDATED_ITEMS+=("kimaki-config/post-upgrade.sh")
       fi
     fi
   fi
 
-  # Copy skills-kill-list.txt
   if [ -f "$SCRIPT_DIR/kimaki/skills-kill-list.txt" ]; then
     if [ "$DRY_RUN" = true ]; then
       if ! cmp -s "$SCRIPT_DIR/kimaki/skills-kill-list.txt" "$KIMAKI_CONFIG_DIR/skills-kill-list.txt" 2>/dev/null; then
-        echo -e "${BLUE}[dry-run]${NC} Would update skills-kill-list.txt"
+        echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_CONFIG_DIR/skills-kill-list.txt"
       fi
     else
       if ! cmp -s "$SCRIPT_DIR/kimaki/skills-kill-list.txt" "$KIMAKI_CONFIG_DIR/skills-kill-list.txt" 2>/dev/null; then
         cp "$SCRIPT_DIR/kimaki/skills-kill-list.txt" "$KIMAKI_CONFIG_DIR/skills-kill-list.txt"
-        log "  Updated skills-kill-list.txt"
+        log "  Updated $KIMAKI_CONFIG_DIR/skills-kill-list.txt"
         UPDATED_ITEMS+=("kimaki-config/skills-kill-list.txt")
       fi
     fi
   fi
 
+  # On local, execute post-upgrade.sh inline to enforce the kill list.
+  # On VPS, kimaki.service ExecStartPre runs it on next service restart.
+  if [ "$LOCAL_MODE" = true ] && [ -x "$KIMAKI_CONFIG_DIR/post-upgrade.sh" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo -e "${BLUE}[dry-run]${NC} Would run: $KIMAKI_CONFIG_DIR/post-upgrade.sh"
+    else
+      log "  Running post-upgrade.sh to enforce skills kill list..."
+      if "$KIMAKI_CONFIG_DIR/post-upgrade.sh" 2>&1 | sed 's/^/    /'; then
+        UPDATED_ITEMS+=("ran post-upgrade.sh (enforced skills kill list)")
+      else
+        warn "  post-upgrade.sh exited non-zero — review output above"
+      fi
+    fi
+  fi
+
   log "  Done."
+
+  # Export resolved paths so print_summary can reference them
+  RESOLVED_KIMAKI_CONFIG_DIR="$KIMAKI_CONFIG_DIR"
+  RESOLVED_KIMAKI_PLUGINS_DIR="$KIMAKI_PLUGINS_DIR"
 }
 
 # ============================================================================
@@ -523,15 +602,34 @@ print_summary() {
   fi
 
   echo ""
-  if [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$LOCAL_MODE" = false ]; then
-    warn "Restart kimaki when ready: systemctl restart kimaki"
-    warn "  (Active sessions will die when you restart.)"
+  if [ "$CHAT_BRIDGE" = "kimaki" ]; then
+    if [ "$LOCAL_MODE" = true ]; then
+      warn "Restart kimaki when ready (active Discord sessions will die):"
+      if [ -f "$HOME/Library/LaunchAgents/com.wp.kimaki.plist" ]; then
+        warn "  launchctl kickstart -k gui/$(id -u)/com.wp.kimaki"
+      else
+        warn "  Stop your kimaki process and re-run: cd $SITE_PATH && kimaki"
+      fi
+    else
+      warn "Restart kimaki when ready: systemctl restart kimaki"
+      warn "  (Active sessions will die when you restart.)"
+    fi
     echo ""
   fi
 
+  local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-$KIMAKI_CONFIG_DIR/plugins}"
+
   log "Verify:"
-  log "  systemctl status kimaki           # chat bridge status"
-  log "  ls $KIMAKI_CONFIG_DIR/plugins     # plugin versions"
+  if [ "$LOCAL_MODE" = true ]; then
+    if [ -f "$HOME/Library/LaunchAgents/com.wp.kimaki.plist" ]; then
+      log "  launchctl print gui/$(id -u)/com.wp.kimaki | head -20  # chat bridge status"
+    else
+      log "  pgrep -fl kimaki                  # chat bridge status"
+    fi
+  else
+    log "  systemctl status kimaki           # chat bridge status"
+  fi
+  log "  ls $PLUGINS_DIR                   # plugin versions"
   log "  cat $SITE_PATH/AGENTS.md | head -20  # agent instructions"
   log "  ls $(runtime_skills_dir)          # installed skills"
 }
@@ -539,9 +637,6 @@ print_summary() {
 # ============================================================================
 # Execute
 # ============================================================================
-
-# Export vars expected by skills.sh
-KIMAKI_CONFIG_DIR="/opt/kimaki-config"
 
 sync_kimaki_config
 sync_skills


### PR DESCRIPTION
## The bug

`./upgrade.sh --local` on a Studio/macOS install **silently skipped plugin sync entirely**.

Two reasons:

1. **Chat-bridge detection** in Phase 1 only checked `/etc/systemd/system/kimaki.service` — never true on local — so `CHAT_BRIDGE` came back empty and Phase 2 short-circuited with *"Skipping (kimaki is not the chat bridge)"*.
2. **Phase 2 hardcoded `/opt/kimaki-config`** for both the staging dir and the plugin destination. Even if the chat-bridge check had passed, plugins would have landed at a path that doesn't exist on local and isn't where `opencode.json` actually loads from.

On local, the kimaki npm package was the only thing receiving plugin updates — meaning the bundled `dm-context-filter.ts` and `dm-agent-sync.ts` versions in this repo were unreachable from local installs. The skill amplified the gap: every step hardcoded VPS paths (`/var/lib/datamachine/workspace/...`, `/opt/kimaki-config/...`, `/var/www/*/AGENTS.md`, `systemctl restart kimaki`) and the trigger phrase was literally *"Pull the latest plugin fixes to this VPS"*.

## What changed

### `upgrade.sh`
- **Chat bridge detection** branches on `LOCAL_MODE`. On local, detect kimaki via `~/Library/LaunchAgents/com.wp.kimaki.plist` or `command -v kimaki`. On VPS, keep the existing systemd unit checks.
- **Phase 2 (`sync_kimaki_config`)** branches on `LOCAL_MODE`:
  - **VPS:** `/opt/kimaki-config` + `/opt/kimaki-config/plugins` (unchanged).
  - **Local:** `$KIMAKI_DATA_DIR/kimaki-config` for `post-upgrade.sh` + kill list, `$(npm root -g)/kimaki/plugins` for plugins (matches `runtimes/opencode.sh` and what `opencode.json` points at on local installs). Backups land at `$KIMAKI_DATA_DIR/backups/`.
  - On local, also **execute `post-upgrade.sh` inline** because launchd has no `ExecStartPre` equivalent. VPS still gets it on the next `systemctl restart kimaki`.
- **Phase 7 (summary)** prints the right restart + verify commands per environment (`systemctl` on VPS, `launchctl kickstart` on local launchd, manual kimaki restart fallback otherwise).
- Drop dead top-level `KIMAKI_CONFIG_DIR=/opt/kimaki-config` — nothing outside Phase 2 read it.
- Refresh header docstring + `--help` to document both targets.

### `kimaki/post-upgrade.sh`
- Resolve `SKILLS_DIR` generically: `KIMAKI_SKILLS_DIR` env override → `$(npm root -g)/kimaki/skills` → `/usr/lib/node_modules/kimaki/skills` Linux-VPS fallback. The kill list now actually applies on local (where bundled kimaki skills like `egaki`, `jitter`, `tuistory`, etc. were polluting the agent skill registry because `post-upgrade.sh` was never invoked **and** hardcoded a Linux-only path).

### `skills/upgrade-wp-coding-agents/SKILL.md`
- Full rewrite. New env-detection table (VPS vs Local). Repo path resolved via `git rev-parse --show-toplevel` instead of hardcoded `/var/lib/datamachine/...`. Separate dry-run / run / verify / restart blocks per environment. Restart command branches on systemd vs launchd vs manual.
- Drop every hardcoded `/var/lib/`, `/var/www/`, `/opt/`, `/root/` path from the steps. Use `$(npm root -g)`, `$KIMAKI_DATA_DIR`, and the script's auto-detection.

## Verification

`./upgrade.sh --dry-run --local --wp-path /Users/.../intelligence-chubes4` on this Studio install:

```
Phase 1: Detecting environment...
Detected OS: macos (platform: mac, local: true)
Runtime:     studio-code
Chat bridge: kimaki                                  # was empty before
Site path:   /Users/chubes/Studio/intelligence-chubes4

Phase 2: Syncing kimaki config (local mode)...      # was "Skipping" before
  Config dir:  /Users/chubes/.kimaki/kimaki-config
  Plugins dir: /Users/chubes/.nvm/.../node_modules/kimaki/plugins (npm-managed)
[dry-run] Would update .../plugins/dm-agent-sync.ts
[dry-run] Would update .../plugins/dm-context-filter.ts
[dry-run] Would update /Users/chubes/.kimaki/kimaki-config/post-upgrade.sh
[dry-run] Would update /Users/chubes/.kimaki/kimaki-config/skills-kill-list.txt

Phase 5: Skipping (local mode — no systemd)
Phase 6: Skipping (runtime is studio-code, not opencode)

Restart kimaki when ready (active Discord sessions will die):
  launchctl kickstart -k gui/501/com.wp.kimaki
```

Plugins land exactly where `opencode.json` on the site loads them from. `bash -n` passes on both scripts.

## VPS impact

VPS code paths are unchanged — same `/opt/kimaki-config` target, same systemd flow, same backup location, same restart message. The only behavioural change for VPS is `post-upgrade.sh` now prefers `$(npm root -g)/kimaki/skills` over the hardcoded `/usr/lib/node_modules/kimaki/skills` when `npm` is on PATH. On Ubuntu/Debian VPSes those resolve to the same path, so this is a no-op for current deployments.