### PR TITLE
refactor(chat-bridges): centralize metadata + unit templates into lib/chat-bridges.sh

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,33 @@
+name: shell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  syntax:
+    name: bash -n on all shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Syntax-check every .sh
+        run: |
+          set -e
+          fail=0
+          while IFS= read -r -d '' f; do
+            if ! bash -n "$f"; then
+              echo "FAIL: $f"
+              fail=1
+            fi
+          done < <(find . -type f -name '*.sh' -not -path './.git/*' -print0)
+          exit "$fail"
+
+  bridge-render:
+    name: chat-bridge template byte-equivalence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/bridge-render.sh
+        run: ./tests/bridge-render.sh

--- a/lib/chat-bridge.sh
+++ b/lib/chat-bridge.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 # Chat bridge: kimaki, cc-connect, telegram — install, config, service setup
+#
+# Unit-file and plist templates, detection logic, and human-facing command
+# accessors all live in lib/chat-bridges.sh (plural). This file is the
+# install-time entrypoint that stitches per-install values into the registry.
+
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/chat-bridges.sh"
 
 install_chat_bridge() {
   if [ "$INSTALL_CHAT" != true ]; then
@@ -52,41 +59,7 @@ _install_kimaki_launchd() {
   run_cmd mkdir -p "$KIMAKI_DATA_DIR"
   run_cmd mkdir -p "$KIMAKI_PLIST_DIR"
 
-  KIMAKI_PLIST_CONTENT="<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-<plist version=\"1.0\">
-<dict>
-    <key>Label</key>
-    <string>$KIMAKI_PLIST_LABEL</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>$KIMAKI_BIN</string>
-        <string>--data-dir</string>
-        <string>$KIMAKI_DATA_DIR</string>
-        <string>--auto-restart</string>
-        <string>--no-critique</string>
-    </array>
-    <key>WorkingDirectory</key>
-    <string>$SITE_PATH</string>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>$KIMAKI_DATA_DIR/kimaki.log</string>
-    <key>StandardErrorPath</key>
-    <string>$KIMAKI_DATA_DIR/kimaki.error.log</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-        <key>KIMAKI_DATA_DIR</key>
-        <string>$KIMAKI_DATA_DIR</string>$(if [ -n "$KIMAKI_BOT_TOKEN" ]; then echo "
-        <key>KIMAKI_BOT_TOKEN</key>
-        <string>$KIMAKI_BOT_TOKEN</string>"; fi)
-    </dict>
-</dict>
-</plist>"
-
-  write_file "$KIMAKI_PLIST" "$KIMAKI_PLIST_CONTENT"
+  write_file "$KIMAKI_PLIST" "$(bridge_render_launchd kimaki "$KIMAKI_PLIST_LABEL")"
 
   if [ "$DRY_RUN" = false ] && [ -n "$KIMAKI_BOT_TOKEN" ]; then
     launchctl bootout "gui/$(id -u)" "$KIMAKI_PLIST" 2>/dev/null || true
@@ -110,12 +83,12 @@ _install_kimaki_systemd() {
   run_cmd cp -r "$SCRIPT_DIR/kimaki" "$KIMAKI_CONFIG_DIR"
   run_cmd chmod +x "$KIMAKI_CONFIG_DIR/post-upgrade.sh"
 
-  ENV_LINES="Environment=HOME=$SERVICE_HOME"
-  ENV_LINES="$ENV_LINES\nEnvironment=PATH=/usr/local/bin:/usr/bin:/bin"
-  ENV_LINES="$ENV_LINES\nEnvironment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR"
-
+  local ENV_BLOCK="Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR"
   if [ -n "$KIMAKI_BOT_TOKEN" ]; then
-    ENV_LINES="$ENV_LINES\nEnvironment=KIMAKI_BOT_TOKEN=$KIMAKI_BOT_TOKEN"
+    ENV_BLOCK="$ENV_BLOCK
+Environment=KIMAKI_BOT_TOKEN=$KIMAKI_BOT_TOKEN"
   fi
 
   if [ "$DRY_RUN" = true ]; then
@@ -124,24 +97,8 @@ _install_kimaki_systemd() {
     KIMAKI_BIN=$(which kimaki 2>/dev/null || echo "/usr/bin/kimaki")
   fi
 
-  SYSTEMD_CONFIG="[Unit]
-Description=Kimaki Discord Bot (wp-coding-agents)
-After=network.target
-
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-$(echo -e "$ENV_LINES")
-ExecStartPre=$KIMAKI_CONFIG_DIR/post-upgrade.sh
-ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
-
-  write_file "/etc/systemd/system/kimaki.service" "$SYSTEMD_CONFIG"
+  write_file "/etc/systemd/system/kimaki.service" \
+    "$(bridge_render_systemd kimaki kimaki.service "$ENV_BLOCK")"
   run_cmd systemctl daemon-reload
   run_cmd systemctl enable kimaki
 }

--- a/lib/chat-bridge.sh
+++ b/lib/chat-bridge.sh
@@ -288,75 +288,8 @@ _install_telegram_launchd() {
 
   run_cmd mkdir -p "$PLIST_DIR"
 
-  SERVE_PLIST_CONTENT="<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-<plist version=\"1.0\">
-<dict>
-    <key>Label</key>
-    <string>$SERVE_PLIST_LABEL</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>$OPENCODE_BIN</string>
-        <string>serve</string>
-    </array>
-    <key>WorkingDirectory</key>
-    <string>$SITE_PATH</string>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>$TELEGRAM_LOG_DIR/opencode-serve.log</string>
-    <key>StandardErrorPath</key>
-    <string>$TELEGRAM_LOG_DIR/opencode-serve.error.log</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-        <key>HOME</key>
-        <string>$SERVICE_HOME</string>$(if [ -n "$OPENCODE_MODEL" ]; then echo "
-        <key>OPENCODE_MODEL</key>
-        <string>$OPENCODE_MODEL</string>"; fi)
-    </dict>
-</dict>
-</plist>"
-
-  write_file "$SERVE_PLIST" "$SERVE_PLIST_CONTENT"
-
-  TELEGRAM_PLIST_CONTENT="<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-<plist version=\"1.0\">
-<dict>
-    <key>Label</key>
-    <string>$TELEGRAM_PLIST_LABEL</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>$TELEGRAM_BIN</string>
-        <string>start</string>
-    </array>
-    <key>WorkingDirectory</key>
-    <string>$SITE_PATH</string>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>$TELEGRAM_LOG_DIR/opencode-telegram.log</string>
-    <key>StandardErrorPath</key>
-    <string>$TELEGRAM_LOG_DIR/opencode-telegram.error.log</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-        <key>HOME</key>
-        <string>$SERVICE_HOME</string>$(if [ -n "$TELEGRAM_BOT_TOKEN" ]; then echo "
-        <key>TELEGRAM_BOT_TOKEN</key>
-        <string>$TELEGRAM_BOT_TOKEN</string>"; fi)$(if [ -n "$TELEGRAM_ALLOWED_USER_ID" ]; then echo "
-        <key>TELEGRAM_ALLOWED_USER_ID</key>
-        <string>$TELEGRAM_ALLOWED_USER_ID</string>"; fi)
-        <key>OPENCODE_API_URL</key>
-        <string>http://localhost:4096</string>
-    </dict>
-</dict>
-</plist>"
-
-  write_file "$TELEGRAM_PLIST" "$TELEGRAM_PLIST_CONTENT"
+  write_file "$SERVE_PLIST" "$(bridge_render_launchd telegram "$SERVE_PLIST_LABEL")"
+  write_file "$TELEGRAM_PLIST" "$(bridge_render_launchd telegram "$TELEGRAM_PLIST_LABEL")"
 
   if [ "$DRY_RUN" = false ] && [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_ALLOWED_USER_ID" ]; then
     launchctl bootout "gui/$(id -u)" "$SERVE_PLIST" 2>/dev/null || true
@@ -382,48 +315,16 @@ _install_telegram_launchd() {
 }
 
 _install_telegram_systemd() {
-  OPENCODE_SERVE_CONFIG="[Unit]
-Description=OpenCode Server (wp-coding-agents)
-After=network.target
+  local ENV_BLOCK="Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin"
 
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-Environment=HOME=$SERVICE_HOME
-Environment=PATH=/usr/local/bin:/usr/bin:/bin
-EnvironmentFile=-$SERVE_ENV_FILE
-ExecStart=$OPENCODE_BIN serve
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
-
-  write_file "/etc/systemd/system/opencode-serve.service" "$OPENCODE_SERVE_CONFIG"
+  write_file "/etc/systemd/system/opencode-serve.service" \
+    "$(bridge_render_systemd telegram opencode-serve.service "$ENV_BLOCK")"
   run_cmd systemctl daemon-reload
   run_cmd systemctl enable opencode-serve
 
-  TELEGRAM_SYSTEMD_CONFIG="[Unit]
-Description=OpenCode Telegram Bot (wp-coding-agents)
-After=network.target opencode-serve.service
-Requires=opencode-serve.service
-
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-Environment=HOME=$SERVICE_HOME
-Environment=PATH=/usr/local/bin:/usr/bin:/bin
-EnvironmentFile=$TELEGRAM_CONFIG_DIR/.env
-ExecStart=$TELEGRAM_BIN start
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
-
-  write_file "/etc/systemd/system/opencode-telegram.service" "$TELEGRAM_SYSTEMD_CONFIG"
+  write_file "/etc/systemd/system/opencode-telegram.service" \
+    "$(bridge_render_systemd telegram opencode-telegram.service "$ENV_BLOCK")"
   run_cmd systemctl daemon-reload
   run_cmd systemctl enable opencode-telegram
 }

--- a/lib/chat-bridge.sh
+++ b/lib/chat-bridge.sh
@@ -160,33 +160,7 @@ _install_cc_connect_launchd() {
   run_cmd mkdir -p "$CC_PLIST_DIR"
   _write_cc_config
 
-  CC_PLIST_CONTENT="<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-<plist version=\"1.0\">
-<dict>
-    <key>Label</key>
-    <string>$CC_PLIST_LABEL</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>$CC_BIN</string>
-    </array>
-    <key>WorkingDirectory</key>
-    <string>$SITE_PATH</string>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>$CC_DATA_DIR/cc-connect.log</string>
-    <key>StandardErrorPath</key>
-    <string>$CC_DATA_DIR/cc-connect.error.log</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    </dict>
-</dict>
-</plist>"
-
-  write_file "$CC_PLIST" "$CC_PLIST_CONTENT"
+  write_file "$CC_PLIST" "$(bridge_render_launchd cc-connect "$CC_PLIST_LABEL")"
 
   if [ "$DRY_RUN" = false ]; then
     launchctl bootout "gui/$(id -u)" "$CC_PLIST" 2>/dev/null || true
@@ -204,11 +178,11 @@ _install_cc_connect_systemd() {
   run_cmd mkdir -p "$CC_DATA_DIR"
   _write_cc_config
 
-  ENV_LINES="Environment=HOME=$SERVICE_HOME"
-  ENV_LINES="$ENV_LINES\nEnvironment=PATH=/usr/local/bin:/usr/bin:/bin"
-
+  local ENV_BLOCK="Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin"
   if [ -n "${CC_CONNECT_TOKEN:-}" ]; then
-    ENV_LINES="$ENV_LINES\nEnvironment=CC_CONNECT_TOKEN=$CC_CONNECT_TOKEN"
+    ENV_BLOCK="$ENV_BLOCK
+Environment=CC_CONNECT_TOKEN=$CC_CONNECT_TOKEN"
   fi
 
   if [ "$DRY_RUN" = true ]; then
@@ -217,23 +191,8 @@ _install_cc_connect_systemd() {
     CC_BIN=$(which cc-connect 2>/dev/null || echo "/usr/bin/cc-connect")
   fi
 
-  SYSTEMD_CONFIG="[Unit]
-Description=cc-connect Chat Bridge (wp-coding-agents)
-After=network.target
-
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-$(echo -e "$ENV_LINES")
-ExecStart=$CC_BIN
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
-
-  write_file "/etc/systemd/system/cc-connect.service" "$SYSTEMD_CONFIG"
+  write_file "/etc/systemd/system/cc-connect.service" \
+    "$(bridge_render_systemd cc-connect cc-connect.service "$ENV_BLOCK")"
   run_cmd systemctl daemon-reload
   run_cmd systemctl enable cc-connect
 }

--- a/lib/chat-bridges.sh
+++ b/lib/chat-bridges.sh
@@ -88,14 +88,26 @@ bridge_binaries() {
   esac
 }
 
-# Human-readable display name for prose in summary / restart hints.
+# Human-readable display name for prose in restart hints etc.
 # Multi-service bridges use "X stack" to signal that the restart command
-# hits multiple services.
+# hits multiple services. Lowercase for mid-sentence usage.
 bridge_display_name() {
   case "$1" in
     kimaki)     echo "kimaki" ;;
     cc-connect) echo "cc-connect" ;;
     telegram)   echo "telegram stack" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Display title for start-of-line headers ("Kimaki (launchd service):").
+# Intentionally separate from bridge_display_name so prose stays natural —
+# cc-connect keeps its lowercase brand name; kimaki and Telegram capitalize.
+bridge_display_title() {
+  case "$1" in
+    kimaki)     echo "Kimaki" ;;
+    cc-connect) echo "cc-connect" ;;
+    telegram)   echo "Telegram" ;;
     *) return 1 ;;
   esac
 }
@@ -543,6 +555,53 @@ bridge_start_hint() {
       ;;
     *)
       echo "bridge_start_hint: unknown env '$env'" >&2
+      return 1 ;;
+  esac
+}
+
+# bridge_stop_hint <bridge> <env>   env = local-launchd | vps
+#
+# Stop instruction for summary output. local-manual returns nothing — the
+# user has their own process management story.
+bridge_stop_hint() {
+  local bridge="$1" env="$2" label units uid
+  uid=$(id -u)
+  case "$env" in
+    local-launchd)
+      for label in $(bridge_launchd_labels "$bridge"); do
+        echo "launchctl kill SIGTERM gui/${uid}/${label}"
+      done
+      ;;
+    vps)
+      units=$(bridge_systemd_units "$bridge" | sed 's/\.service//g')
+      # shellcheck disable=SC2086
+      echo "systemctl stop $units"
+      ;;
+    local-manual)
+      ;;
+    *)
+      echo "bridge_stop_hint: unknown env '$env'" >&2
+      return 1 ;;
+  esac
+}
+
+# bridge_is_ready <bridge>
+#
+# Returns 0 if the bridge has all credentials it needs to actually run,
+# 1 otherwise. cc-connect has no token requirement so it is always ready.
+# Callers can branch between "start it" and "configure first" onboarding.
+bridge_is_ready() {
+  case "$1" in
+    kimaki)
+      [ -n "${KIMAKI_BOT_TOKEN:-}" ]
+      ;;
+    cc-connect)
+      return 0
+      ;;
+    telegram)
+      [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_ALLOWED_USER_ID:-}" ]
+      ;;
+    *)
       return 1 ;;
   esac
 }

