### PR TITLE
fix(upgrade): run detect_environment before chat-bridge detection

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -182,6 +182,10 @@ if [ ! -f "$RUNTIME_FILE" ]; then
 fi
 source "$RUNTIME_FILE"
 
+# Run detect_environment first — it auto-sets LOCAL_MODE=true on macOS,
+# which the chat bridge detection below depends on to pick the right branch.
+detect_environment
+
 # Detect chat bridge from installed services / installed binaries.
 # VPS: systemd unit files are the source of truth.
 # Local: no systemd — fall back to launchd plist (macOS) or `command -v <bridge>`.
@@ -203,9 +207,6 @@ else
     CHAT_BRIDGE="telegram"
   fi
 fi
-
-# Run detect_environment — populates SITE_PATH, SERVICE_USER, etc.
-detect_environment
 
 log "Runtime:     $RUNTIME"
 log "Chat bridge: ${CHAT_BRIDGE:-none detected}"


### PR DESCRIPTION
Closes #54.

## Summary

On macOS, `upgrade.sh` silently reported `Chat bridge: none detected` even when kimaki was installed and on PATH, causing Phase 2 (sync kimaki config + plugins) to be skipped. Plugin updates like `dm-context-filter.ts` never landed on local installs unless the user knew to pass `--local` explicitly.

## Root cause

The chat-bridge detection block ran **before** `detect_environment`:

```bash
# LOCAL_MODE still false here on a fresh invocation
if [ "$LOCAL_MODE" = true ]; then
  # macOS / launchd / command -v
else
  # /etc/systemd/system/*.service
fi

detect_environment  # <- THIS is what flips LOCAL_MODE=true on macOS
```

`detect_environment` (in `lib/detect.sh`) is what sets `LOCAL_MODE=true` when `uname -s` reports Darwin. Because it ran after the detection block, macOS installs fell into the Linux/systemd branch, found no unit files, and left `CHAT_BRIDGE=""`.

`bash -x` confirmed:
```
+ source .../runtimes/studio-code.sh
+ '[' false = true ']'                           ← LOCAL_MODE still false
+ '[' -f /etc/systemd/system/kimaki.service ']'  ← wrong branch
+ '[' -f /etc/systemd/system/cc-connect.service ']'
+ '[' -f /etc/systemd/system/opencode-telegram.service ']'
+ detect_environment
+ LOCAL_MODE=true                                 ← too late
```

## Fix

Move `detect_environment` above the chat-bridge detection block. `LOCAL_MODE` is now settled before the local-vs-VPS branch decision, so macOS installs pick the launchd/`command -v` branch correctly.

VPS behaviour is unchanged — `detect_environment` does not touch `LOCAL_MODE` on Linux.

## Verification

Before (no `--local`):
```
[wp-coding-agents] Runtime:     studio-code
[wp-coding-agents] Chat bridge: none detected
[wp-coding-agents] Phase 2: Skipping (no chat bridge detected)
```

After (no `--local`):
```
[wp-coding-agents] Runtime:     studio-code
[wp-coding-agents] Chat bridge: kimaki
[wp-coding-agents] Phase 2: Syncing kimaki config (local mode)...
```

Explicit `--local` still forces local mode correctly. VPS path unaffected (no systemd on this macOS machine to test against, but the edit is a pure reorder — the VPS branch conditions are unchanged).