### PR TITLE
fix: strip project discovery from system prompt to prevent wrong-channel minion routing

### DIFF
--- a/kimaki/plugins/dm-context-filter.ts
+++ b/kimaki/plugins/dm-context-filter.ts
@@ -20,6 +20,22 @@
 //    bot. The agent has no capability to act on this; pure metadata leakage.
 // 9. Upgrading kimaki — ~80 tokens of /upgrade-and-restart playbook. The user
 //    runs the slash command themselves when they want to upgrade.
+// 10. Reading other sessions — ~250 tokens documenting `kimaki session list
+//    --project` / `session search --channel <id>`. These are cross-project
+//    discovery vectors; on a single-project fleet server the agent only ever
+//    needs to list sessions in the current project (no flags required).
+// 11. Project discovery inlines — scattered `kimaki project list|add|create`,
+//    `kimaki send --project`, and bare `kimaki send --channel <channel_id>`
+//    examples that survive section stripping. These let the agent discover
+//    other Discord channels and route minion sessions away from the current
+//    thread. See Extra-Chill/data-machine-code#49.
+//
+// What it injects into the system prompt:
+// - `## Minion Session Routing` — positive instruction telling the agent that
+//   all minion sessions go in the current channel. Defense in depth on top of
+//   the stripping above: even if the agent discovers channel IDs some other
+//   way (training data, --help output, user mention), the instruction steers
+//   it back to ${channelId}. Use --cwd to target a different repo dir.
 //
 // NOTE: "## debugging kimaki issues" is intentionally kept — when Kimaki itself
 // throws errors, the agent needs the kimaki.log path to investigate.
@@ -53,6 +69,7 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "## creating worktrees");
         result = stripSection(result, "## worktree");
         result = stripSection(result, "## cross-project commands");
+        result = stripSection(result, "## reading other sessions");
         result = stripSection(result, "## waiting for a session to finish");
         result = stripSection(result, "## showing diffs");
         result = stripSection(result, "## about critique");
@@ -60,8 +77,13 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "### fetching user comments from critique diffs");
         result = stripSection(result, "### reviewing diffs with AI");
         result = stripWorktreeInlines(result);
+        result = stripProjectDiscoveryInlines(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");
+        // Append positive routing instruction so the agent never tries to
+        // discover or send sessions to other channels, even if it learns
+        // channel IDs from --help or training data.
+        result = appendMinionRoutingInstruction(result);
         return result;
       });
     },
@@ -172,6 +194,95 @@ function stripWorktreeInlines(block: string): string {
   );
 
   return result;
+}
+
+/**
+ * Remove project / channel discovery examples that survive section stripping.
+ *
+ * The system prompt bakes the current channel ID into most `kimaki send`
+ * examples via `${channelId}`, which is the safe/correct form for this
+ * session. But several other forms leak the *capability* to target other
+ * channels or projects:
+ *
+ *   - `kimaki project list|add|create` — enumerates every registered project
+ *     with its Discord channel ID.
+ *   - `kimaki send --project <dir>` — resolves a channel from a project dir.
+ *   - `kimaki send --channel <channel_id>` with a literal `<channel_id>`
+ *     placeholder (as opposed to the baked-in current-channel ID) — teaches
+ *     the agent it can pick a channel freely.
+ *
+ * On DM-managed sites the current Discord thread is the only correct target
+ * for minion sessions. Cross-repo work uses DM Code's workspace worktrees,
+ * not cross-channel kimaki sends. See Extra-Chill/data-machine-code#49.
+ *
+ * We keep `${channelId}` examples untouched — those are the intended,
+ * session-scoped forms.
+ */
+function stripProjectDiscoveryInlines(block: string): string {
+  let result = block;
+
+  // Standalone `kimaki project ...` commands on their own lines (inside any
+  // surviving section or orphaned between sections). Covers list|add|create.
+  result = result.replace(
+    /\n+kimaki project (?:list|add|create)[^\n]*\n/g,
+    "\n"
+  );
+
+  // `kimaki send --project /path/...` bash examples, as full lines.
+  result = result.replace(
+    /\n+kimaki send --project [^\n]*\n/g,
+    "\n"
+  );
+
+  // `kimaki send --channel <channel_id> ...` examples that use the literal
+  // placeholder `<channel_id>` rather than the baked-in session channel.
+  // The `${channelId}` form is template-substituted before this plugin runs,
+  // so by the time we see the prompt the current channel is already a
+  // concrete numeric ID — it will not match `<channel_id>` and stays intact.
+  result = result.replace(
+    /\n+kimaki send --channel <channel_id>[^\n]*\n/g,
+    "\n"
+  );
+
+  // Matching `kimaki session search "..." --channel <channel_id>` examples.
+  result = result.replace(
+    /\n+kimaki session search [^\n]*--channel <channel_id>[^\n]*\n/g,
+    "\n"
+  );
+
+  // Any remaining `--project /path/...` flag usage in inline prose or code
+  // blocks. Conservative: only strip whole lines where the flag is the
+  // dominant content (starts with command + --project).
+  result = result.replace(
+    /\n+kimaki (?:session|task) [^\n]*--project [^\n]*\n/g,
+    "\n"
+  );
+
+  return result;
+}
+
+/**
+ * Append a positive minion-session routing instruction.
+ *
+ * Stripping alone is not enough: the agent can still learn channel IDs from
+ * `kimaki --help`, other agents' mentions, or training data. This instruction
+ * is defense in depth — it tells the agent the *policy* (all minion sessions
+ * go in this channel) so that even if a channel ID surfaces some other way,
+ * the agent still routes correctly. Cross-repo work is handled by pointing
+ * `--cwd` at a Data Machine Code workspace worktree, not by switching
+ * channels.
+ */
+function appendMinionRoutingInstruction(block: string): string {
+  const instruction = `
+
+## Minion Session Routing
+
+All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run \`kimaki project list\`, \`kimaki project add\`, \`kimaki project create\`, or \`kimaki send --project\` — those are cross-project discovery commands that route sessions to other agents' channels.
+
+If a minion needs to work in a different repo directory, use \`kimaki send --cwd /path/to/repo\` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (\`studio wp datamachine-code workspace worktree add <repo> <branch>\`) — the worktree becomes the \`--cwd\` target for any follow-up minion session.
+`;
+  // Ensure exactly one blank line between existing content and the appendix.
+  return block.replace(/\s*$/, "") + instruction;
 }
 
 export default fleetContextFilter;