--- a/lib/chat-bridges.sh
+++ b/lib/chat-bridges.sh
@@ -92,36 +92,39 @@ bridge_binaries() {
 # Detection — returns first matching bridge name on stdout, or empty
 # ===========================================================================
 
-# Local: prefer launchd plists, fall back to `command -v <primary-binary>`.
+# Local: a bridge is "present" if ANY of its launchd plists exist or ANY of
+# its binaries are on PATH. Multi-service bridges (telegram) install a pair
+# of plists — either one signals presence.
 # Priority order matches setup.sh: kimaki > cc-connect > telegram.
 bridge_detect_local() {
-  local bridge label primary
+  local bridge label bin
   for bridge in $(bridge_names); do
-    # First launchd label covers the single-service bridges (kimaki, cc-connect)
-    # and the primary service for multi-service bridges (telegram's serve plist).
-    label=$(bridge_launchd_labels "$bridge" | awk '{print $1}')
-    if [ -f "$HOME/Library/LaunchAgents/${label}.plist" ]; then
-      echo "$bridge"
-      return 0
-    fi
-    primary=$(bridge_binaries "$bridge" | awk '{print $1}')
-    if command -v "$primary" >/dev/null 2>&1; then
-      echo "$bridge"
-      return 0
-    fi
+    for label in $(bridge_launchd_labels "$bridge"); do
+      if [ -f "$HOME/Library/LaunchAgents/${label}.plist" ]; then
+        echo "$bridge"
+        return 0
+      fi
+    done
+    for bin in $(bridge_binaries "$bridge"); do
+      if command -v "$bin" >/dev/null 2>&1; then
+        echo "$bridge"
+        return 0
+      fi
+    done
   done
   return 0
 }
 
-# VPS: systemd unit files. Priority matches local.
+# VPS: a bridge is "present" if ANY of its systemd unit files exist.
 bridge_detect_vps() {
   local bridge unit
   for bridge in $(bridge_names); do
-    unit=$(bridge_systemd_units "$bridge" | awk '{print $1}')
-    if [ -f "/etc/systemd/system/${unit}" ]; then
-      echo "$bridge"
-      return 0
-    fi
+    for unit in $(bridge_systemd_units "$bridge"); do
+      if [ -f "/etc/systemd/system/${unit}" ]; then
+        echo "$bridge"
+        return 0
+      fi
+    done
   done
   return 0
 }

--- a/lib/chat-bridges.sh
+++ b/lib/chat-bridges.sh
@@ -298,8 +298,6 @@ _render_launchd_kimaki() {
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-        <key>HOME</key>
-        <string>$SERVICE_HOME</string>
         <key>KIMAKI_DATA_DIR</key>
         <string>$KIMAKI_DATA_DIR</string>$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
         <key>KIMAKI_BOT_TOKEN</key>

--- a/lib/chat-bridges.sh
+++ b/lib/chat-bridges.sh
@@ -88,6 +88,18 @@ bridge_binaries() {
   esac
 }
 
+# Human-readable display name for prose in summary / restart hints.
+# Multi-service bridges use "X stack" to signal that the restart command
+# hits multiple services.
+bridge_display_name() {
+  case "$1" in
+    kimaki)     echo "kimaki" ;;
+    cc-connect) echo "cc-connect" ;;
+    telegram)   echo "telegram stack" ;;
+    *) return 1 ;;
+  esac
+}
+
 # ===========================================================================
 # Detection — returns first matching bridge name on stdout, or empty
 # ===========================================================================

