### PR TITLE
fix(upgrade): migrate agent.build.prompt to instructions array

### DIFF
--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """
-repair-opencode-json.py — Detect and optionally repair the `plugin` array in
-an existing opencode.json against what the current wp-coding-agents setup
-would produce for the detected (RUNTIME, CHAT_BRIDGE). Data Machine is
-always installed.
+repair-opencode-json.py — Detect and optionally repair drift in an existing
+opencode.json against what the current wp-coding-agents setup would produce
+for the detected (RUNTIME, CHAT_BRIDGE). Data Machine is always installed.
+
+Checks two independent drift vectors:
+  1. `plugin` array — matches what setup would produce for the detected
+     (RUNTIME, CHAT_BRIDGE) combo.
+  2. `agent.build.prompt` / `agent.plan.prompt` — legacy format that breaks
+     Anthropic Claude Max OAuth (see wp-coding-agents#60). Migrated to a
+     top-level `instructions` array that preserves the canonical system prompt
+     opening.
 
 Exit codes:
   0 — no drift; file is already correct
@@ -12,9 +19,9 @@ Exit codes:
 
 Output (stdout): JSON diagnostic object. Examples:
 
-  {"status":"ok","plugins":[...]}
-  {"status":"drift","missing":[...],"unexpected":[...],"current":[...],"expected":[...]}
-  {"status":"repaired","before":[...],"after":[...],"backup":"/path/to/backup"}
+  {"status":"ok","plugins":[...],"prompt_migration":"ok"}
+  {"status":"drift","missing":[...],"unexpected":[...],...,"prompt_migration":"needed"}
+  {"status":"repaired","before":[...],"after":[...],"backup":"/path/to/backup","prompt_migration":"migrated"}
 
 CLI usage:
   repair-opencode-json.py --file <path> \
@@ -107,6 +114,89 @@ def repair(
     return list(expected)
 
 
+def parse_file_includes(prompt: str) -> List[str]:
+    """Extract ``{file:./path}`` references from a prompt string.
+
+    Returns relative paths (without the ``./`` prefix) in order of appearance.
+    Skips ``{file:./AGENTS.md}`` — AGENTS.md is auto-discovered by opencode
+    and should not go in the ``instructions`` array.
+    """
+    import re
+
+    paths: List[str] = []
+    for match in re.finditer(r"\{file:\./([^}]+)\}", prompt):
+        rel = match.group(1)
+        if rel == "AGENTS.md":
+            continue
+        paths.append(rel)
+    return paths
+
+
+def check_prompt_migration(data: dict) -> dict:
+    """Check whether ``agent.build.prompt`` / ``agent.plan.prompt`` need migration.
+
+    Returns a dict with keys:
+      status: "ok" | "needed"
+      details: human-readable description (when needed)
+      instructions: the ``instructions`` array that should be written
+    """
+    agent = data.get("agent", {})
+    build_prompt = agent.get("build", {}).get("prompt", "")
+    plan_prompt = agent.get("plan", {}).get("prompt", "")
+
+    if not build_prompt and not plan_prompt:
+        # Already on new format or never had prompts.
+        return {"status": "ok", "instructions": list(data.get("instructions", []))}
+
+    # Extract file paths from whichever prompt has them (prefer build).
+    source = build_prompt or plan_prompt
+    paths = parse_file_includes(source)
+
+    return {
+        "status": "needed",
+        "details": (
+            "agent.build.prompt/agent.plan.prompt detected — "
+            "must migrate to top-level 'instructions' array to fix "
+            "Anthropic Claude Max OAuth (see wp-coding-agents#60)"
+        ),
+        "instructions": [f"./{p}" for p in paths],
+    }
+
+
+def apply_prompt_migration(data: dict) -> dict:
+    """Migrate ``agent.build.prompt`` → ``instructions`` in *data* (in-place).
+
+    - Removes ``prompt`` keys from ``agent.build`` and ``agent.plan``.
+    - Sets top-level ``instructions`` array (preserving any existing entries
+      that are not duplicates of the migrated paths).
+    - Returns the migration result dict from ``check_prompt_migration``.
+    """
+    result = check_prompt_migration(data)
+    if result["status"] != "needed":
+        return result
+
+    new_instructions = result["instructions"]
+
+    # Remove prompt keys.
+    agent = data.get("agent", {})
+    for sub in ("build", "plan"):
+        agent.get(sub, {}).pop("prompt", None)
+    # Clean up empty dicts.
+    for sub in ("build", "plan"):
+        if sub in agent and isinstance(agent[sub], dict) and not agent[sub]:
+            pass  # keep mode/model keys
+
+    # Merge with any existing instructions, preserving user-added entries.
+    existing = set(data.get("instructions", []))
+    merged = list(data.get("instructions", []))
+    for p in new_instructions:
+        if p not in existing:
+            merged.append(p)
+    data["instructions"] = merged
+
+    return result
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--file", required=True, help="Path to opencode.json")
@@ -154,6 +244,10 @@ def main() -> int:
         )
         return 2
 
+    # --- Prompt migration check (runs for all runtimes with opencode.json) ---
+    prompt_result = check_prompt_migration(data)
+
+    # --- Plugin array check ---
     expected = expected_plugins(
         runtime=args.runtime,
         chat_bridge=args.chat_bridge,
@@ -164,38 +258,79 @@ def main() -> int:
 
     # Claude Code / Studio Code: no plugin array concept here. Report ok
     # if current is empty or absent; otherwise let user know we skipped.
+    plugin_skipped = False
     if args.runtime != "opencode":
-        print(
-            json.dumps(
-                {
-                    "status": "skipped",
-                    "reason": f"runtime {args.runtime} does not use opencode.json plugin array",
-                    "current": current,
-                }
+        plugin_skipped = True
+        if prompt_result["status"] == "ok":
+            print(
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "plugins": current,
+                        "prompt_migration": "ok",
+                    }
+                )
             )
-        )
-        return 0
+            return 0
 
     diff = diff_plugins(current, expected)
-    has_drift = bool(diff["missing"] or diff["unexpected"])
+    has_plugin_drift = bool(diff["missing"] or diff["unexpected"])
+    has_prompt_drift = prompt_result["status"] == "needed"
+    has_any_drift = has_plugin_drift or has_prompt_drift
 
-    if not has_drift:
-        print(json.dumps({"status": "ok", "plugins": current}))
+    if not has_any_drift:
+        result: dict = {"status": "ok", "plugins": current, "prompt_migration": "ok"}
+        if plugin_skipped:
+            result["plugins_skipped"] = f"runtime {args.runtime} does not use opencode.json plugin array"
+        print(json.dumps(result))
         return 0
 
     if not args.apply:
-        print(
-            json.dumps(
-                {
-                    "status": "drift",
-                    "missing": diff["missing"],
-                    "unexpected": diff["unexpected"],
-                    "current": current,
-                    "expected": expected,
-                }
-            )
-        )
+        result = {
+            "status": "drift",
+            "current": current,
+            "expected": expected,
+            "prompt_migration": prompt_result["status"],
+        }
+        if has_plugin_drift:
+            result["missing"] = diff["missing"]
+            result["unexpected"] = diff["unexpected"]
+        if has_prompt_drift:
+            result["prompt_details"] = prompt_result.get("details", "")
+            result["prompt_instructions"] = prompt_result.get("instructions", [])
+        if plugin_skipped:
+            result["plugins_skipped"] = f"runtime {args.runtime} does not use opencode.json plugin array"
+        print(json.dumps(result))
         return 1
+
+    # Apply: write backup, update data, write file.
+    suffix = args.backup_suffix or __import__("datetime").datetime.now().strftime(
+        "%Y%m%d-%H%M%S"
+    )
+    backup_path = f"{args.file}.backup.{suffix}"
+    shutil.copy2(args.file, backup_path)
+
+    if has_plugin_drift and not plugin_skipped:
+        data["plugin"] = repair(data, expected)
+
+    prompt_migration_status = "ok"
+    if has_prompt_drift:
+        apply_prompt_migration(data)
+        prompt_migration_status = "migrated"
+
+    with open(args.file, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+
+    result = {
+        "status": "repaired",
+        "before": current,
+        "after": data.get("plugin", current),
+        "backup": backup_path,
+        "prompt_migration": prompt_migration_status,
+    }
+    print(json.dumps(result))
+    return 1
 
     # Apply: write backup, update data, write file.
     suffix = args.backup_suffix or __import__("datetime").datetime.now().strftime(

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -42,10 +42,11 @@
 #   chat-bridge service.
 #
 #   opencode.json is only touched when --repair-opencode-json is passed.
-#   The repair surgically rewrites the `plugin` array to match what current
-#   setup would produce for the detected (runtime, chat bridge, DM) combo,
-#   preserving all other keys. A .backup.<ts> is written alongside. Without
-#   the flag, drift is diagnosed and reported in the summary but not fixed.
+#   The repair surgically rewrites the `plugin` array and migrates
+#   `agent.build.prompt`/`agent.plan.prompt` to a top-level `instructions`
+#   array (fixes Anthropic Claude Max OAuth, see wp-coding-agents#60).
+#   A .backup.<ts> is written alongside. Without the flag, drift is diagnosed
+#   and reported in the summary but not fixed.
 #
 
 set -e
@@ -123,9 +124,11 @@ USAGE:
   ./upgrade.sh --skills-only    Only sync agent skills
   ./upgrade.sh --agents-md-only Only regenerate AGENTS.md
   ./upgrade.sh --repair-opencode-json
-                                Detect AND fix drift between opencode.json's
-                                "plugin" array and what current setup would
-                                produce. Writes a .backup.<ts> alongside.
+                                Detect AND fix drift in opencode.json:
+                                - plugin array → match current setup
+                                - agent.build.prompt → instructions array
+                                  (fixes Anthropic Claude Max OAuth, #60)
+                                Writes a .backup.<ts> alongside.
                                 Default behaviour: diagnose + warn only.
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
   ./upgrade.sh --wp-path <path> Override detected WordPress path
@@ -148,8 +151,9 @@ NEVER TOUCHED:
 
 OPT-IN TOUCHES:
   - opencode.json — only with --repair-opencode-json. Rewrites the
-    "plugin" array to match current setup output; preserves all other
-    keys; writes a .backup.<ts> alongside.
+    "plugin" array + migrates "agent.build.prompt" to "instructions"
+    array (fixes Anthropic Claude Max OAuth); preserves all other keys;
+    writes a .backup.<ts> alongside.
 HELP
   exit 0
 fi
@@ -472,35 +476,33 @@ _sync_kimaki_config() {
 }
 
 # ============================================================================
-# Phase 2b: Detect + optionally repair opencode.json plugin drift
+# Phase 2b: Detect + optionally repair opencode.json drift
 #
 # opencode.json is user-owned (model settings, agent prompt files, permissions,
-# etc.), so this phase is read-only by default. It compares the file's
-# `plugin` array against what current setup would produce for the detected
-# (RUNTIME, CHAT_BRIDGE) combo and surfaces drift.
+# etc.), so this phase is read-only by default. It compares the file against
+# what current setup would produce and surfaces drift.
 #
-# The most common drift vectors:
-#   - install predates v0.4.0 (no `plugin` key at all)
-#   - install predates #51 fix (stale `opencode-claude-auth@latest` on kimaki)
-#   - new plugins added to setup.sh that the install never got
+# Drift vectors checked:
+#   1. `plugin` array — matches expected plugins for the detected runtime
+#      and chat bridge. Only applies when runtime is opencode.
+#   2. `agent.build.prompt` / `agent.plan.prompt` — legacy format that
+#      breaks Anthropic Claude Max OAuth (see wp-coding-agents#60). Migrated
+#      to a top-level `instructions` array. This check runs for ALL runtimes
+#      because opencode.json can exist even when the primary runtime is
+#      claude-code (e.g. kimaki spawns opencode sessions).
 #
-# With --repair-opencode-json, the `plugin` array is surgically rewritten to
-# match the expected list. All other keys are preserved. A .backup.<ts> is
-# written alongside.
-#
-# Non-opencode runtimes (claude-code, studio-code) are skipped silently —
-# they use different config mechanisms.
+# With --repair-opencode-json, both drift vectors are repaired surgically.
+# All other keys are preserved. A .backup.<ts> is written alongside.
 # ============================================================================
 
 check_opencode_json_drift() {
-  # Only runs for opencode runtime. Silent skip on others.
-  if [ "$RUNTIME" != "opencode" ]; then
-    return 0
-  fi
+  # Runs whenever opencode.json exists on disk. The repair script handles
+  # both plugin-array drift (opencode runtime only) and prompt migration
+  # (all runtimes — agent.build.prompt → instructions breaks Anthropic
+  # Claude Max OAuth regardless of which runtime is primary).
 
   local OPENCODE_JSON_FILE="$SITE_PATH/opencode.json"
   if [ ! -f "$OPENCODE_JSON_FILE" ]; then
-    warn "Phase 2b: $OPENCODE_JSON_FILE not found — skipping drift check"
     return 0
   fi
 
@@ -516,7 +518,7 @@ check_opencode_json_drift() {
   local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
 
   if [ "$REPAIR_OPENCODE_JSON" = true ]; then
-    log "Phase 2b: Repairing opencode.json plugin array..."
+    log "Phase 2b: Repairing opencode.json..."
     if [ "$DRY_RUN" = true ]; then
       echo -e "${BLUE}[dry-run]${NC} Would run: python3 $HELPER --file $OPENCODE_JSON_FILE --runtime $RUNTIME --chat-bridge $BRIDGE_ARG --kimaki-plugins-dir $PLUGINS_DIR --apply"
       # Still show the diagnostic even in dry-run
@@ -541,14 +543,19 @@ check_opencode_json_drift() {
 
     local status
     status=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('status','?'))" 2>/dev/null || echo "parse-error")
+    local prompt_migration
+    prompt_migration=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('prompt_migration','?'))" 2>/dev/null || echo "?")
 
     case "$status" in
       ok)
-        log "  opencode.json plugin array already correct"
+        log "  opencode.json already correct"
         ;;
       repaired)
         log "  opencode.json repaired (backup: ${OPENCODE_JSON_FILE}.backup.$TIMESTAMP)"
         log "  $out"
+        if [ "$prompt_migration" = "migrated" ]; then
+          UPDATED_ITEMS+=("opencode.json prompt → instructions migration")
+        fi
         UPDATED_ITEMS+=("opencode.json plugin array (repaired)")
         ;;
       skipped)
@@ -572,13 +579,15 @@ check_opencode_json_drift() {
 
   local status
   status=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('status','?'))" 2>/dev/null || echo "parse-error")
+  local prompt_migration
+  prompt_migration=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('prompt_migration','?'))" 2>/dev/null || echo "?")
 
   case "$status" in
     ok)
-      log "Phase 2b: opencode.json plugin array matches current setup"
+      log "Phase 2b: opencode.json matches current setup"
       ;;
     drift)
-      warn "Phase 2b: opencode.json plugin array has drift — re-run with --repair-opencode-json to fix"
+      warn "Phase 2b: opencode.json has drift — re-run with --repair-opencode-json to fix"
       warn "  $out"
       OPENCODE_JSON_DRIFT=true
       ;;
@@ -897,9 +906,9 @@ print_summary() {
 
   if [ "$OPENCODE_JSON_DRIFT" = true ]; then
     echo ""
-    warn "opencode.json plugin-array drift detected."
+    warn "opencode.json drift detected (plugin array or prompt format)."
     warn "  Re-run with: ./upgrade.sh --repair-opencode-json"
-    warn "  (Drift is common on installs that predate #51 or v0.4.0.)"
+    warn "  (Drift is common on installs that predate #51, #60, or v0.4.0.)"
   fi
 
   echo ""


### PR DESCRIPTION
## Problem

Existing installs set up before #60 have `agent.build.prompt` / `agent.plan.prompt` in their `opencode.json`. This format pushes custom prompts to the top of `system[1]`, displacing OpenCode's canonical opening. Anthropic's third-party-app detector fingerprints the first bytes of `system[1]` on Claude Max OAuth requests — when the canonical opening is missing, it routes to extra-usage billing and returns 400.

The upgrade script's Phase 2b skipped the drift check entirely when the primary runtime was `claude-code`, so installs where kimaki spawns opencode sessions (like chubes.net) were stuck with no automated fix path.

## Changes

**`lib/repair-opencode-json.py`** — added prompt migration alongside existing plugin check:
- `parse_file_includes()` — extracts `{file:./path}` references from legacy prompt strings
- `check_prompt_migration()` — detects `agent.build.prompt`/`agent.plan.prompt` presence
- `apply_prompt_migration()` — removes `prompt` keys, sets top-level `instructions` array
- Prompt check runs for **all runtimes**; plugin array check stays opencode-only

**`upgrade.sh`** — Phase 2b now runs whenever `opencode.json` exists:
- Removed `RUNTIME != "opencode"` gate on `check_opencode_json_drift()`
- Updated docs, help text, and summary warnings to cover both drift vectors
- `--repair-opencode-json` now fixes both plugin array and prompt format

## Testing

Verified on chubes.net VPS (runtime: claude-code, bridge: kimaki):
- Old-format `opencode.json` → diagnostic detects `prompt_migration: "needed"`
- `--apply` → migrates correctly, preserves mode/model/plugin/permissions
- Re-run on migrated config → reports `ok` (idempotent)
- `upgrade.sh --dry-run` with old config → warns about drift
- `upgrade.sh --dry-run` with new config → reports "matches current setup"