### PR TITLE
fix(kimaki): include node bin dir in launchd PATH

### DIFF
--- a/lib/chat-bridges.sh
+++ b/lib/chat-bridges.sh
@@ -298,6 +298,8 @@ bridge_render_launchd() {
 _render_launchd_kimaki() {
   local label="$1"
   [ "$label" = "com.wp.kimaki" ] || { echo "kimaki has no label '$label'" >&2; return 1; }
+  local kimaki_bin_dir
+  kimaki_bin_dir="$(dirname "$KIMAKI_BIN")"
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -324,7 +326,7 @@ _render_launchd_kimaki() {
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>$kimaki_bin_dir:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>KIMAKI_DATA_DIR</key>
         <string>$KIMAKI_DATA_DIR</string>$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
         <key>KIMAKI_BOT_TOKEN</key>


### PR DESCRIPTION
## Summary
- Prepends the resolved Kimaki binary directory to the generated macOS launchd PATH.
- Fixes nvm-installed Kimaki failing under launchd because the `#!/usr/bin/env node` wrapper cannot resolve `node`.

## Tests
- `bash tests/bridge-render.sh`
- Rendered Kimaki launchd plist with `KIMAKI_BIN=/Users/chubes/.nvm/versions/node/v24.13.1/bin/kimaki` and verified PATH includes that bin directory.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the launchd PATH failure, made the one-file shell template fix, and ran local verification. Chris remains responsible for review and merge.