--- a/lib/chat-bridges.sh
+++ b/lib/chat-bridges.sh
@@ -1,0 +1,535 @@
+#!/bin/bash
+# lib/chat-bridges.sh — single source of truth for chat-bridge identity + templates.
+#
+# Registry of metadata and template generators for every supported chat bridge
+# (kimaki, cc-connect, telegram). Both install-time (setup.sh via
+# lib/chat-bridge.sh) and upgrade-time (upgrade.sh Phase 5) consume the same
+# generators here so systemd units and launchd plists never drift between the
+# two paths (see #48).
+#
+# Bash 3.2 compatible — macOS default shell. No associative arrays. All data
+# access goes through case-based accessor functions.
+#
+# ---------------------------------------------------------------------------
+# Surface
+# ---------------------------------------------------------------------------
+#   Registry:
+#     bridge_names                     List supported bridges (space-sep).
+#     bridge_systemd_units <b>         Unit file names for bridge <b>.
+#     bridge_launchd_labels <b>        Plist labels for bridge <b>.
+#     bridge_binaries <b>              Binaries the bridge needs on PATH.
+#
+#   Detection:
+#     bridge_detect_local              Prints detected bridge name or empty.
+#     bridge_detect_vps                Prints detected bridge name or empty.
+#
+#   Template generators:
+#     bridge_render_systemd <b> <unit> <merged_env>   Emit full unit file.
+#     bridge_render_launchd <b> <label>               Emit full plist XML.
+#
+#   Human-facing command accessors (consumed by summary + upgrade hints):
+#     bridge_restart_cmd <b> <env>     "systemctl restart …" or launchctl lines.
+#     bridge_verify_cmd <b> <env>      Status inspection command(s).
+#     bridge_logs_cmd <b>              tail -f path(s).
+#     bridge_start_hint <b> <env>      First-run start command(s).
+#
+# ---------------------------------------------------------------------------
+# Caller contract — template generators expect these globals to be set
+# (same as the existing _install_*_systemd / _install_*_launchd functions):
+#
+#   SERVICE_USER, SERVICE_HOME, SITE_PATH             — all bridges
+#   KIMAKI_BIN, KIMAKI_CONFIG_DIR, KIMAKI_DATA_DIR    — kimaki
+#   KIMAKI_BOT_TOKEN                                  — kimaki (optional)
+#   CC_BIN, CC_DATA_DIR                               — cc-connect
+#   CC_CONNECT_TOKEN                                  — cc-connect (optional)
+#   OPENCODE_BIN, TELEGRAM_BIN                        — telegram
+#   SERVE_ENV_FILE, TELEGRAM_CONFIG_DIR               — telegram
+#   TELEGRAM_BOT_TOKEN, TELEGRAM_ALLOWED_USER_ID      — telegram (optional)
+#   OPENCODE_MODEL                                    — telegram (optional)
+#
+# These are per-install values resolved by detect_environment + setup.sh and
+# are not owned by this file.
+# ---------------------------------------------------------------------------
+
+# ===========================================================================
+# Registry — bridge identity data
+# ===========================================================================
+
+bridge_names() {
+  echo "kimaki cc-connect telegram"
+}
+
+bridge_systemd_units() {
+  case "$1" in
+    kimaki)     echo "kimaki.service" ;;
+    cc-connect) echo "cc-connect.service" ;;
+    telegram)   echo "opencode-serve.service opencode-telegram.service" ;;
+    *) return 1 ;;
+  esac
+}
+
+bridge_launchd_labels() {
+  case "$1" in
+    kimaki)     echo "com.wp.kimaki" ;;
+    cc-connect) echo "com.wp.cc-connect" ;;
+    telegram)   echo "com.wp.opencode-serve com.wp.opencode-telegram" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Primary binary first; additional binaries space-separated. Used for
+# `command -v` fallback detection on local installs.
+bridge_binaries() {
+  case "$1" in
+    kimaki)     echo "kimaki" ;;
+    cc-connect) echo "cc-connect" ;;
+    telegram)   echo "opencode-telegram opencode" ;;
+    *) return 1 ;;
+  esac
+}
+
+# ===========================================================================
+# Detection — returns first matching bridge name on stdout, or empty
+# ===========================================================================
+
+# Local: prefer launchd plists, fall back to `command -v <primary-binary>`.
+# Priority order matches setup.sh: kimaki > cc-connect > telegram.
+bridge_detect_local() {
+  local bridge label primary
+  for bridge in $(bridge_names); do
+    # First launchd label covers the single-service bridges (kimaki, cc-connect)
+    # and the primary service for multi-service bridges (telegram's serve plist).
+    label=$(bridge_launchd_labels "$bridge" | awk '{print $1}')
+    if [ -f "$HOME/Library/LaunchAgents/${label}.plist" ]; then
+      echo "$bridge"
+      return 0
+    fi
+    primary=$(bridge_binaries "$bridge" | awk '{print $1}')
+    if command -v "$primary" >/dev/null 2>&1; then
+      echo "$bridge"
+      return 0
+    fi
+  done
+  return 0
+}
+
+# VPS: systemd unit files. Priority matches local.
+bridge_detect_vps() {
+  local bridge unit
+  for bridge in $(bridge_names); do
+    unit=$(bridge_systemd_units "$bridge" | awk '{print $1}')
+    if [ -f "/etc/systemd/system/${unit}" ]; then
+      echo "$bridge"
+      return 0
+    fi
+  done
+  return 0
+}
+
+# ===========================================================================
+# Template generators — systemd unit files
+# ===========================================================================
+
+# bridge_render_systemd <bridge> <unit-name> <merged-env-block>
+#
+# Emits the full unit file to stdout. <merged-env-block> is the set of
+# `Environment=KEY=VALUE` lines (already merged by the caller, if upgrading
+# an existing unit file — see upgrade.sh::_merge_systemd_env_lines).
+bridge_render_systemd() {
+  local bridge="$1" unit="$2" env_block="$3"
+  case "$bridge" in
+    kimaki)
+      _render_systemd_kimaki "$unit" "$env_block" ;;
+    cc-connect)
+      _render_systemd_cc_connect "$unit" "$env_block" ;;
+    telegram)
+      _render_systemd_telegram "$unit" "$env_block" ;;
+    *)
+      echo "bridge_render_systemd: unknown bridge '$bridge'" >&2
+      return 1 ;;
+  esac
+}
+
+_render_systemd_kimaki() {
+  local unit="$1" env_block="$2"
+  [ "$unit" = "kimaki.service" ] || { echo "kimaki has no unit '$unit'" >&2; return 1; }
+  cat <<EOF
+[Unit]
+Description=Kimaki Discord Bot (wp-coding-agents)
+After=network.target
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$SITE_PATH
+$env_block
+ExecStartPre=$KIMAKI_CONFIG_DIR/post-upgrade.sh
+ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+_render_systemd_cc_connect() {
+  local unit="$1" env_block="$2"
+  [ "$unit" = "cc-connect.service" ] || { echo "cc-connect has no unit '$unit'" >&2; return 1; }
+  cat <<EOF
+[Unit]
+Description=cc-connect Chat Bridge (wp-coding-agents)
+After=network.target
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$SITE_PATH
+$env_block
+ExecStart=$CC_BIN
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+_render_systemd_telegram() {
+  local unit="$1" env_block="$2"
+  case "$unit" in
+    opencode-serve.service)
+      cat <<EOF
+[Unit]
+Description=OpenCode Server (wp-coding-agents)
+After=network.target
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$SITE_PATH
+$env_block
+EnvironmentFile=-$SERVE_ENV_FILE
+ExecStart=$OPENCODE_BIN serve
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+      ;;
+    opencode-telegram.service)
+      cat <<EOF
+[Unit]
+Description=OpenCode Telegram Bot (wp-coding-agents)
+After=network.target opencode-serve.service
+Requires=opencode-serve.service
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$SITE_PATH
+$env_block
+EnvironmentFile=$TELEGRAM_CONFIG_DIR/.env
+ExecStart=$TELEGRAM_BIN start
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+      ;;
+    *)
+      echo "telegram has no unit '$unit'" >&2
+      return 1 ;;
+  esac
+}
+
+# ===========================================================================
+# Template generators — launchd plists
+# ===========================================================================
+
+# bridge_render_launchd <bridge> <plist-label>
+#
+# Emits the full plist XML to stdout. Multi-service bridges (telegram) pick
+# the plist matching <plist-label>.
+bridge_render_launchd() {
+  local bridge="$1" label="$2"
+  case "$bridge" in
+    kimaki)
+      _render_launchd_kimaki "$label" ;;
+    cc-connect)
+      _render_launchd_cc_connect "$label" ;;
+    telegram)
+      _render_launchd_telegram "$label" ;;
+    *)
+      echo "bridge_render_launchd: unknown bridge '$bridge'" >&2
+      return 1 ;;
+  esac
+}
+
+_render_launchd_kimaki() {
+  local label="$1"
+  [ "$label" = "com.wp.kimaki" ] || { echo "kimaki has no label '$label'" >&2; return 1; }
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$label</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$KIMAKI_BIN</string>
+        <string>--data-dir</string>
+        <string>$KIMAKI_DATA_DIR</string>
+        <string>--auto-restart</string>
+        <string>--no-critique</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$SITE_PATH</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$KIMAKI_DATA_DIR/kimaki.log</string>
+    <key>StandardErrorPath</key>
+    <string>$KIMAKI_DATA_DIR/kimaki.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>$SERVICE_HOME</string>
+        <key>KIMAKI_DATA_DIR</key>
+        <string>$KIMAKI_DATA_DIR</string>$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
+        <key>KIMAKI_BOT_TOKEN</key>
+        <string>$KIMAKI_BOT_TOKEN</string>"; fi)
+    </dict>
+</dict>
+</plist>
+EOF
+}
+
+_render_launchd_cc_connect() {
+  local label="$1"
+  [ "$label" = "com.wp.cc-connect" ] || { echo "cc-connect has no label '$label'" >&2; return 1; }
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$label</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$CC_BIN</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$SITE_PATH</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$CC_DATA_DIR/cc-connect.log</string>
+    <key>StandardErrorPath</key>
+    <string>$CC_DATA_DIR/cc-connect.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>
+EOF
+}
+
+_render_launchd_telegram() {
+  local label="$1"
+  local log_dir="$TELEGRAM_CONFIG_DIR"
+  case "$label" in
+    com.wp.opencode-serve)
+      cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$label</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$OPENCODE_BIN</string>
+        <string>serve</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$SITE_PATH</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$log_dir/opencode-serve.log</string>
+    <key>StandardErrorPath</key>
+    <string>$log_dir/opencode-serve.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>$SERVICE_HOME</string>$(if [ -n "${OPENCODE_MODEL:-}" ]; then echo "
+        <key>OPENCODE_MODEL</key>
+        <string>$OPENCODE_MODEL</string>"; fi)
+    </dict>
+</dict>
+</plist>
+EOF
+      ;;
+    com.wp.opencode-telegram)
+      cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$label</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$TELEGRAM_BIN</string>
+        <string>start</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$SITE_PATH</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$log_dir/opencode-telegram.log</string>
+    <key>StandardErrorPath</key>
+    <string>$log_dir/opencode-telegram.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>$SERVICE_HOME</string>$(if [ -n "${TELEGRAM_BOT_TOKEN:-}" ]; then echo "
+        <key>TELEGRAM_BOT_TOKEN</key>
+        <string>$TELEGRAM_BOT_TOKEN</string>"; fi)$(if [ -n "${TELEGRAM_ALLOWED_USER_ID:-}" ]; then echo "
+        <key>TELEGRAM_ALLOWED_USER_ID</key>
+        <string>$TELEGRAM_ALLOWED_USER_ID</string>"; fi)
+        <key>OPENCODE_API_URL</key>
+        <string>http://localhost:4096</string>
+    </dict>
+</dict>
+</plist>
+EOF
+      ;;
+    *)
+      echo "telegram has no label '$label'" >&2
+      return 1 ;;
+  esac
+}
+
+# ===========================================================================
+# Human-facing command accessors
+# ===========================================================================
+
+# bridge_restart_cmd <bridge> <env>    env = local-launchd | local-manual | vps
+#
+# Emits one restart instruction per line. Multi-service bridges emit multiple
+# lines. Caller is responsible for any surrounding prose.
+bridge_restart_cmd() {
+  local bridge="$1" env="$2" label units uid
+  uid=$(id -u)
+  case "$env" in
+    local-launchd)
+      for label in $(bridge_launchd_labels "$bridge"); do
+        echo "launchctl kickstart -k gui/${uid}/${label}"
+      done
+      ;;
+    local-manual)
+      case "$bridge" in
+        kimaki)     echo "cd $SITE_PATH && kimaki" ;;
+        cc-connect) echo "cd $SITE_PATH && cc-connect" ;;
+        telegram)
+          echo "cd $SITE_PATH && opencode serve &"
+          echo "opencode-telegram start"
+          ;;
+      esac
+      ;;
+    vps)
+      units=$(bridge_systemd_units "$bridge" | sed 's/\.service//g')
+      # shellcheck disable=SC2086
+      echo "systemctl restart $units"
+      ;;
+    *)
+      echo "bridge_restart_cmd: unknown env '$env'" >&2
+      return 1 ;;
+  esac
+}
+
+# bridge_verify_cmd <bridge> <env>    env = local-launchd | local-manual | vps
+#
+# Emits one verify/status command per line.
+bridge_verify_cmd() {
+  local bridge="$1" env="$2" label units uid primary
+  uid=$(id -u)
+  case "$env" in
+    local-launchd)
+      for label in $(bridge_launchd_labels "$bridge"); do
+        echo "launchctl print gui/${uid}/${label} | head -20"
+      done
+      ;;
+    local-manual)
+      primary=$(bridge_binaries "$bridge" | awk '{print $1}')
+      echo "pgrep -fl ${primary}"
+      ;;
+    vps)
+      units=$(bridge_systemd_units "$bridge" | sed 's/\.service//g')
+      # shellcheck disable=SC2086
+      echo "systemctl status $units"
+      ;;
+    *)
+      echo "bridge_verify_cmd: unknown env '$env'" >&2
+      return 1 ;;
+  esac
+}
+
+# bridge_logs_cmd <bridge>  — tail -f recipe(s). Uses the same caller globals
+# as the template generators.
+bridge_logs_cmd() {
+  case "$1" in
+    kimaki)
+      echo "tail -f $KIMAKI_DATA_DIR/kimaki.log"
+      ;;
+    cc-connect)
+      echo "tail -f ${CC_DATA_DIR:-$SERVICE_HOME/.cc-connect}/cc-connect.log"
+      ;;
+    telegram)
+      echo "tail -f $TELEGRAM_CONFIG_DIR/opencode-serve.log"
+      echo "tail -f $TELEGRAM_CONFIG_DIR/opencode-telegram.log"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# bridge_start_hint <bridge> <env>   env = local-launchd | local-manual | vps
+#
+# First-run start instruction for summary output. Single-line where sensible,
+# multi-line for multi-service bridges.
+bridge_start_hint() {
+  local bridge="$1" env="$2" label units uid
+  uid=$(id -u)
+  case "$env" in
+    local-launchd)
+      for label in $(bridge_launchd_labels "$bridge"); do
+        echo "launchctl kickstart gui/${uid}/${label}"
+      done
+      ;;
+    local-manual)
+      bridge_restart_cmd "$bridge" local-manual
+      ;;
+    vps)
+      units=$(bridge_systemd_units "$bridge" | sed 's/\.service//g')
+      # shellcheck disable=SC2086
+      echo "systemctl start $units"
+      ;;
+    *)
+      echo "bridge_start_hint: unknown env '$env'" >&2
+      return 1 ;;
+  esac
+}

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -114,71 +114,132 @@ _print_next_steps() {
 }
 
 _print_local_next_steps() {
-  if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$PLATFORM" = "mac" ]; then
-    if [ -n "$KIMAKI_BOT_TOKEN" ]; then
-      echo "  Kimaki (launchd service):"
-      echo "    Start:  launchctl kickstart gui/$(id -u)/com.wp.kimaki"
-      echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.wp.kimaki"
-    else
-      echo "  Kimaki setup:"
-      echo "    1. Run onboarding:  cd $SITE_PATH && kimaki"
-      echo "    2. Enable service:  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.kimaki.plist"
-    fi
-    echo "    Logs:   tail -f $KIMAKI_DATA_DIR/kimaki.log"
-    echo ""
-  elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "cc-connect" ] && [ "$PLATFORM" = "mac" ]; then
-    echo "  cc-connect (launchd service):"
-    echo "    Start:  launchctl kickstart gui/$(id -u)/com.wp.cc-connect"
-    echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.wp.cc-connect"
-    echo "    Logs:   tail -f ${CC_DATA_DIR:-$SERVICE_HOME/.cc-connect}/cc-connect.log"
-    echo ""
-  elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "telegram" ] && [ "$PLATFORM" = "mac" ]; then
-    if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_ALLOWED_USER_ID" ]; then
-      echo "  Telegram (launchd services):"
-      echo "    Start:  launchctl kickstart gui/$(id -u)/com.wp.opencode-serve"
-      echo "            launchctl kickstart gui/$(id -u)/com.wp.opencode-telegram"
-      echo "    Stop:   launchctl kill SIGTERM gui/$(id -u)/com.wp.opencode-serve"
-      echo "            launchctl kill SIGTERM gui/$(id -u)/com.wp.opencode-telegram"
-    else
-      echo "  Telegram setup:"
-      echo "    1. Add tokens to $SERVICE_HOME/.config/opencode-telegram-bot/.env"
-      echo "    2. Enable services:"
-      echo "       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.opencode-serve.plist"
-      echo "       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.wp.opencode-telegram.plist"
-    fi
-    echo "    Logs:   tail -f $SERVICE_HOME/.config/opencode-telegram-bot/opencode-serve.log"
-    echo "            tail -f $SERVICE_HOME/.config/opencode-telegram-bot/opencode-telegram.log"
-    echo ""
-  elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ]; then
-    echo "  Start your agent:"
-    echo "    cd $SITE_PATH && kimaki"
-    echo ""
-  elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "telegram" ]; then
-    echo "  Start your agent:"
-    echo "    cd $SITE_PATH && opencode serve &"
-    echo "    opencode-telegram start"
-    echo ""
-  elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "cc-connect" ]; then
-    echo "  Start your agent:"
-    echo "    cd $SITE_PATH && cc-connect"
-    echo ""
-  else
-    echo "  Start your agent:"
-    if [ "$RUNTIME" = "claude-code" ]; then
-      echo "    cd $SITE_PATH && claude"
-    else
-      echo "    cd $SITE_PATH && opencode"
-    fi
-    echo ""
+  # No chat bridge installed — show the raw runtime CLI fallback.
+  if [ "$INSTALL_CHAT" != true ] || [ -z "$CHAT_BRIDGE" ]; then
+    _print_bare_runtime_start
+    return
   fi
