### PR TITLE
fix(skills): restore wp-coding-agents skills on every kimaki restart

### DIFF
--- a/kimaki/post-upgrade.sh
+++ b/kimaki/post-upgrade.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
-# post-upgrade.sh — Remove unwanted bundled Kimaki skills.
+# post-upgrade.sh — Enforce kimaki skill state on every restart.
+#
+# Two symmetric passes run against $(npm root -g)/kimaki/skills/:
+#   1. KILL   — remove unwanted bundled kimaki skills listed in skills-kill-list.txt.
+#   2. RESTORE — re-copy wp-coding-agents skills from the persistent source dir
+#               (kimaki-config/skills/). `npm update -g kimaki` wipes the
+#               bundled skills dir, so without this restore pass Discord
+#               slash commands silently degrade between upgrades.
 #
 # Invoked two ways:
 #   VPS:   ExecStartPre in kimaki.service (runs on every service start).
@@ -9,6 +16,12 @@
 #   1. KIMAKI_SKILLS_DIR env var (explicit override)
 #   2. $(npm root -g)/kimaki/skills (works on macOS + Linux when npm is on PATH)
 #   3. /usr/lib/node_modules/kimaki/skills (Linux VPS fallback when npm absent)
+#
+# Persistent skill source dir resolution priority:
+#   1. KIMAKI_SKILL_SOURCE_DIR env var (explicit override)
+#   2. $KIMAKI_DATA_DIR/kimaki-config/skills/ if KIMAKI_DATA_DIR set
+#   3. $HOME/.kimaki/kimaki-config/skills/ (local default)
+#   4. /opt/kimaki-config/skills/ (VPS default)
 set -euo pipefail
 
 if [[ -n "${KIMAKI_SKILLS_DIR:-}" ]]; then
@@ -48,4 +61,34 @@ while IFS= read -r skill || [[ -n "$skill" ]]; do
   fi
 done < "$KILL_LIST"
 
