### PR TITLE
fix: install security-policy plugins on every setup/upgrade, not just fresh

### DIFF
--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -12,15 +12,28 @@ Checks two independent drift vectors:
      top-level `instructions` array that preserves the canonical system prompt
      opening.
 
+Modes:
+  default          diagnose drift; exit 1 on drift, 0 on clean
+  --additive       add missing managed plugin entries + apply prompt
+                   migration; never remove unexpected entries; exit 0
+                   unless there is unexpected drift that still needs
+                   attention (then exit 1 with status=needs_full_repair)
+  --apply          full reconcile — replace plugin array with exactly
+                   what setup would produce today (removes unexpected
+                   entries). Also applies prompt migration.
+
 Exit codes:
-  0 — no drift; file is already correct
-  1 — drift detected (or repair applied if --apply)
+  0 — file is clean OR additive repair completed with no unexpected drift
+  1 — drift detected without --apply; OR --additive left unexpected
+      entries that need --apply to remove
   2 — usage / IO error
 
 Output (stdout): JSON diagnostic object. Examples:
 
   {"status":"ok","plugins":[...],"prompt_migration":"ok"}
   {"status":"drift","missing":[...],"unexpected":[...],...,"prompt_migration":"needed"}
+  {"status":"additive_repaired","before":[...],"after":[...],"added":[...],"backup":"...","prompt_migration":"migrated"}
+  {"status":"needs_full_repair","after":[...],"unexpected":[...]}
   {"status":"repaired","before":[...],"after":[...],"backup":"/path/to/backup","prompt_migration":"migrated"}
 
 CLI usage:
@@ -28,10 +41,21 @@ CLI usage:
     --runtime <opencode|claude-code|studio-code> \
     --chat-bridge <kimaki|cc-connect|telegram|none> \
     [--kimaki-plugins-dir <path>] \
-    [--apply] \
+    [--additive | --apply] \
     [--backup-suffix <timestamp>]
 