+
+  local env
+  if [ "$PLATFORM" = "mac" ]; then
+    env="local-launchd"
+  else
+    env="local-manual"
+  fi
+
+  # macOS launchd with creds set: uniform Start/Stop/Logs block.
+  if [ "$env" = "local-launchd" ] && bridge_is_ready "$CHAT_BRIDGE"; then
+    _print_launchd_run_block "$CHAT_BRIDGE"
+    return
+  fi
+
+  # macOS launchd without creds: bridge-specific setup prose.
+  if [ "$env" = "local-launchd" ]; then
+    _print_launchd_setup_block "$CHAT_BRIDGE"
+    return
+  fi
+
+  # Local-manual (Linux local, no launchd): plain start command.
+  echo "  Start your agent:"
+  local cmd
+  while IFS= read -r cmd; do
+    echo "    $cmd"
+  done < <(bridge_start_hint "$CHAT_BRIDGE" local-manual)
+  echo ""
 }
 
 _print_vps_next_steps() {
-  if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ]; then
-    if [ -n "$KIMAKI_BOT_TOKEN" ]; then
-      echo "  Bot token configured via KIMAKI_BOT_TOKEN."
-      echo "  Start the agent:  systemctl start kimaki"
+  if [ "$INSTALL_CHAT" != true ] || [ -z "$CHAT_BRIDGE" ]; then
+    echo "  No chat bridge installed. Run your agent manually:"
+    _print_bare_runtime_cmd
+    echo ""
+    return
+  fi
+
+  # Credentials configured.
+  if bridge_is_ready "$CHAT_BRIDGE"; then
+    local cmd units
+    # Bridge-specific preamble — matches longstanding prose.
+    case "$CHAT_BRIDGE" in
+      kimaki)   echo "  Bot token configured via KIMAKI_BOT_TOKEN." ;;
+      telegram) echo "  Telegram credentials configured. Start the agent:" ;;
+    esac
+    units=$(bridge_systemd_units "$CHAT_BRIDGE" | wc -w | tr -d ' ')
+    if [ "$units" -gt 1 ]; then
+      # Multi-service bridge: list each service start on its own line.
+      for unit in $(bridge_systemd_units "$CHAT_BRIDGE"); do
+        echo "    systemctl start ${unit%.service}"
+      done
     else