-echo "kimaki-config: done ($removed skills removed)"
+# Restore pass — re-copy wp-coding-agents skills from the persistent source
+# dir. Idempotent: `rm -rf` before each `cp -r` so a stale copy in SKILLS_DIR
+# always gets replaced by the current source.
+if [[ -n "${KIMAKI_SKILL_SOURCE_DIR:-}" ]]; then
+  SOURCE_DIR="$KIMAKI_SKILL_SOURCE_DIR"
+elif [[ -n "${KIMAKI_DATA_DIR:-}" ]]; then
+  SOURCE_DIR="$KIMAKI_DATA_DIR/kimaki-config/skills"
+elif [[ -d "$HOME/.kimaki/kimaki-config/skills" ]]; then
+  SOURCE_DIR="$HOME/.kimaki/kimaki-config/skills"
+else
+  SOURCE_DIR="/opt/kimaki-config/skills"
+fi
+
+restored=0
+if [[ -d "$SOURCE_DIR" ]]; then
+  for skill_dir in "$SOURCE_DIR"/*/; do
+    [[ -d "$skill_dir" ]] || continue
+    skill_name="$(basename "$skill_dir")"
+    if [[ -f "$skill_dir/SKILL.md" ]]; then
+      target="$SKILLS_DIR/$skill_name"
+      rm -rf "$target"
+      cp -r "$skill_dir" "$target"
+      echo "kimaki-config: restored $skill_name"
+      restored=$((restored + 1))
+    fi
+  done
+else
+  echo "kimaki-config: persistent skill source dir not found at $SOURCE_DIR, skipping restore"
+fi
+
+echo "kimaki-config: done ($removed skills removed, $restored skills restored)"

--- a/lib/skills.sh
+++ b/lib/skills.sh
@@ -64,6 +64,51 @@ install_skills_from_local_repo() {
   fi
 }
 
+# Mirror every SKILL.md-containing subdir from $SKILLS_DIR into the
+# persistent kimaki-config/skills/ dir. This is the durable source of
+# truth that survives `npm update -g kimaki` wipes — kimaki/post-upgrade.sh
+# reads from this path on every kimaki restart to restore the mirror copy
+# at $(npm root -g)/kimaki/skills/.
+#
+# Path resolution matches the plugin-persistence pattern used elsewhere:
+#   Local: $KIMAKI_DATA_DIR/kimaki-config/skills/ (defaults to ~/.kimaki/kimaki-config/skills/)
+#   VPS:   /opt/kimaki-config/skills/
+install_skills_to_persistent_source() {
+  local persistent_dir
+  if [ "$LOCAL_MODE" = true ]; then
+    local data_dir="${KIMAKI_DATA_DIR:-$HOME/.kimaki}"
+    persistent_dir="$data_dir/kimaki-config/skills"
+  else
+    persistent_dir="/opt/kimaki-config/skills"
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would mirror skills to persistent source: $persistent_dir/"
+    return
+  fi
+
+  mkdir -p "$persistent_dir" 2>/dev/null || {
+    warn "Could not create persistent skill source dir $persistent_dir — skipping mirror"
+    return
+  }
+
+  local copied=0
+  for skill_dir in "$SKILLS_DIR"/*/; do
+    [ -d "$skill_dir" ] || continue
+    local skill_name
+    skill_name=$(basename "$skill_dir")
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      rm -rf "$persistent_dir/$skill_name"
+      cp -r "$skill_dir" "$persistent_dir/$skill_name"
+      copied=$((copied + 1))
+    fi
+  done
+  if [ "$copied" -gt 0 ]; then
+    log "Skills mirrored to persistent source: $persistent_dir/ ($copied)"
+    log "  post-upgrade.sh will restore these on every kimaki restart."
+  fi
+}
+
 install_skills() {
   SKILLS_DIR="$(runtime_skills_dir)"
 
@@ -94,9 +139,16 @@ install_skills() {
             fi
           done
           log "Skills also copied to Kimaki: $KIMAKI_SKILLS_DIR/"
-          warn "Note: Kimaki upgrades (npm update -g kimaki) will remove these. Re-run --skills-only after upgrading."
         fi
       fi
+
+      # Mirror skills into the persistent kimaki-config/skills/ dir so
+      # post-upgrade.sh can restore them on every kimaki restart after
+      # `npm update -g kimaki` wipes $(npm root -g)/kimaki/skills/.
+      # Path mirrors the plugin-persistence pattern:
+      #   Local: $KIMAKI_DATA_DIR/kimaki-config/skills/ (defaults to ~/.kimaki/kimaki-config/skills/)
+      #   VPS:   /opt/kimaki-config/skills/
+      install_skills_to_persistent_source
     fi
   else
     log "Phase 8.5: Skipping agent skills (--no-skills)"

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -101,7 +101,14 @@ Drop `--dry-run`:
 
 Backups are written next to each touched file with a timestamp suffix. On VPS that means `/opt/kimaki-config.backup.<ts>`, `AGENTS.md.backup.<ts>`, `kimaki.service.backup.<ts>`. On local, the kimaki-config backup lands under `$KIMAKI_DATA_DIR/backups/` (defaults to `~/.kimaki/backups/`).
 
-On local, `upgrade.sh` also runs `post-upgrade.sh` inline to enforce the skills kill list against the npm-installed kimaki package — VPS gets this on the next `systemctl restart kimaki` via the unit's `ExecStartPre`.
+### Persistent skill source
+
+`--skills-only` (and a full run) also mirrors every installed skill into the persistent kimaki-config skill source dir. This is the durable copy that survives `npm update -g kimaki` wipes of `$(npm root -g)/kimaki/skills/`:
+
+- **Local:** `$KIMAKI_DATA_DIR/kimaki-config/skills/` (defaults to `~/.kimaki/kimaki-config/skills/`)
+- **VPS:** `/opt/kimaki-config/skills/`
+
+On local, `upgrade.sh` runs `post-upgrade.sh` inline. On VPS, `kimaki.service`'s `ExecStartPre` runs it on next service start. `post-upgrade.sh` performs two symmetric passes against `$(npm root -g)/kimaki/skills/`: (1) remove the unwanted bundled skills listed in `skills-kill-list.txt`, and (2) restore the wp-coding-agents skills from the persistent source dir. Both passes are idempotent and run on every kimaki restart.
 
 ## Step 5 — Verify
 


### PR DESCRIPTION
## Summary

`wp-coding-agents` installs agent skills into three places when `CHAT_BRIDGE=kimaki`:

1. `$SITE_PATH/.opencode/skills/` (or `.claude/skills/`) — runtime dir, used by opencode/claude directly.
2. `$(npm root -g)/kimaki/skills/` — the **only** path kimaki reads for Discord slash command registration. Kimaki hardcodes opencode's `skills.paths` to its own install dir (kimaki `src/opencode.ts:669-671`), so this mirror copy is required for `/upgrade-wp-coding-agents` & friends to show up as Discord slash commands.
3. (new) the persistent kimaki-config skill source — see below.

**The fragility:** `npm update -g kimaki` (or any reinstall) wipes `$(npm root -g)/kimaki/skills/`. wp-coding-agents already handles the kill-list side of kimaki's bundled-skill cleanup via `kimaki/post-upgrade.sh` + `kimaki/skills-kill-list.txt` (runs on every kimaki restart — VPS via `ExecStartPre`, local via `upgrade.sh` inline). But there was no symmetric restore process re-copying wp-coding-agents skills back in. Discord slash commands silently degraded between upgrades.

Repro on a real Studio install: `/upgrade-wp-coding-agents-skill` stopped being registered as a Discord slash command because the skill file wasn't in `$(npm root -g)/kimaki/skills/` even though it lived in the repo at `skills/upgrade-wp-coding-agents/SKILL.md`.

## Fix

Make the kimaki skill-restore symmetric with the kill-list flow — both run automatically on every kimaki restart, both idempotent.

### Persistent skill source dir

New durable source of truth for wp-coding-agents skills, mirroring the `kimaki-config/plugins/` pattern already used for plugin persistence:

- **Local:** `$KIMAKI_DATA_DIR/kimaki-config/skills/` (defaults to `~/.kimaki/kimaki-config/skills/`)
- **VPS:** `/opt/kimaki-config/skills/`

### `lib/skills.sh`

New `install_skills_to_persistent_source()` called from inside the existing `CHAT_BRIDGE=kimaki` block. Mirrors every `SKILL.md`-containing subdir from the runtime skills dir into the persistent source dir. Idempotent (`rm -rf` then `cp -r`).

Also drops the stale `"re-run --skills-only after upgrading"` warning — the restore is now automatic on every kimaki restart.

### `kimaki/post-upgrade.sh`

After the existing kill loop, new restore loop:

1. Resolve source dir: `KIMAKI_SKILL_SOURCE_DIR` env > `$KIMAKI_DATA_DIR/kimaki-config/skills/` > `$HOME/.kimaki/kimaki-config/skills/` > `/opt/kimaki-config/skills/`.
2. For each subdir containing `SKILL.md`, `rm -rf` the target in `SKILLS_DIR` and `cp -r` from source.
3. Log `kimaki-config: restored <skill>`. Count restored skills separately from removed.

Header comment updated to document both kill and restore roles. Filenames unchanged (`post-upgrade.sh` / `skills-kill-list.txt`) because VPS systemd unit references them via `ExecStartPre`.

### `skills/upgrade-wp-coding-agents/SKILL.md`

Step 4 now documents the persistent skill source dir and the dual kill/restore passes.

## Testing

- `bash -n lib/skills.sh kimaki/post-upgrade.sh` — passes.
- `tests/bridge-render.sh` — all 8 snapshots byte-identical.
- `./setup.sh --local --skills-only --wp-path … --chat kimaki --dry-run` — new `Would mirror skills to persistent source: …/kimaki-config/skills/` line surfaces.
- Real run on Studio install (`intelligence-chubes4`): all three dirs populated — `.claude/skills/` (runtime), `$(npm root -g)/kimaki/skills/` (kimaki bundled), and `~/.kimaki/kimaki-config/skills/` (new persistent source), 5 skills each.
- Wipe simulation: `rm -rf $(npm root -g)/kimaki/skills/upgrade-wp-coding-agents`, then `bash kimaki/post-upgrade.sh` → logs `kimaki-config: restored upgrade-wp-coding-agents` (and 4 others), skill reappears in the bundled dir.

## Out of scope

- Doesn't touch kimaki itself.
- No file renames (VPS systemd `ExecStartPre` still finds `post-upgrade.sh` + `skills-kill-list.txt` at their existing paths).
- No VPS systemd unit changes.
- Multi-runtime skill-dir population (e.g. populating both `.claude/skills/` and `.opencode/skills/` in a single run) is a separate concern — tracked as a follow-up.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** drafted the fix design and implementation (persistent source path, symmetric restore loop, idempotency). Chris reviewed and validated the full restore cycle on his Studio install — real populate run, simulated `npm` wipe, `post-upgrade.sh` restore verified end-to-end.