### PR DESCRIPTION
## Summary

Agents running under the `dm-context-filter` plugin could still discover other Discord channel IDs and spawn minion sessions there, violating the \"one agent per Discord channel\" boundary. Refs Extra-Chill/data-machine-code#49.

The existing filter stripped the `## cross-project commands` section, but three residual vectors let channel IDs leak back into the system prompt:

1. **`## reading other sessions`** — documented `kimaki session list --project /path/to/project` and `kimaki session search --channel <channel_id>`. Direct project-and-channel discovery surface.
2. **Project-discovery inlines** — stray `kimaki project list|add|create`, `kimaki send --project`, and bare `kimaki send --channel <channel_id>` examples scattered across surviving sections (scheduled sends, opencode commands, handoff instructions).
3. **No positive counter-instruction** — once the agent learned a channel ID some other way (training data, `kimaki --help`, another agent mentioning it), nothing told it *not* to use that ID.

## What this PR changes

`kimaki/plugins/dm-context-filter.ts`:

- **Strip `## reading other sessions`** as a whole section. On a single-project fleet server the agent only ever needs `kimaki session list` (no flags) for the current project — the flag-heavy documentation is pure leakage.
- **Add `stripProjectDiscoveryInlines()`** to catch surviving lines that reference `kimaki project list|add|create`, `kimaki send --project <dir>`, or `kimaki send --channel <channel_id>` (literal placeholder — the current-channel `\${channelId}` form is substituted to a concrete numeric ID before the plugin runs, so it never matches and stays intact).
- **Inject `## Minion Session Routing`** at the end of the system prompt. Positive defense-in-depth instruction: all minion sessions stay in the current channel; cross-repo work uses `kimaki send --cwd /path/to/repo` (same channel, different checkout) or Data Machine Code's workspace worktrees.

Updated the header comment block to document items 10 and 11 (reading-other-sessions + project-discovery inlines) and the new positive-injection behavior.

## Verification

- Regex patterns targeted against the exact strings in `kimaki/cli/src/system-message.ts` (line 635 for `session search --channel <channel_id>`, lines 652-670 for the `## cross-project commands` block, line 667 for `kimaki send --channel <channel_id>`).
- The `\${channelId}` template variable is substituted before `experimental.chat.system.transform` runs, so the current session's baked-in channel ID (numeric, e.g. `1493345787894038649`) does not match the `<channel_id>` placeholder regex — current-channel examples in `## starting new sessions from CLI` are preserved.
- Conservative line-level regexes — each pattern anchors on a full line starting with `kimaki <verb>` to avoid mangling prose that happens to mention `--project` or `--channel`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the two new helper functions (`stripProjectDiscoveryInlines`, `appendMinionRoutingInstruction`), updated the header-comment block, and composed this PR body. Chris reviewed the regex patterns against the actual system-prompt source in `kimaki/cli/src/system-message.ts` and verified the existing filter coverage before adding the new strips.