+      cmd=$(bridge_start_hint "$CHAT_BRIDGE" vps)
+      echo "  Start the agent:  $cmd"
+    fi
+    echo ""
+    return
+  fi
+
+  # Credentials missing: bridge-specific VPS onboarding.
+  _print_vps_setup_block "$CHAT_BRIDGE"
+  echo ""
+}
+
+# ----------------------------------------------------------------------------
+# Presentation helpers
+# ----------------------------------------------------------------------------
+
+# Start/Stop/Logs block for macOS launchd when credentials are configured.
+# Output shape:
+#   <Display> (launchd service[s]):
+#     Start:  <cmd>
+#             <cmd>   (for multi-service bridges)
+#     Stop:   <cmd>
+#             <cmd>
+#     Logs:   <cmd>
+#             <cmd>
+_print_launchd_run_block() {
+  local bridge="$1" display units_label
+  display=$(bridge_display_title "$bridge")
+  if [ "$(bridge_launchd_labels "$bridge" | wc -w | tr -d ' ')" -gt 1 ]; then
+    units_label="launchd services"
+  else
+    units_label="launchd service"
+  fi
+  echo "  $display ($units_label):"
+  _print_labelled_lines "    Start:  " bridge_start_hint "$bridge" local-launchd
+  _print_labelled_lines "    Stop:   " bridge_stop_hint  "$bridge" local-launchd
+  _print_labelled_lines "    Logs:   " bridge_logs_cmd   "$bridge"
+  echo ""
+}
+
+# Bridge-specific onboarding prose for macOS launchd when credentials are
+# missing. cc-connect is always "ready" (no token) so it never reaches here.
+_print_launchd_setup_block() {
+  local bridge="$1" uid
+  uid=$(id -u)
+  case "$bridge" in
+    kimaki)
+      echo "  Kimaki setup:"
+      echo "    1. Run onboarding:  cd $SITE_PATH && kimaki"
+      echo "    2. Enable service:  launchctl bootstrap gui/${uid} ~/Library/LaunchAgents/com.wp.kimaki.plist"
+      ;;
+    telegram)
+      echo "  Telegram setup:"
+      echo "    1. Add tokens to $SERVICE_HOME/.config/opencode-telegram-bot/.env"
+      echo "    2. Enable services:"
+      for label in $(bridge_launchd_labels telegram); do
+        echo "       launchctl bootstrap gui/${uid} ~/Library/LaunchAgents/${label}.plist"
+      done
+      ;;
+  esac
+  _print_labelled_lines "    Logs:   " bridge_logs_cmd "$bridge"
+  echo ""
+}
+
+# Bridge-specific onboarding prose for VPS when credentials are missing.
+_print_vps_setup_block() {
+  local bridge="$1"
+  case "$bridge" in
+    kimaki)
       echo "  1. Set up Discord bot token:"
       echo "     Option A: Run kimaki interactively first (sets up database)"
       if [ "$RUN_AS_ROOT" = false ]; then
@@ -192,15 +253,8 @@ _print_vps_next_steps() {
       echo "       Environment=KIMAKI_BOT_TOKEN=your-token-here"
       echo ""
       echo "  2. Start the agent:  systemctl start kimaki"
-    fi
-  elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "cc-connect" ]; then
-    echo "  Start the agent:  systemctl start cc-connect"
-  elif [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "telegram" ]; then
-    if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_ALLOWED_USER_ID" ]; then
-      echo "  Telegram credentials configured. Start the agent:"
-      echo "    systemctl start opencode-serve"
-      echo "    systemctl start opencode-telegram"
-    else
+      ;;
+    telegram)
       echo "  1. Get your Telegram credentials:"
       echo "     - Bot token: message @BotFather → /newbot"
       echo "     - Your user ID: message @userinfobot"
@@ -210,16 +264,40 @@ _print_vps_next_steps() {
       echo "     Set TELEGRAM_BOT_TOKEN and TELEGRAM_ALLOWED_USER_ID"
       echo ""
       echo "  3. Start the agent:"
-      echo "     systemctl start opencode-serve"
-      echo "     systemctl start opencode-telegram"
-    fi
-  else
-    echo "  No chat bridge installed. Run your agent manually:"
-    if [ "$RUNTIME" = "claude-code" ]; then
-      echo "    cd $SITE_PATH && claude"
+      for unit in $(bridge_systemd_units telegram); do
+        echo "     systemctl start ${unit%.service}"
+      done
+      ;;
+  esac
+}
+
+# Run a command producing 1+ lines; print the first line prefixed with
+# <label>, subsequent lines indented to the same column.
+_print_labelled_lines() {
+  local label="$1"; shift
+  local pad
+  pad=$(printf '%*s' "${#label}" '')
+  local first=true line
+  while IFS= read -r line; do
+    if [ "$first" = true ]; then
+      echo "${label}${line}"
+      first=false
     else
-      echo "    cd $SITE_PATH && opencode"
+      echo "${pad}${line}"
     fi
-  fi
+  done < <("$@")
+}
+
+# Raw-runtime fallback when no chat bridge is installed.
+_print_bare_runtime_start() {
+  echo "  Start your agent:"
+  _print_bare_runtime_cmd
   echo ""
+}
+_print_bare_runtime_cmd() {
+  if [ "$RUNTIME" = "claude-code" ]; then
+    echo "    cd $SITE_PATH && claude"
+  else
+    echo "    cd $SITE_PATH && opencode"
+  fi
 }

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -44,15 +44,9 @@ Before running anything, identify (a) which side you are on and (b) which chat b
 
 Ordering matches install priority: kimaki > cc-connect > telegram if more than one is installed.
 
-### Restart commands per bridge × environment
+### Restart commands
 
-| Bridge | VPS | Local (launchd) | Local (manual) |
-|---|---|---|---|
-| kimaki | `systemctl restart kimaki` | `launchctl kickstart -k gui/$(id -u)/com.wp.kimaki` | stop the `kimaki` process and re-run |
-| cc-connect | `systemctl restart cc-connect` | `launchctl kickstart -k gui/$(id -u)/com.wp.cc-connect` | stop the `cc-connect` process and re-run |
-| telegram | `systemctl restart opencode-serve opencode-telegram` | `launchctl kickstart -k gui/$(id -u)/com.wp.opencode-serve` **and** `... com.wp.opencode-telegram` | stop both `opencode serve` and `opencode-telegram start`, then restart |
-
-The script's summary block prints these verbatim for the detected combination — do not guess, just pass through what the summary shows.
+Do not guess restart commands. The script's summary block prints the exact command for the detected bridge × environment combination at the end of every run — pass that through to the user verbatim. The source of truth for these commands is `lib/chat-bridges.sh::bridge_restart_cmd`; they are rendered once and reused by both `upgrade.sh` and setup-time summary output, so the skill never needs its own copy.
 
 ## Step 2 — Resolve the repo path
 