-Only --apply writes to disk. Without it, the tool is a pure diagnostic.
+Without --additive or --apply the tool is a pure diagnostic.
+
+--additive is the default mode called from setup.sh and upgrade.sh: it
+installs managed plugin entries the user is missing (dm-context-filter,
+dm-agent-sync, opencode-claude-auth — whichever apply to the detected
+runtime + chat-bridge combo) and migrates legacy agent prompts to the
+top-level `instructions` array (fixes Anthropic Claude Max OAuth, see
+wp-coding-agents#60). It never removes user-added plugin entries.
+
+--apply is the opt-in full reconciliation, used by
+`upgrade.sh --repair-opencode-json`. It removes unexpected plugin
+entries in addition to the additive behaviour above.
 """
 from __future__ import annotations
 
@@ -215,10 +239,27 @@ def main() -> int:
         default="/opt/kimaki-config/plugins",
         help="Directory where DM plugins live (VPS default: /opt/kimaki-config/plugins)",
     )
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--apply",
         action="store_true",
-        help="Write repaired config to disk (with .backup.<suffix> alongside)",
+        help=(
+            "Full reconciliation: replace plugin array with exactly what "
+            "setup would produce today (removes unexpected entries). "
+            "Also applies prompt migration. Writes a .backup.<suffix> "
+            "alongside."
+        ),
+    )
+    mode_group.add_argument(
+        "--additive",
+        action="store_true",
+        help=(
+            "Additive repair: add missing managed plugin entries and apply "
+            "prompt migration. Never removes unexpected entries. Writes a "
+            ".backup.<suffix> alongside. Use this from setup/upgrade "
+            "scripts to fix security-critical plugin drift without "
+            "clobbering user-added entries."
+        ),
     )
     parser.add_argument(
         "--backup-suffix",
@@ -281,11 +322,14 @@ def main() -> int:
     if not has_any_drift:
         result: dict = {"status": "ok", "plugins": current, "prompt_migration": "ok"}
         if plugin_skipped:
-            result["plugins_skipped"] = f"runtime {args.runtime} does not use opencode.json plugin array"
+            result["plugins_skipped"] = (
+                f"runtime {args.runtime} does not use opencode.json plugin array"
+            )
         print(json.dumps(result))
         return 0
 
-    if not args.apply:
+    # Diagnostic mode (no --apply, no --additive): report drift, exit 1.
+    if not args.apply and not args.additive:
         result = {
             "status": "drift",
             "current": current,
@@ -299,11 +343,13 @@ def main() -> int:
             result["prompt_details"] = prompt_result.get("details", "")
             result["prompt_instructions"] = prompt_result.get("instructions", [])
         if plugin_skipped:
-            result["plugins_skipped"] = f"runtime {args.runtime} does not use opencode.json plugin array"
+            result["plugins_skipped"] = (
+                f"runtime {args.runtime} does not use opencode.json plugin array"
+            )
         print(json.dumps(result))
         return 1
 
-    # Apply: write backup, update data, write file.
+    # Write mode (--apply or --additive): back up, mutate, write, report.
     suffix = args.backup_suffix or __import__("datetime").datetime.now().strftime(
         "%Y%m%d-%H%M%S"
     )
@@ -311,7 +357,9 @@ def main() -> int:
     shutil.copy2(args.file, backup_path)
 
     if has_plugin_drift and not plugin_skipped:
-        data["plugin"] = repair(data, expected)
+        # --apply:    replace with exactly `expected` (removes unexpected).
+        # --additive: merge missing entries, preserving user additions.
+        data["plugin"] = repair(data, expected, preserve_extras=args.additive)
 
     prompt_migration_status = "ok"
     if has_prompt_drift:
@@ -322,39 +370,37 @@ def main() -> int:
         json.dump(data, fh, indent=2)
         fh.write("\n")
 
+    after_plugins: List[str] = list(data.get("plugin", current))
+    added = [p for p in expected if p in after_plugins and p not in current]
+    still_unexpected = [p for p in after_plugins if p not in set(expected)]
+
+    if args.additive:
+        # Additive leaves unexpected entries alone. If there were any,
+        # flag them so the caller knows a full reconcile is still needed.
+        status = "needs_full_repair" if still_unexpected else "additive_repaired"
+        result = {
+            "status": status,
+            "before": current,
+            "after": after_plugins,
+            "added": added,
+            "backup": backup_path,
+            "prompt_migration": prompt_migration_status,
+        }
+        if still_unexpected:
+            result["unexpected"] = still_unexpected
+        print(json.dumps(result))
+        # Exit 0 on a clean additive repair; 1 when user still needs to
+        # run --apply to remove unexpected entries.
+        return 1 if still_unexpected else 0
+
     result = {
         "status": "repaired",
         "before": current,
-        "after": data.get("plugin", current),
+        "after": after_plugins,
         "backup": backup_path,
         "prompt_migration": prompt_migration_status,
     }
     print(json.dumps(result))
-    return 1
-
-    # Apply: write backup, update data, write file.
-    suffix = args.backup_suffix or __import__("datetime").datetime.now().strftime(
-        "%Y%m%d-%H%M%S"
-    )
-    backup_path = f"{args.file}.backup.{suffix}"
-    shutil.copy2(args.file, backup_path)
-
-    data["plugin"] = repair(data, expected)
-
-    with open(args.file, "w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
-        fh.write("\n")
-
-    print(
-        json.dumps(
-            {
-                "status": "repaired",
-                "before": current,
-                "after": data["plugin"],
-                "backup": backup_path,
-            }
-        )
-    )
     return 1
 
 

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -175,9 +175,34 @@ wp-content/uploads/datamachine-files/users/USER_ID/USER.md"
 }
 
 runtime_generate_config() {
-  # Skip if already exists — safe for re-runs
+  # Resolve Kimaki plugin dir + copy plugin files FIRST, unconditionally.
+  # Setup.sh must be idempotent: whether this site has a fresh install or an
+  # existing opencode.json, the kimaki plugins dir on disk must end up with
+  # the current dm-context-filter.ts + dm-agent-sync.ts. Previously this only
+  # ran on fresh installs because the whole function early-returned on an
+  # existing file, which left upgraded installs missing the security policy
+  # filter they're meant to run with. See wp-coding-agents#67.
+  KIMAKI_PLUGINS_DIR=""
+  if [ "$CHAT_BRIDGE" = "kimaki" ]; then
+    if [ "$LOCAL_MODE" = true ]; then
+      KIMAKI_PLUGINS_DIR="$(npm root -g 2>/dev/null)/kimaki/plugins"
+      if [ "$DRY_RUN" = false ] && [ -n "$KIMAKI_PLUGINS_DIR" ] && [ -d "$(dirname "$KIMAKI_PLUGINS_DIR")" ]; then
+        mkdir -p "$KIMAKI_PLUGINS_DIR"
+        cp "$SCRIPT_DIR/kimaki/plugins/dm-context-filter.ts" "$KIMAKI_PLUGINS_DIR/" 2>/dev/null || true
+        cp "$SCRIPT_DIR/kimaki/plugins/dm-agent-sync.ts" "$KIMAKI_PLUGINS_DIR/" 2>/dev/null || true
+      fi
+    else
+      KIMAKI_PLUGINS_DIR="/opt/kimaki-config/plugins"
+    fi
+  fi
+
+  # On existing opencode.json, delegate to the repair helper in --additive
+  # mode. This adds managed plugin entries the user is missing and applies
+  # the prompt → instructions migration (fixes Anthropic Claude Max OAuth,
+  # wp-coding-agents#60) without touching user-added plugins, model settings,
+  # MCP config, permissions, or other keys. Idempotent on clean installs.
   if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/opencode.json" ]; then
-    log "opencode.json already exists — skipping (delete to regenerate)"
+    _runtime_repair_opencode_json_additive
     return
   fi
 
@@ -209,18 +234,8 @@ runtime_generate_config() {
   fi
 
   # DM context filter + agent sync — only when the bridge is Kimaki, since
-  # these plugins rewrite Kimaki-specific prompts.
+  # these plugins rewrite Kimaki-specific prompts. Paths resolved above.
   if [ "$CHAT_BRIDGE" = "kimaki" ]; then
-    if [ "$LOCAL_MODE" = true ]; then
-      KIMAKI_PLUGINS_DIR="$(npm root -g 2>/dev/null)/kimaki/plugins"
-      if [ "$DRY_RUN" = false ] && [ -d "$(dirname "$KIMAKI_PLUGINS_DIR")" ]; then
-        mkdir -p "$KIMAKI_PLUGINS_DIR"
-        cp "$SCRIPT_DIR/kimaki/plugins/dm-context-filter.ts" "$KIMAKI_PLUGINS_DIR/" 2>/dev/null || true
-        cp "$SCRIPT_DIR/kimaki/plugins/dm-agent-sync.ts" "$KIMAKI_PLUGINS_DIR/" 2>/dev/null || true
-      fi
-    else
-      KIMAKI_PLUGINS_DIR="/opt/kimaki-config/plugins"
-    fi
     OPENCODE_PLUGINS="${OPENCODE_PLUGINS}\n    \"${KIMAKI_PLUGINS_DIR}/dm-context-filter.ts\","
     OPENCODE_PLUGINS="${OPENCODE_PLUGINS}\n    \"${KIMAKI_PLUGINS_DIR}/dm-agent-sync.ts\","
   fi
@@ -271,6 +286,57 @@ runtime_generate_config() {
   else
     echo -e "$OPENCODE_JSON" > "$SITE_PATH/opencode.json"
   fi
+}
+
+# Additive repair of an existing opencode.json. Called when runtime_generate_config
+# finds the file already on disk. Adds managed plugin entries the user is missing,
+# migrates legacy agent.*.prompt → instructions (see wp-coding-agents#60), never
+# removes user-added plugins. For the opt-in full reconciliation that also removes
+# unexpected entries, users run `./upgrade.sh --repair-opencode-json`.
+_runtime_repair_opencode_json_additive() {
+  local HELPER="$SCRIPT_DIR/lib/repair-opencode-json.py"
+  if [ ! -f "$HELPER" ]; then
+    log "opencode.json exists but repair helper not found ($HELPER) — leaving as-is"
+    return
+  fi
+
+  local BRIDGE_ARG="${CHAT_BRIDGE:-none}"
+  local PLUGINS_DIR="${KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
+  local SUFFIX
+  SUFFIX="$(date +%Y%m%d-%H%M%S)"
+
+  log "opencode.json already exists — running additive repair..."
+
+  local repair_out repair_rc
+  repair_out=$(python3 "$HELPER" \
+    --file "$SITE_PATH/opencode.json" \
+    --runtime opencode \
+    --chat-bridge "$BRIDGE_ARG" \
+    --kimaki-plugins-dir "$PLUGINS_DIR" \
+    --additive \
+    --backup-suffix "$SUFFIX" 2>&1) && repair_rc=0 || repair_rc=$?
+
+  local repair_status
+  repair_status=$(echo "$repair_out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('status','?'))" 2>/dev/null || echo "parse-error")
+
+  case "$repair_status" in
+    ok)
+      log "  opencode.json already up to date"
+      ;;
+    additive_repaired)
+      log "  opencode.json repaired additively (backup: $SITE_PATH/opencode.json.backup.$SUFFIX)"
+      log "  $repair_out"
+      ;;
+    needs_full_repair)
+      warn "  opencode.json additively repaired, but unexpected plugin entries remain"
+      warn "  Review and run './upgrade.sh --repair-opencode-json' if you want them removed"
+      warn "  $repair_out"
+      ;;
+    *)
+      warn "  repair-opencode-json.py returned status=$repair_status (rc=$repair_rc)"
+      warn "  $repair_out"
+      ;;
+  esac
 }
 
 runtime_generate_instructions() {

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -41,12 +41,20 @@
 #   the DM workspace cloned repos, agent memory files, or the running
 #   chat-bridge service.
 #
-#   opencode.json is only touched when --repair-opencode-json is passed.
-#   The repair surgically rewrites the `plugin` array and migrates
-#   `agent.build.prompt`/`agent.plan.prompt` to a top-level `instructions`
-#   array (fixes Anthropic Claude Max OAuth, see wp-coding-agents#60).
-#   A .backup.<ts> is written alongside. Without the flag, drift is diagnosed
-#   and reported in the summary but not fixed.
+#   opencode.json is touched by default in additive mode: managed plugin
+#   entries the user is missing get added (dm-context-filter.ts,
+#   dm-agent-sync.ts, opencode-claude-auth@latest — whichever apply), and
+#   legacy `agent.build.prompt`/`agent.plan.prompt` keys get migrated to a
+#   top-level `instructions` array (fixes Anthropic Claude Max OAuth, see
+#   wp-coding-agents#60). User-added plugin entries are left alone.
+#
+#   --repair-opencode-json upgrades the repair to full reconciliation:
+#   the `plugin` array is replaced with exactly what setup would produce
+#   today, removing any unexpected entries in addition to the additive
+#   behaviour above. Use this when you've intentionally pruned plugins
+#   the user added by hand.
+#
+#   A .backup.<ts> is written alongside in both modes.
 #
 
 set -e
@@ -124,12 +132,15 @@ USAGE:
   ./upgrade.sh --skills-only    Only sync agent skills
   ./upgrade.sh --agents-md-only Only regenerate AGENTS.md
   ./upgrade.sh --repair-opencode-json
-                                Detect AND fix drift in opencode.json:
-                                - plugin array → match current setup
+                                Full reconciliation of opencode.json:
+                                - plugin array → match current setup exactly
+                                  (adds missing + removes unexpected)
                                 - agent.build.prompt → instructions array
                                   (fixes Anthropic Claude Max OAuth, #60)
                                 Writes a .backup.<ts> alongside.
-                                Default behaviour: diagnose + warn only.
+                                Default upgrade behaviour is additive repair:
+                                only adds missing managed entries, never
+                                removes user-added plugins.
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
   ./upgrade.sh --wp-path <path> Override detected WordPress path
   ./upgrade.sh --local          Local mode (no systemd; auto-on on macOS)
@@ -149,11 +160,19 @@ NEVER TOUCHED:
   - Agent memory files (SOUL.md, MEMORY.md, USER.md, etc.)
   - Running chat-bridge service (never restarted automatically)
 
+DEFAULT TOUCHES:
+  - opencode.json — additive repair. Adds managed plugin entries the
+    user is missing (dm-context-filter.ts, dm-agent-sync.ts,
+    opencode-claude-auth@latest — whichever apply to the detected runtime
+    + chat bridge) and migrates "agent.build.prompt" to top-level
+    "instructions" (fixes Anthropic Claude Max OAuth). Never removes
+    user-added plugins. Preserves all other keys.
+    Writes a .backup.<ts> alongside.
+
 OPT-IN TOUCHES:
-  - opencode.json — only with --repair-opencode-json. Rewrites the
-    "plugin" array + migrates "agent.build.prompt" to "instructions"
-    array (fixes Anthropic Claude Max OAuth); preserves all other keys;
-    writes a .backup.<ts> alongside.
+  - opencode.json (--repair-opencode-json) — full reconcile. In addition
+    to the additive behaviour above, removes unexpected plugin entries
+    so the array matches exactly what setup would produce today.
 HELP
   exit 0
 fi
@@ -496,10 +515,24 @@ _sync_kimaki_config() {
 # ============================================================================
 
 check_opencode_json_drift() {
-  # Runs whenever opencode.json exists on disk. The repair script handles
-  # both plugin-array drift (opencode runtime only) and prompt migration
-  # (all runtimes — agent.build.prompt → instructions breaks Anthropic
-  # Claude Max OAuth regardless of which runtime is primary).
+  # Runs whenever opencode.json exists on disk. Default behaviour is
+  # additive repair: managed plugin entries the user is missing get added
+  # (dm-context-filter.ts, dm-agent-sync.ts, opencode-claude-auth@latest —
+  # whichever apply to the detected runtime + chat bridge), and legacy
+  # agent.build.prompt / agent.plan.prompt get migrated to a top-level
+  # `instructions` array (fixes Anthropic Claude Max OAuth,
+  # wp-coding-agents#60).
+  #
+  # User-added plugin entries are left alone in additive mode. If any are
+  # present after the repair the user is told to re-run with
+  # --repair-opencode-json for the full reconciliation, which removes
+  # unexpected entries too.
+  #
+  # Why additive is the default: dm-context-filter.ts is a security policy
+  # plugin (it strips cross-channel routing discovery from Kimaki system
+  # prompts). Installs that predate the filter, or were bootstrapped before
+  # kimaki was the chat bridge, must not be left without it just because
+  # the user never knew to pass an opt-in flag. See wp-coding-agents#67.
 
   local OPENCODE_JSON_FILE="$SITE_PATH/opencode.json"
   if [ ! -f "$OPENCODE_JSON_FILE" ]; then
@@ -517,86 +550,91 @@ check_opencode_json_drift() {
   # Kimaki plugins dir — match what _sync_kimaki_config resolved.
   local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
 
+  # Runtime arg for repair-opencode-json.py: always `opencode` when the file
+  # exists. The primary RUNTIME may be `studio-code` or `claude-code` (e.g.
+  # on Studio sites where all three runtimes are detected), but the presence
+  # of opencode.json on disk means opencode IS in use — otherwise the file
+  # wouldn't be there. expected_plugins() skips plugin-array drift entirely
+  # for non-opencode runtimes, which would silently mask real drift here.
+  local RUNTIME_ARG="opencode"
+
+  # Mode: --apply (full reconcile, opt-in) or --additive (default).
+  local MODE_FLAG="--additive"
+  local MODE_LABEL="additive repair"
   if [ "$REPAIR_OPENCODE_JSON" = true ]; then
-    log "Phase 2b: Repairing opencode.json..."
-    if [ "$DRY_RUN" = true ]; then
-      echo -e "${BLUE}[dry-run]${NC} Would run: python3 $HELPER --file $OPENCODE_JSON_FILE --runtime $RUNTIME --chat-bridge $BRIDGE_ARG --kimaki-plugins-dir $PLUGINS_DIR --apply"
-      # Still show the diagnostic even in dry-run
-      local dry_out
-      dry_out=$(python3 "$HELPER" \
-        --file "$OPENCODE_JSON_FILE" \
-        --runtime "$RUNTIME" \
-        --chat-bridge "$BRIDGE_ARG" \
-        --kimaki-plugins-dir "$PLUGINS_DIR" 2>&1 || true)
-      echo "$dry_out" | sed 's/^/    /'
-      return 0
-    fi
+    MODE_FLAG="--apply"
+    MODE_LABEL="full repair"
+  fi
 
-    local out rc
-    out=$(python3 "$HELPER" \
+  log "Phase 2b: opencode.json $MODE_LABEL..."
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would run: python3 $HELPER --file $OPENCODE_JSON_FILE --runtime $RUNTIME_ARG --chat-bridge $BRIDGE_ARG --kimaki-plugins-dir $PLUGINS_DIR $MODE_FLAG"
+    local dry_out
+    dry_out=$(python3 "$HELPER" \
       --file "$OPENCODE_JSON_FILE" \
-      --runtime "$RUNTIME" \
+      --runtime "$RUNTIME_ARG" \
       --chat-bridge "$BRIDGE_ARG" \
-      --kimaki-plugins-dir "$PLUGINS_DIR" \
-      --apply \
-      --backup-suffix "$TIMESTAMP" 2>&1) && rc=0 || rc=$?
-
-    local status
-    status=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('status','?'))" 2>/dev/null || echo "parse-error")
-    local prompt_migration
-    prompt_migration=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('prompt_migration','?'))" 2>/dev/null || echo "?")
-
-    case "$status" in
-      ok)
-        log "  opencode.json already correct"
-        ;;
-      repaired)
-        log "  opencode.json repaired (backup: ${OPENCODE_JSON_FILE}.backup.$TIMESTAMP)"
-        log "  $out"
-        if [ "$prompt_migration" = "migrated" ]; then
-          UPDATED_ITEMS+=("opencode.json prompt → instructions migration")
-        fi
-        UPDATED_ITEMS+=("opencode.json plugin array (repaired)")
-        ;;
-      skipped)
-        log "  $out"
-        ;;
-      *)
-        warn "  repair-opencode-json.py returned status=$status (rc=$rc)"
-        warn "  $out"
-        ;;
-    esac
+      --kimaki-plugins-dir "$PLUGINS_DIR" 2>&1 || true)
+    echo "$dry_out" | sed 's/^/    /'
     return 0
   fi
 
-  # Diagnostic-only path (default).
-  local out rc
-  out=$(python3 "$HELPER" \
+  local repair_out repair_rc
+  repair_out=$(python3 "$HELPER" \
     --file "$OPENCODE_JSON_FILE" \
-    --runtime "$RUNTIME" \
+    --runtime "$RUNTIME_ARG" \
     --chat-bridge "$BRIDGE_ARG" \
-    --kimaki-plugins-dir "$PLUGINS_DIR" 2>&1) && rc=0 || rc=$?
+    --kimaki-plugins-dir "$PLUGINS_DIR" \
+    "$MODE_FLAG" \
+    --backup-suffix "$TIMESTAMP" 2>&1) && repair_rc=0 || repair_rc=$?
 
-  local status
-  status=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('status','?'))" 2>/dev/null || echo "parse-error")
-  local prompt_migration
-  prompt_migration=$(echo "$out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('prompt_migration','?'))" 2>/dev/null || echo "?")
+  local repair_status prompt_migration
+  repair_status=$(echo "$repair_out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('status','?'))" 2>/dev/null || echo "parse-error")
+  prompt_migration=$(echo "$repair_out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('prompt_migration','?'))" 2>/dev/null || echo "?")
 
-  case "$status" in
+  case "$repair_status" in
     ok)
-      log "Phase 2b: opencode.json matches current setup"
+      log "  opencode.json already correct"
+      ;;
+    additive_repaired)
+      log "  opencode.json repaired additively (backup: ${OPENCODE_JSON_FILE}.backup.$TIMESTAMP)"
+      log "  $repair_out"
+      if [ "$prompt_migration" = "migrated" ]; then
+        UPDATED_ITEMS+=("opencode.json prompt → instructions migration")
+      fi
+      UPDATED_ITEMS+=("opencode.json plugin array (added missing managed entries)")
+      ;;
+    needs_full_repair)
+      warn "  opencode.json additively repaired, but unexpected plugin entries remain"
+      warn "  Run './upgrade.sh --repair-opencode-json' to remove them (backup: ${OPENCODE_JSON_FILE}.backup.$TIMESTAMP)"
+      warn "  $repair_out"
+      if [ "$prompt_migration" = "migrated" ]; then
+        UPDATED_ITEMS+=("opencode.json prompt → instructions migration")
+      fi
+      UPDATED_ITEMS+=("opencode.json plugin array (added managed entries; unexpected entries still present)")
+      OPENCODE_JSON_DRIFT=true
+      ;;
+    repaired)
+      log "  opencode.json fully repaired (backup: ${OPENCODE_JSON_FILE}.backup.$TIMESTAMP)"
+      log "  $repair_out"
+      if [ "$prompt_migration" = "migrated" ]; then
+        UPDATED_ITEMS+=("opencode.json prompt → instructions migration")
+      fi
+      UPDATED_ITEMS+=("opencode.json plugin array (repaired)")
       ;;
     drift)
-      warn "Phase 2b: opencode.json has drift — re-run with --repair-opencode-json to fix"
-      warn "  $out"
+      # Only reachable if we passed neither --apply nor --additive, which
+      # shouldn't happen with the dispatch above. Defensive.
+      warn "Phase 2b: opencode.json has drift — $repair_out"
       OPENCODE_JSON_DRIFT=true
       ;;
     skipped)
-      log "Phase 2b: $out"
+      log "  $repair_out"
       ;;
     *)
-      warn "Phase 2b: repair-opencode-json.py returned status=$status (rc=$rc)"
-      warn "  $out"
+      warn "  repair-opencode-json.py returned status=$repair_status (rc=$repair_rc)"
+      warn "  $repair_out"
       ;;
   esac
 }
@@ -906,9 +944,9 @@ print_summary() {
 
   if [ "$OPENCODE_JSON_DRIFT" = true ]; then
     echo ""
-    warn "opencode.json drift detected (plugin array or prompt format)."
+    warn "opencode.json: managed entries were added, but unexpected plugins remain."
     warn "  Re-run with: ./upgrade.sh --repair-opencode-json"
-    warn "  (Drift is common on installs that predate #51, #60, or v0.4.0.)"
+    warn "  to remove them (the backup from this run is preserved)."
   fi
 
   echo ""


### PR DESCRIPTION
## The gap

`dm-context-filter.ts` is a security-policy plugin: it strips cross-project and cross-channel routing discovery from the Kimaki system prompt so minion sessions stay in the current channel, per the agent-boundary model ([data-machine-code#49](https://github.com/Extra-Chill/data-machine-code/issues/49)) and the Minion Session Routing rule that the plugin itself appends to every prompt.

An audit of the setup + upgrade paths found three routes that legitimately leave a live install **without** the filter, silently:

1. **Install predates v0.4.0** (when the filter first shipped).
2. **Install predates Kimaki as the chat bridge** — the filter only gets wired when `CHAT_BRIDGE=kimaki`, so a later bridge change never backfilled it.
3. **`setup.sh --local` re-run against an existing `opencode.json`** — the whole `runtime_generate_config` body was guarded behind a "file already exists" early-return, which also guarded the `cp` calls that place the filter on disk. So both the file reference in `opencode.json` *and* the file itself on disk were left out.

And `upgrade.sh`'s default behaviour was warn-only — it would diagnose the drift and tell the user to re-run with `--repair-opencode-json`, but never fix it. For a plugin whose job is policy enforcement, opt-in repair is the wrong default.

This PR closes all three routes and makes the default behaviour additive repair.

## The fix

Three logical pieces, one per commit:

### 1. `feat(repair): add --additive mode to repair-opencode-json.py`

New mode that adds missing managed plugin entries and applies the `agent.build.prompt` → `instructions` migration, but **never removes user-added plugin entries**. Returns one of two new statuses:

- `additive_repaired` — managed entries added, no unexpected plugins. Exit 0.
- `needs_full_repair` — managed entries added, but unexpected plugin entries remain. Exit 1 so callers know the user still needs `--apply` to remove them.

`--apply` remains the full reconciliation. Prompt migration runs in both modes because the underlying Claude Max OAuth bug ([#60](https://github.com/Extra-Chill/wp-coding-agents/issues/60)) is a functional break, not an opt-in. Also dropped a dead code block after an early return in `main()`.

### 2. `fix(setup): additive repair on existing opencode.json`

Hoists the Kimaki plugin-file copy out of the fresh-install path so it runs on every setup invocation (idempotent). Routes the existing-file branch through a new `_runtime_repair_opencode_json_additive` helper that calls `repair-opencode-json.py --additive`.

### 3. `fix(upgrade): additive opencode.json repair by default`

`check_opencode_json_drift` dispatches on `--repair-opencode-json`:

- flag set → `--apply` (full reconcile: add missing + remove unexpected). Unchanged semantics.
- flag not set → `--additive` (add missing managed entries, never remove unexpected, migrate legacy prompts). **Previously diagnostic-only.**

`--repair-opencode-json` becomes an "escalation to full reconciliation" rather than the only way to get any repair at all.

Also: always pass `--runtime opencode` to the repair helper when `opencode.json` exists, regardless of the primary `RUNTIME`. On Studio sites the primary is `studio-code`, but `opencode.json` is still the active config for any opencode sessions spawned on top — passing `studio-code` would silently skip the plugin-array check entirely.

## Verification

End-to-end on this machine's `intelligence-chubes4` Studio install, which fell through exactly the gap described above:

**Before**:
- `opencode.json` → `"plugin": []`
- `~/.nvm/.../kimaki/plugins/` → did not exist
- Old `upgrade.sh` default: warn only, no fix

**After one `upgrade.sh --local`**:
- `opencode.json` → contains both `dm-context-filter.ts` and `dm-agent-sync.ts`, all user keys (model, instructions, permission, mcp with three servers) preserved exactly
- `~/.nvm/.../kimaki/plugins/` → populated with current versions
- `.backup.<ts>` written alongside
- Summary correctly lists the additive additions as `Updated:` items

**After a second run**:
- Status: `ok`, no new backup, `Nothing changed — everything was already up to date`

User-added plugin preservation verified on a synthetic fixture: when `plugin: ["some-user-added-plugin@1.0.0"]`, the additive run adds the managed entries, preserves the user entry, and returns `needs_full_repair` + exit 1 so the caller knows `--apply` is still needed to remove it.

Prompt migration path verified on a fixture with `agent.build.prompt` containing `{file:./...}` references: `agent.build.prompt` removed, `{file:./AGENTS.md}` skipped (auto-discovered), remaining file refs promoted to top-level `instructions`.

## Out of scope (filed separately)

- **Kimaki-side CLI guards** against `--project` / `--channel` / `kimaki project list` routing to other channels. Remorses (upstream kimaki) is not open to PRs from third parties, so the wp-coding-agents fix is limited to "make sure the stripping plugin is actually loaded."
- **Stripping-plugin completeness** — prompt-level stripping can't prevent an agent that already knows kimaki from its own training data from reconstructing forbidden flags. That's a limitation of prompt-based policy in general, noted but not solved here.
- **`intelligence-chubes4` topology mismatch** — kimaki's worktree-must-be-of-project-directory validation is right for coding-agent-per-repo fleets but wrong for a personal-intelligence-agent site that works on arbitrary external repos. Filed as a separate investigation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Investigation of the leakage root cause across three scripts, diff design, implementation of additive mode in repair-opencode-json.py and the two shell scripts, end-to-end verification on my own install. Chris drove the scoping decisions (additive-only default, prompt migration auto-applies, no kimaki-side changes) in the planning session.