### PR TITLE
feat(dm-agent-sync): recompose composable files at session start

### DIFF
--- a/hooks/dm-agent-sync.sh
+++ b/hooks/dm-agent-sync.sh
@@ -55,6 +55,19 @@ detect_wp_cmd() {
 WP_CMD=$(detect_wp_cmd) || exit 0
 
 # ---------------------------------------------------------------------------
+# Refresh composable files before computing @ includes
+# ---------------------------------------------------------------------------
+# SectionRegistry callbacks can read live state (Intelligence sources, skill
+# inventory, etc.). DM regenerates composable files when their feeder state
+# fires a registered invalidation hook, but those hooks only run inside a
+# WordPress request. State changed via direct DB edits, cron, or external
+# processes would leave the on-disk file stale. Running `agent compose` here
+# guarantees AGENTS.md (and any sibling composable files) match live state
+# at the moment the coding-agent session starts.
+
+$WP_CMD datamachine agent compose >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
 # Query active agents from Data Machine
 # ---------------------------------------------------------------------------
 

--- a/kimaki/plugins/dm-agent-sync.ts
+++ b/kimaki/plugins/dm-agent-sync.ts
@@ -41,6 +41,15 @@ const dmAgentSync: Plugin = async ({ $ }) => {
   return {
     config: async (config) => {
       try {
+        // Refresh composable files before the session reads them.
+        // DM SectionRegistry callbacks render live state (configured sources,
+        // skills, config). DM's own invalidation hooks cover state changes
+        // that happen inside a WordPress request, but cron jobs, direct DB
+        // edits, or other external processes would leave AGENTS.md stale.
+        // Running compose here guarantees the file matches live state at the
+        // moment OpenCode loads the session prompt.
+        await $`wp datamachine agent compose --allow-root 2>/dev/null`.quiet().nothrow();
+
         // Query all agents from Data Machine.
         const agentsRaw = await $`wp datamachine agents list --format=json --allow-root 2>/dev/null`.quiet().nothrow().text();
 


### PR DESCRIPTION
## Summary

- `hooks/dm-agent-sync.sh`: runs `wp datamachine agent compose` immediately after WP-CLI detection, before building the CLAUDE.md `@` include block. Covers Claude Code and Studio Code SessionStart.
- `kimaki/plugins/dm-agent-sync.ts`: OpenCode `config` hook runs the same compose call before listing agents and assembling agent-switcher entries.

Both calls are silenced and tolerate missing DM — no behavior change on sites without Data Machine.

## Why

Coding-agent sessions read AGENTS.md once at the top and cache it for the duration of the session. DM's `ComposableFileInvalidation` (see Extra-Chill/data-machine#1160) keeps AGENTS.md fresh while WordPress is handling requests, but state changed by cron, direct DB edits, WP-CLI invocations, or other external processes between requests leaves the on-disk file stale until the next in-request invalidation hook fires.

A single compose call at session-start makes this a non-issue: the file on disk matches live state at the exact moment the external runtime reads it. Belt-and-suspenders with DM's in-request invalidation.

## Pairs with

- Extra-Chill/data-machine#1160 — adds the invalidation filter DM uses for in-request refresh.
- Automattic/intelligence#142 — contributes live `Configured Sources` state to the AGENTS.md section and registers on the new DM filter.

This PR stands alone: `agent compose` has existed in DM for a long time, so the compose call is safe against any DM version.

## Test plan

- [ ] Claude Code: `claude` session start runs the hook, `agent compose` runs, AGENTS.md is updated, CLAUDE.md `@` include block is rewritten. Confirm via `claude --debug` logs or file mtime.
- [ ] Studio Code: same flow.
- [ ] OpenCode: `opencode` invocation runs the plugin's `config` hook, compose fires, agent switcher reflects current agent roster + file paths.
- [ ] Site without Data Machine: both runtimes no-op silently (already covered by existing DM-detection guards; verify no error output).
- [ ] Rapid session starts: DM's 60-second debounce prevents redundant disk writes; the compose call itself is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)