--- a/tests/bridge-render.sh
+++ b/tests/bridge-render.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# tests/bridge-render.sh — byte-equivalence guard for chat-bridge templates.
+#
+# Captures the output of the legacy install functions in lib/chat-bridge.sh
+# (by mocking write_file / run_cmd / log / warn / launchctl / systemctl /
+# chmod / chown) and the output of the new bridge_render_systemd /
+# bridge_render_launchd generators in lib/chat-bridges.sh, and diffs them.
+#
+# Every unit file and plist across every bridge × env × token-state combo
+# must be byte-identical. Exits non-zero if any diff is non-empty.
+#
+# Usage:
+#   tests/bridge-render.sh              # run and diff, print pass/fail
+#   tests/bridge-render.sh --verbose    # also print the captured output
+#   tests/bridge-render.sh --update     # (future) refresh fixtures
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+VERBOSE=false
+for arg in "$@"; do
+  case "$arg" in
+    --verbose) VERBOSE=true ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Mock env — fixed values so templates are deterministic
+# ---------------------------------------------------------------------------
+export SERVICE_USER="chubes"
+export SERVICE_HOME="/home/chubes"
+export SITE_PATH="/var/www/site"
+export PLATFORM="linux"
+export LOCAL_MODE=false
+export DRY_RUN=false
+export INSTALL_CHAT=true
+export RUN_AS_ROOT=false
+
+# kimaki
+export KIMAKI_DATA_DIR="$SERVICE_HOME/.kimaki"
+export KIMAKI_CONFIG_DIR="/opt/kimaki-config"
+export KIMAKI_BIN="/usr/bin/kimaki"
+export KIMAKI_BOT_TOKEN=""
+
+# cc-connect
+export CC_BIN="/usr/bin/cc-connect"
+export CC_DATA_DIR="$SERVICE_HOME/.cc-connect"
+export CC_CONNECT_TOKEN=""
+
+# telegram
+export OPENCODE_BIN="/usr/bin/opencode"
+export TELEGRAM_BIN="/usr/bin/opencode-telegram"
+export SERVE_ENV_FILE="$SERVICE_HOME/.config/opencode-serve.env"
+export TELEGRAM_CONFIG_DIR="$SERVICE_HOME/.config/opencode-telegram-bot"
+export TELEGRAM_BOT_TOKEN=""
+export TELEGRAM_ALLOWED_USER_ID=""
+export OPENCODE_MODEL=""
+
+# ---------------------------------------------------------------------------
+# Mocks — replace side-effecting helpers with capture-only versions
+# ---------------------------------------------------------------------------
+CAPTURED_FILE=""
+CAPTURED_CONTENT=""
+
+write_file() {
+  CAPTURED_FILE="$1"
+  CAPTURED_CONTENT="$2"
+}
+
+run_cmd()  { :; }
+log()      { :; }
+warn()     { :; }
+launchctl() { :; }
+systemctl() { :; }
+chmod()    { :; }
+chown()    { :; }
+
+# lib/common.sh exports colour vars + log/warn/error; install_chat_bridge
+# wants them defined.
+RED=""
+GREEN=""
+YELLOW=""
+BLUE=""
+NC=""
+
+# ---------------------------------------------------------------------------
+# Load legacy install functions
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC1091
+source lib/chat-bridge.sh
+# shellcheck disable=SC1091
+source lib/chat-bridges.sh
+
+TMPDIR_OLD="$(mktemp -d)"
+TMPDIR_NEW="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_OLD" "$TMPDIR_NEW"' EXIT
+
+# capture_old  <label> <installer-function>
+#   Calls the legacy installer under mocks and writes CAPTURED_CONTENT to
+#   $TMPDIR_OLD/<label>. If the installer writes multiple files the caller
+#   splits them (see telegram below).
+capture_old() {
+  local label="$1" fn="$2"
+  CAPTURED_FILE=""; CAPTURED_CONTENT=""
+  "$fn"
+  printf '%s\n' "$CAPTURED_CONTENT" > "$TMPDIR_OLD/$label"
+}
+
+# For multi-file installers (telegram) we need to capture each write_file
+# call. Swap the mock to append to an ordered list.
+OLD_WRITES_FILES=()
+OLD_WRITES_CONTENT=()
+
+capture_old_multi_setup() {
+  OLD_WRITES_FILES=()
+  OLD_WRITES_CONTENT=()
+  # Redefine write_file for this capture
+  write_file() {
+    OLD_WRITES_FILES+=("$1")
+    OLD_WRITES_CONTENT+=("$2")
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Helpers for rebuilding env blocks equivalent to the legacy installers
+# ---------------------------------------------------------------------------
+kimaki_env_block() {
+  local out="Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR"
+  if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then
+    out="$out
+Environment=KIMAKI_BOT_TOKEN=$KIMAKI_BOT_TOKEN"
+  fi
+  printf '%s' "$out"
+}
+
+cc_connect_env_block() {
+  local out="Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin"
+  if [ -n "${CC_CONNECT_TOKEN:-}" ]; then
+    out="$out
+Environment=CC_CONNECT_TOKEN=$CC_CONNECT_TOKEN"
+  fi
+  printf '%s' "$out"
+}
+
+telegram_env_block() {
+  printf '%s' "Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin"
+}
+
+# ---------------------------------------------------------------------------
+# Snapshots: systemd
+# ---------------------------------------------------------------------------
+echo "==> systemd snapshots"
+
+# kimaki
+capture_old kimaki-systemd _install_kimaki_systemd
+bridge_render_systemd kimaki kimaki.service "$(kimaki_env_block)" > "$TMPDIR_NEW/kimaki-systemd"
+
+# cc-connect
+capture_old cc-connect-systemd _install_cc_connect_systemd
+bridge_render_systemd cc-connect cc-connect.service "$(cc_connect_env_block)" > "$TMPDIR_NEW/cc-connect-systemd"
+
+# telegram (two writes)
+capture_old_multi_setup
+_install_telegram_systemd
+printf '%s\n' "${OLD_WRITES_CONTENT[0]}" > "$TMPDIR_OLD/telegram-serve-systemd"
+printf '%s\n' "${OLD_WRITES_CONTENT[1]}" > "$TMPDIR_OLD/telegram-bot-systemd"
+bridge_render_systemd telegram opencode-serve.service "$(telegram_env_block)" > "$TMPDIR_NEW/telegram-serve-systemd"
+bridge_render_systemd telegram opencode-telegram.service "$(telegram_env_block)" > "$TMPDIR_NEW/telegram-bot-systemd"
+
+# restore single-capture mock for launchd pass
+write_file() { CAPTURED_FILE="$1"; CAPTURED_CONTENT="$2"; }
+
+# ---------------------------------------------------------------------------
+# Snapshots: launchd
+#
+# Launchd installers depend on PLATFORM=mac + LOCAL_MODE=true + HOME set.
+# Swap in mac-specific env for this pass only, so dry-run bin path matches.
+# ---------------------------------------------------------------------------
+echo "==> launchd snapshots"
+
+PLATFORM="mac"
+LOCAL_MODE=true
+HOME_SAVE="$HOME"
+export HOME="$SERVICE_HOME"
+# The launchd installers hardcode /opt/homebrew/bin/... under DRY_RUN=true,
+# so run them as if dry-running to get deterministic binary paths.
+DRY_RUN_SAVE="$DRY_RUN"
+DRY_RUN=true
+KIMAKI_BIN="/opt/homebrew/bin/kimaki"
+CC_BIN="/opt/homebrew/bin/cc-connect"
+OPENCODE_BIN="/opt/homebrew/bin/opencode"
+TELEGRAM_BIN="/opt/homebrew/bin/opencode-telegram"
+
+# kimaki
+capture_old kimaki-launchd _install_kimaki_launchd
+bridge_render_launchd kimaki com.wp.kimaki > "$TMPDIR_NEW/kimaki-launchd"
+
+# cc-connect
+capture_old cc-connect-launchd _install_cc_connect_launchd
+bridge_render_launchd cc-connect com.wp.cc-connect > "$TMPDIR_NEW/cc-connect-launchd"
+
+# telegram (two writes)
+capture_old_multi_setup
+_install_telegram_launchd
+printf '%s\n' "${OLD_WRITES_CONTENT[0]}" > "$TMPDIR_OLD/telegram-serve-launchd"
+printf '%s\n' "${OLD_WRITES_CONTENT[1]}" > "$TMPDIR_OLD/telegram-bot-launchd"
+bridge_render_launchd telegram com.wp.opencode-serve > "$TMPDIR_NEW/telegram-serve-launchd"
+bridge_render_launchd telegram com.wp.opencode-telegram > "$TMPDIR_NEW/telegram-bot-launchd"
+
+export HOME="$HOME_SAVE"
+DRY_RUN="$DRY_RUN_SAVE"
+
+# ---------------------------------------------------------------------------
+# Diff pass
+# ---------------------------------------------------------------------------
+FAILED=0
+echo "==> diffs"
+for f in "$TMPDIR_OLD"/*; do
+  name="$(basename "$f")"
+  new="$TMPDIR_NEW/$name"
+  if [ ! -f "$new" ]; then
+    echo "  FAIL $name (missing new output)"
+    FAILED=$((FAILED+1))
+    continue
+  fi
+  if diff -q "$f" "$new" >/dev/null 2>&1; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    diff -u "$f" "$new" | head -40
+    FAILED=$((FAILED+1))
+  fi
+done
+
+if [ "$VERBOSE" = true ]; then
+  echo
+  echo "==> captured outputs at:"
+  echo "  old: $TMPDIR_OLD"
+  echo "  new: $TMPDIR_NEW"
+  trap - EXIT
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+  echo
+  echo "FAILED: $FAILED snapshot(s) drifted"
+  exit 1
+fi
+
+echo
+echo "OK: all snapshots byte-identical"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -54,8 +54,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
-# wordpress is needed for wp_cmd helper used by compose).
-for lib in common detect wordpress skills; do
+# wordpress is needed for wp_cmd helper used by compose; chat-bridges for
+# systemd/launchd template generators shared with setup-time install).
+for lib in common detect wordpress skills chat-bridges; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -783,22 +784,8 @@ Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR"
   local MERGED_ENV
   MERGED_ENV=$(_merge_systemd_env_lines "$CURRENT_ENV" "$TEMPLATE_ENV")
 
-  local NEW_UNIT="[Unit]
-Description=Kimaki Discord Bot (wp-coding-agents)
-After=network.target
-
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-$MERGED_ENV
-ExecStartPre=$KIMAKI_CONFIG_DIR/post-upgrade.sh
-ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
+  local NEW_UNIT
+  NEW_UNIT=$(bridge_render_systemd kimaki kimaki.service "$MERGED_ENV")
 
   _smart_update_systemd_unit "$UNIT_FILE" "$NEW_UNIT" "kimaki.service"
 }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -205,26 +205,14 @@ source "$RUNTIME_FILE"
 # which the chat bridge detection below depends on to pick the right branch.
 detect_environment
 
-# Detect chat bridge from installed services / installed binaries.
-# VPS: systemd unit files are the source of truth.
-# Local: no systemd — fall back to launchd plist (macOS) or `command -v <bridge>`.
-# Ordering matches install priority: kimaki > cc-connect > telegram.
+# Detect chat bridge from installed services / installed binaries via the
+# lib/chat-bridges.sh registry. See bridge_detect_local / bridge_detect_vps
+# for the full probe order (launchd plists + command -v on local; systemd
+# unit files on VPS). Priority: kimaki > cc-connect > telegram.
 if [ "$LOCAL_MODE" = true ]; then
-  if [ -f "$HOME/Library/LaunchAgents/com.wp.kimaki.plist" ] || command -v kimaki &>/dev/null; then
-    CHAT_BRIDGE="kimaki"
-  elif [ -f "$HOME/Library/LaunchAgents/com.wp.cc-connect.plist" ] || command -v cc-connect &>/dev/null; then
-    CHAT_BRIDGE="cc-connect"
-  elif [ -f "$HOME/Library/LaunchAgents/com.wp.opencode-telegram.plist" ] || command -v opencode-telegram &>/dev/null; then
-    CHAT_BRIDGE="telegram"
-  fi
+  CHAT_BRIDGE=$(bridge_detect_local)
 else
-  if [ -f "/etc/systemd/system/kimaki.service" ]; then
-    CHAT_BRIDGE="kimaki"
-  elif [ -f "/etc/systemd/system/cc-connect.service" ]; then
-    CHAT_BRIDGE="cc-connect"
-  elif [ -f "/etc/systemd/system/opencode-telegram.service" ]; then
-    CHAT_BRIDGE="telegram"
-  fi
+  CHAT_BRIDGE=$(bridge_detect_vps)
 fi
 
 log "Runtime:     $RUNTIME"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -823,38 +823,21 @@ _update_telegram_systemd() {
   local SERVE_UNIT="/etc/systemd/system/opencode-serve.service"
   local TG_UNIT="/etc/systemd/system/opencode-telegram.service"
 
-  local OPENCODE_BIN TG_BIN SERVE_ENV_FILE TG_CONFIG_DIR
+  local OPENCODE_BIN TELEGRAM_BIN SERVE_ENV_FILE TELEGRAM_CONFIG_DIR
   OPENCODE_BIN=$(which opencode 2>/dev/null || echo "/usr/bin/opencode")
-  TG_BIN=$(which opencode-telegram 2>/dev/null || echo "/usr/bin/opencode-telegram")
+  TELEGRAM_BIN=$(which opencode-telegram 2>/dev/null || echo "/usr/bin/opencode-telegram")
   SERVE_ENV_FILE="$SERVICE_HOME/.config/opencode-serve.env"
-  TG_CONFIG_DIR="$SERVICE_HOME/.config/opencode-telegram-bot"
+  TELEGRAM_CONFIG_DIR="$SERVICE_HOME/.config/opencode-telegram-bot"
+
+  local TEMPLATE_ENV="Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin"
 
   # --- opencode-serve.service ---
   if [ -f "$SERVE_UNIT" ]; then
-    local SERVE_CURRENT_ENV
+    local SERVE_CURRENT_ENV SERVE_MERGED_ENV SERVE_NEW
     SERVE_CURRENT_ENV=$(grep '^Environment=' "$SERVE_UNIT" || true)
-    local SERVE_TEMPLATE_ENV="Environment=HOME=$SERVICE_HOME
-Environment=PATH=/usr/local/bin:/usr/bin:/bin"
-    local SERVE_MERGED_ENV
-    SERVE_MERGED_ENV=$(_merge_systemd_env_lines "$SERVE_CURRENT_ENV" "$SERVE_TEMPLATE_ENV")
-
-    local SERVE_NEW="[Unit]
-Description=OpenCode Server (wp-coding-agents)
-After=network.target
-
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-$SERVE_MERGED_ENV
-EnvironmentFile=-$SERVE_ENV_FILE
-ExecStart=$OPENCODE_BIN serve
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
-
+    SERVE_MERGED_ENV=$(_merge_systemd_env_lines "$SERVE_CURRENT_ENV" "$TEMPLATE_ENV")
+    SERVE_NEW=$(bridge_render_systemd telegram opencode-serve.service "$SERVE_MERGED_ENV")
     _smart_update_systemd_unit "$SERVE_UNIT" "$SERVE_NEW" "opencode-serve.service"
   else
     warn "  $SERVE_UNIT does not exist — skipping"
@@ -862,31 +845,10 @@ WantedBy=multi-user.target"
 
   # --- opencode-telegram.service ---
   if [ -f "$TG_UNIT" ]; then
-    local TG_CURRENT_ENV
+    local TG_CURRENT_ENV TG_MERGED_ENV TG_NEW
     TG_CURRENT_ENV=$(grep '^Environment=' "$TG_UNIT" || true)
-    local TG_TEMPLATE_ENV="Environment=HOME=$SERVICE_HOME
-Environment=PATH=/usr/local/bin:/usr/bin:/bin"
-    local TG_MERGED_ENV
-    TG_MERGED_ENV=$(_merge_systemd_env_lines "$TG_CURRENT_ENV" "$TG_TEMPLATE_ENV")
-
-    local TG_NEW="[Unit]
-Description=OpenCode Telegram Bot (wp-coding-agents)
-After=network.target opencode-serve.service
-Requires=opencode-serve.service
-
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-$TG_MERGED_ENV
-EnvironmentFile=$TG_CONFIG_DIR/.env
-ExecStart=$TG_BIN start
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
-
+    TG_MERGED_ENV=$(_merge_systemd_env_lines "$TG_CURRENT_ENV" "$TEMPLATE_ENV")
+    TG_NEW=$(bridge_render_systemd telegram opencode-telegram.service "$TG_MERGED_ENV")
     _smart_update_systemd_unit "$TG_UNIT" "$TG_NEW" "opencode-telegram.service"
   else
     warn "  $TG_UNIT does not exist — skipping"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -910,97 +910,63 @@ print_summary() {
   _print_verify_block
 }
 
+# Resolve the runtime environment for restart/verify output.
+# Returns: local-launchd | local-manual | vps
+_resolve_bridge_env() {
+  local bridge="$1" label
+  if [ "$LOCAL_MODE" != true ]; then
+    echo "vps"
+    return
+  fi
+  for label in $(bridge_launchd_labels "$bridge"); do
+    if [ -f "$HOME/Library/LaunchAgents/${label}.plist" ]; then
+      echo "local-launchd"
+      return
+    fi
+  done
+  echo "local-manual"
+}
+
 # Print the correct restart command for the detected chat bridge × environment.
 _print_bridge_restart_hint() {
-  case "$CHAT_BRIDGE" in
-    kimaki)
-      if [ "$LOCAL_MODE" = true ]; then
-        warn "Restart kimaki when ready (active chat sessions will die):"
-        if [ -f "$HOME/Library/LaunchAgents/com.wp.kimaki.plist" ]; then
-          warn "  launchctl kickstart -k gui/$(id -u)/com.wp.kimaki"
-        else
-          warn "  Stop your kimaki process and re-run: cd $SITE_PATH && kimaki"
-        fi
-      else
-        warn "Restart kimaki when ready: systemctl restart kimaki"
-        warn "  (Active sessions will die when you restart.)"
-      fi
-      echo ""
-      ;;
-    cc-connect)
-      if [ "$LOCAL_MODE" = true ]; then
-        warn "Restart cc-connect when ready (active chat sessions will die):"
-        if [ -f "$HOME/Library/LaunchAgents/com.wp.cc-connect.plist" ]; then
-          warn "  launchctl kickstart -k gui/$(id -u)/com.wp.cc-connect"
-        else
-          warn "  Stop your cc-connect process and re-run: cd $SITE_PATH && cc-connect"
-        fi
-      else
-        warn "Restart cc-connect when ready: systemctl restart cc-connect"
-        warn "  (Active sessions will die when you restart.)"
-      fi
-      echo ""
-      ;;
-    telegram)
-      if [ "$LOCAL_MODE" = true ]; then
-        warn "Restart telegram stack when ready (active chat sessions will die):"
-        if [ -f "$HOME/Library/LaunchAgents/com.wp.opencode-serve.plist" ]; then
-          warn "  launchctl kickstart -k gui/$(id -u)/com.wp.opencode-serve"
-          warn "  launchctl kickstart -k gui/$(id -u)/com.wp.opencode-telegram"
-        else
-          warn "  Stop your opencode serve + opencode-telegram processes and restart manually"
-        fi
-      else
-        warn "Restart telegram stack when ready:"
-        warn "  systemctl restart opencode-serve opencode-telegram"
-        warn "  (Active sessions will die when you restart.)"
-      fi
-      echo ""
-      ;;
-  esac
+  [ -n "$CHAT_BRIDGE" ] || return 0
+
+  local env display cmd
+  env=$(_resolve_bridge_env "$CHAT_BRIDGE")
+  display=$(bridge_display_name "$CHAT_BRIDGE")
+
+  warn "Restart $display when ready (active chat sessions will die):"
+  while IFS= read -r cmd; do
+    warn "  $cmd"
+  done < <(bridge_restart_cmd "$CHAT_BRIDGE" "$env")
+  echo ""
 }
 
 _print_verify_block() {
   log "Verify:"
-  case "$CHAT_BRIDGE" in
-    kimaki)
-      if [ "$LOCAL_MODE" = true ]; then
-        if [ -f "$HOME/Library/LaunchAgents/com.wp.kimaki.plist" ]; then
-          log "  launchctl print gui/$(id -u)/com.wp.kimaki | head -20   # chat bridge status"
-        else
-          log "  pgrep -fl kimaki                                        # chat bridge status"
-        fi
-      else
-        log "  systemctl status kimaki                                  # chat bridge status"
-      fi
-      local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
-      log "  ls $PLUGINS_DIR   # plugin versions"
-      ;;
-    cc-connect)
-      if [ "$LOCAL_MODE" = true ]; then
-        if [ -f "$HOME/Library/LaunchAgents/com.wp.cc-connect.plist" ]; then
-          log "  launchctl print gui/$(id -u)/com.wp.cc-connect | head -20   # chat bridge status"
-        else
-          log "  pgrep -fl cc-connect                                        # chat bridge status"
-        fi
-      else
-        log "  systemctl status cc-connect                                 # chat bridge status"
-      fi
-      log "  cc-connect --version                                        # binary version"
-      ;;
-    telegram)
-      if [ "$LOCAL_MODE" = true ]; then
-        log "  launchctl print gui/$(id -u)/com.wp.opencode-serve | head -20     # opencode-serve status"
-        log "  launchctl print gui/$(id -u)/com.wp.opencode-telegram | head -20  # telegram bot status"
-      else
-        log "  systemctl status opencode-serve opencode-telegram           # chat bridge status"
-      fi
-      log "  opencode-telegram --version                                 # binary version"
-      ;;
-    *)
-      log "  (no chat bridge detected)"
-      ;;
-  esac
+
+  if [ -z "$CHAT_BRIDGE" ]; then
+    log "  (no chat bridge detected)"
+  else
+    local env primary cmd
+    env=$(_resolve_bridge_env "$CHAT_BRIDGE")
+    primary=$(bridge_binaries "$CHAT_BRIDGE" | awk '{print $1}')
+
+    while IFS= read -r cmd; do
+      log "  $cmd   # chat bridge status"
+    done < <(bridge_verify_cmd "$CHAT_BRIDGE" "$env")
+
+    case "$CHAT_BRIDGE" in
+      kimaki)
+        local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
+        log "  ls $PLUGINS_DIR   # plugin versions"
+        ;;
+      *)
+        log "  $primary --version   # binary version"
+        ;;
+    esac
+  fi
+
   log "  cat $SITE_PATH/AGENTS.md | head -20   # agent instructions"
   log "  ls $(runtime_skills_dir)              # installed skills"
 }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -802,29 +802,17 @@ _update_cc_connect_systemd() {
   local CC_BIN
   CC_BIN=$(which cc-connect 2>/dev/null || echo "/usr/bin/cc-connect")
 
-  # Mirrors _install_cc_connect_systemd in lib/chat-bridge.sh.
-  # CC_CONNECT_TOKEN is only added if setup originally set it (lives in current env).
+  # CC_CONNECT_TOKEN lives in the existing unit's env if setup originally
+  # set it; mandatory template omits it and _merge_systemd_env_lines
+  # preserves host-specific keys.
   local TEMPLATE_ENV="Environment=HOME=$SERVICE_HOME
 Environment=PATH=/usr/local/bin:/usr/bin:/bin"
 
   local MERGED_ENV
   MERGED_ENV=$(_merge_systemd_env_lines "$CURRENT_ENV" "$TEMPLATE_ENV")
 
-  local NEW_UNIT="[Unit]
-Description=cc-connect Chat Bridge (wp-coding-agents)
-After=network.target
-
-[Service]
-Type=simple
-User=$SERVICE_USER
-WorkingDirectory=$SITE_PATH
-$MERGED_ENV
-ExecStart=$CC_BIN
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target"
+  local NEW_UNIT
+  NEW_UNIT=$(bridge_render_systemd cc-connect cc-connect.service "$MERGED_ENV")
 
   _smart_update_systemd_unit "$UNIT_FILE" "$NEW_UNIT" "cc-connect.service"
 }


### PR DESCRIPTION
Closes #50.

## Summary

Before: chat-bridge identity strings, systemd unit templates, launchd plist XML, detection logic, and restart/verify/logs command strings were scattered across **7 sites** (setup + install, upgrade Phase 1/2/5/7, summary, skill). Adding a new bridge or tweaking a template required audits across at least 4 files. PR #49 already carried a `# Mirrors _install_cc_connect_systemd` comment as evidence of the drift risk.

After: single source of truth in `lib/chat-bridges.sh`. Every consumer reads through accessor functions. Zero inline unit/plist templates remain in `lib/chat-bridge.sh` or `upgrade.sh`.

## Architecture

```
┌─────────────────────────────────────────────────┐
│ lib/chat-bridges.sh  (new, single source)       │
│                                                 │
│  Registry:                                      │
│    bridge_names, bridge_systemd_units,          │
│    bridge_launchd_labels, bridge_binaries,      │
│    bridge_display_name, bridge_display_title    │
│                                                 │
│  Detection:                                     │
│    bridge_detect_local, bridge_detect_vps       │
│                                                 │
│  Readiness (token check):                       │
│    bridge_is_ready                              │
│                                                 │
│  Command accessors:                             │
│    bridge_restart_cmd / bridge_verify_cmd /     │
│    bridge_start_hint / bridge_stop_hint /       │
│    bridge_logs_cmd                              │
│                                                 │
│  Template generators:                           │
│    bridge_render_systemd <b> <unit> <env>       │
│    bridge_render_launchd <b> <label>            │
└─────────────────────────────────────────────────┘
       │              │               │
       ▼              ▼               ▼
  lib/chat-bridge.sh  upgrade.sh   lib/summary.sh
```

## Design choices

1. **Bash 3.2 compatible** — macOS default shell. No associative arrays; every data accessor is a `case` statement.
2. **One generator for install + upgrade** — the template-drift failure mode that caused #48 is eliminated by construction. `bridge_render_systemd` is the only place a unit file shape lives.
3. **Multi-service bridges (telegram)** — `bridge_systemd_units` / `bridge_launchd_labels` return space-separated lists; generators key on `(bridge, unit-or-label)`.
4. **Env-block construction stays inline** — install emits optional vars (KIMAKI_BOT_TOKEN, CC_CONNECT_TOKEN) when set; upgrade emits a mandatory-only template and merges with the existing unit's Environment= lines via the unchanged `_merge_systemd_env_lines` helper. Different contracts so centralizing buys nothing.
5. **Prose helpers separated from data** — bridge-specific onboarding prose (BotFather steps, systemd edit instructions) stays in `summary.sh` as presentation helpers because it is not data. Commands themselves are driven by registry accessors.

## Phases — one commit each

| # | Commit | Net lines |
|---|---|---|
| 1 | add `lib/chat-bridges.sh` registry | +535 |
| 2 | byte-equivalence snapshot harness | +255 |
| 3a | swap kimaki consumers | -56 |
| 3b | swap cc-connect consumers | -53 |
| 3c | swap telegram consumers | -137 |
| 4 | swap detection block | -9 |
| 5a | data-drive restart hint + verify block | -22 |
| 5b | data-drive summary next-steps | +137 |
| 6 | strip restart-command table from skill | -6 |
| 7 | CI: syntax + bridge-render workflow | +33 |

**Net: +1159 / -484**. Most of the addition is the new registry (607) + the snapshot test harness (255) + new CI workflow (33). The consumer code shrank meaningfully (`lib/chat-bridge.sh` -243, `upgrade.sh` net -53 with detection tightening, restart/verify refactor, and telegram dedup).

## Verification

Three complementary acceptance tests were run at every phase boundary:

### 1. Byte-identical unit/plist rendering — `tests/bridge-render.sh`

Mocks `write_file` / `run_cmd` / `log` / `warn` / `launchctl` / `systemctl` to capture template output with zero side effects. Renders every bridge × (systemd + launchd) through both the legacy install functions and the new generator, diffs with `diff -q`.

```
==> diffs
  ok   cc-connect-launchd
  ok   cc-connect-systemd
  ok   kimaki-launchd
  ok   kimaki-systemd
  ok   telegram-bot-launchd
  ok   telegram-bot-systemd
  ok   telegram-serve-launchd
  ok   telegram-serve-systemd

OK: all snapshots byte-identical
```

All 8 snapshots clean at every phase. This caught a real drift in Phase 1 (my first draft had `HOME=$SERVICE_HOME` in the kimaki launchd EnvironmentVariables dict — the original plist doesn't set HOME — and the test rejected it before any consumer was swapped).

### 2. Byte-identical summary output — 15-combination text diff

Captured `_print_local_next_steps` and `_print_vps_next_steps` output across every meaningful input combination from both `git HEAD~1` (pre-refactor) and the current branch, using fixed mock env. Combinations:

- `(mac-local, vps) × (kimaki, cc-connect, telegram) × (ready, unready)` = 12
- `linux-local-manual × {kimaki, cc-connect, telegram}` = 3
- `(local, vps) × no-bridge fallback` = 2

Diff: **empty**. Prose byte-identical across every pair.

### 3. End-to-end dry-run on a live Studio install

```
$ ./upgrade.sh --dry-run --wp-path /Users/chubes/Studio/intelligence-chubes4
[wp-coding-agents] Chat bridge: kimaki
[wp-coding-agents] Phase 2: Syncing kimaki config (local mode)...
[wp-coding-agents] Upgrade complete.
```

Clean. Note detection works without passing `--local` (a consequence of Phase 4 + the #55 ordering fix already on main).

## CI

`.github/workflows/shell.yml` (new) — two jobs on ubuntu-latest:

1. **syntax** — `bash -n` on every `*.sh` in the repo.
2. **bridge-render** — runs `tests/bridge-render.sh` to guarantee template output stays byte-identical. Future bridge additions or template tweaks either match snapshots or fail CI.

Both under 30 seconds. First workflow in the repo.

## What this unblocks

- Adding a fourth chat bridge now means one file (registry) + prose in summary. Not an audit across 7.
- Template tweaks (e.g. tighter systemd hardening, different launchd KeepAlive) land in one place and apply to both install and upgrade.
- The scattered identity strings that caused #48 cannot drift again — CI enforces it.