### PR TITLE
fix(runtime): resolve Data Machine memory paths in Studio

### DIFF
--- a/hooks/dm-agent-sync.sh
+++ b/hooks/dm-agent-sync.sh
@@ -98,7 +98,7 @@ fi
 
 ALL_FILES=""
 while IFS= read -r slug; do
-  PATHS_RAW=$($WP_CMD datamachine agent paths --agent="$slug" --format=json 2>/dev/null) || continue
+  PATHS_RAW=$($WP_CMD datamachine memory paths --agent="$slug" --format=json 2>/dev/null) || continue
 
   FILES=$(echo "$PATHS_RAW" | python3 -c "
 import sys, json, re
@@ -131,7 +131,7 @@ while IFS= read -r f; do
 "
 done <<< "$UNIQUE_FILES"
 
-DISCOVER_LINE="Discover DM paths: \`$WP_CMD datamachine agent paths\`"
+DISCOVER_LINE="Discover DM paths: \`$WP_CMD datamachine memory paths\`"
 NEW_CONTENT="${AT_INCLUDES}
 ${DISCOVER_LINE}"
 

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -33,7 +33,7 @@ print_summary() {
   if [ -n "$AGENT_SLUG" ]; then
     echo "  Agent:       $AGENT_SLUG"
   fi
-  echo "  Discover:    $WP_CMD datamachine agent paths${AGENT_SLUG:+ --agent=$AGENT_SLUG} $WP_ROOT_FLAG"
+  echo "  Discover:    $WP_CMD datamachine memory paths${AGENT_SLUG:+ --agent=$AGENT_SLUG} $WP_ROOT_FLAG"
   echo "  Code tools:  data-machine-code (workspace, GitHub, git)"
   echo "  Workspace:   $DM_WORKSPACE_DIR (created on first use)"
   echo ""

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -5,7 +5,7 @@
 wp_cmd() {
   if [ "$IS_STUDIO" = true ]; then
     # shellcheck disable=SC2086
-    run_cmd studio wp "$@"
+    run_cmd studio wp "$@" --path="$SITE_PATH"
   else
     # shellcheck disable=SC2086
     run_cmd $WP_CMD "$@" $WP_ROOT_FLAG --path="$SITE_PATH"

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -25,7 +25,7 @@ runtime_discover_dm_paths() {
     if [ -n "$AGENT_SLUG" ]; then
       AGENT_FLAG="--agent=$AGENT_SLUG"
     fi
-    DM_PATHS_RAW=$(wp_cmd datamachine agent paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
+    DM_PATHS_RAW=$(wp_cmd datamachine memory paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
     # SQLite translation layer may emit HTML error noise — extract only JSON
     DM_PATHS_JSON=$(echo "$DM_PATHS_RAW" | sed -n '/^{/,/^}/p')
     if [ -n "$DM_PATHS_JSON" ]; then
@@ -39,7 +39,7 @@ data = json.load(sys.stdin)
 for f in data.get('relative_files', []):
     print(f)
 " 2>/dev/null)
-      log "Agent files discovered via 'wp datamachine agent paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+      log "Agent files discovered via 'wp datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
     fi
   else
     # Dry-run: use placeholder paths
@@ -112,7 +112,7 @@ runtime_generate_config() {
 "
   done
 
-  DISCOVER_LINE="Discover DM paths: \`$WP_CLI_DISPLAY datamachine agent paths\`"
+  DISCOVER_LINE="Discover DM paths: \`$WP_CLI_DISPLAY datamachine memory paths\`"
   SENTINEL_CONTENT="<!-- DM_AGENT_SYNC_START -->
 ${AT_INCLUDES}
 ${DISCOVER_LINE}

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -150,11 +150,11 @@ runtime_discover_dm_paths() {
     if [ -n "$AGENT_SLUG" ]; then
       AGENT_FLAG="--agent=$AGENT_SLUG"
     fi
-    DM_PATHS_RAW=$(wp_cmd datamachine agent paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
+    DM_PATHS_RAW=$(wp_cmd datamachine memory paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
     # SQLite translation layer may emit HTML error noise — extract only JSON
     DM_PATHS_JSON=$(echo "$DM_PATHS_RAW" | sed -n '/^{/,/^}/p')
     if [ -z "$DM_PATHS_JSON" ]; then
-      error "'$WP_CMD datamachine agent paths' returned no JSON — is Data Machine active and agent created?"
+      error "'$WP_CMD datamachine memory paths' returned no JSON — is Data Machine active and agent created?"
     fi
     DM_AGENT_FILES=$(echo "$DM_PATHS_JSON" | python3 -c "
 import sys, json
@@ -162,7 +162,7 @@ data = json.load(sys.stdin)
 for f in data.get('relative_files', []):
     print(f)
 ")
-    log "Agent files discovered via '$WP_CMD datamachine agent paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+    log "Agent files discovered via '$WP_CMD datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
   else
     # Dry-run: use placeholder paths
     DM_DRY_SLUG="${AGENT_SLUG:-AGENT_SLUG}"

--- a/runtimes/studio-code.sh
+++ b/runtimes/studio-code.sh
@@ -53,7 +53,7 @@ runtime_discover_dm_paths() {
     if [ -n "$AGENT_SLUG" ]; then
       AGENT_FLAG="--agent=$AGENT_SLUG"
     fi
-    DM_PATHS_RAW=$(wp_cmd datamachine agent paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
+    DM_PATHS_RAW=$(wp_cmd datamachine memory paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
     # SQLite translation layer may emit HTML error noise — extract only JSON
     DM_PATHS_JSON=$(echo "$DM_PATHS_RAW" | sed -n '/^{/,/^}/p')
     if [ -n "$DM_PATHS_JSON" ]; then
@@ -67,7 +67,7 @@ data = json.load(sys.stdin)
 for f in data.get('relative_files', []):
     print(f)
 " 2>/dev/null)
-      log "Agent files discovered via 'studio wp datamachine agent paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+      log "Agent files discovered via 'studio wp datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
     fi
   else
     # Dry-run: use placeholder paths
@@ -119,7 +119,7 @@ runtime_generate_config() {
 "
     done
 
-    DISCOVER_LINE="Discover DM paths: \`studio wp datamachine agent paths\`"
+    DISCOVER_LINE="Discover DM paths: \`studio wp datamachine memory paths\`"
     SENTINEL_CONTENT="<!-- DM_AGENT_SYNC_START -->
 ${AT_INCLUDES}
 ${DISCOVER_LINE}
@@ -172,7 +172,7 @@ APPENDEOF
 "
   done
 
-  DISCOVER_LINE="Discover DM paths: \`studio wp datamachine agent paths\`"
+  DISCOVER_LINE="Discover DM paths: \`studio wp datamachine memory paths\`"
   SENTINEL_CONTENT="<!-- DM_AGENT_SYNC_START -->
 ${AT_INCLUDES}
 ${DISCOVER_LINE}


### PR DESCRIPTION
## Summary
- Updates runtime path discovery to call `wp datamachine memory paths`, matching the current Data Machine CLI surface.
- Passes `--path=$SITE_PATH` through the Studio `wp_cmd()` helper so setup targets the configured site even when launched from another checkout.
- Updates generated discovery hints and the agent-sync hook to use the current memory paths command.

## Verification
- `bash -n lib/wordpress.sh runtimes/opencode.sh runtimes/claude-code.sh runtimes/studio-code.sh hooks/dm-agent-sync.sh lib/summary.sh`
- Verified old command fails on the live Studio site: `studio wp datamachine agent paths --format=json --agent=intelligence-test-collapse --path=/Users/chubes/Studio/intelligence-chubes4`
- Verified replacement command returns agent paths: `studio wp datamachine memory paths --format=json --agent=intelligence-test-collapse --path=/Users/chubes/Studio/intelligence-chubes4`
- Started `--runtime-only` setup from the Intelligence checkout and confirmed it progressed past the previous `datamachine agent paths returned no JSON` failure; the follow-up run was interrupted before completion.

## Notes
- An unrelated local modification to `lib/chat-bridges.sh` was present in the worktree and was not included in this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the runtime-only setup failure, drafting the shell changes, and running focused verification. Chris remains responsible for review and merge.