### PR TITLE
fix(kimaki): restore opencode plugins after npm update

### DIFF
--- a/kimaki/post-upgrade.sh
+++ b/kimaki/post-upgrade.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
-# post-upgrade.sh — Enforce kimaki skill state on every restart.
+# post-upgrade.sh — Enforce kimaki skill + plugin state on every restart.
 #
-# Two symmetric passes run against $(npm root -g)/kimaki/skills/:
-#   1. KILL   — remove unwanted bundled kimaki skills listed in skills-kill-list.txt.
-#   2. RESTORE — re-copy wp-coding-agents skills from the persistent source dir
-#               (kimaki-config/skills/). `npm update -g kimaki` wipes the
-#               bundled skills dir, so without this restore pass Discord
-#               slash commands silently degrade between upgrades.
+# Three symmetric passes run against the npm-installed kimaki package:
+#   1. KILL    — remove unwanted bundled kimaki skills listed in
+#                skills-kill-list.txt (target: $(npm root -g)/kimaki/skills/).
+#   2. RESTORE skills  — re-copy wp-coding-agents skills from the persistent
+#                source dir (kimaki-config/skills/) into kimaki/skills/.
+#   3. RESTORE plugins — re-copy wp-coding-agents opencode plugins from the
+#                persistent source dir (kimaki-config/plugins/) into
+#                kimaki/plugins/. opencode.json references the plugin .ts
+#                files at $(npm root -g)/kimaki/plugins/<file>.ts; without
+#                this restore pass dm-context-filter.ts and dm-agent-sync.ts
+#                silently disappear after every `npm update -g kimaki` and
+#                Discord agents lose their context-filter / agent-sync
+#                policies until the next manual upgrade.sh run.
+#
+# `npm update -g kimaki` wipes both kimaki/skills/ AND kimaki/plugins/, so
+# the persistent kimaki-config/ dir is the source of truth and this script
+# rehydrates the npm install on every kimaki restart.
 #
 # Invoked two ways:
 #   VPS:   ExecStartPre in kimaki.service (runs on every service start).
@@ -17,78 +28,152 @@
 #   2. $(npm root -g)/kimaki/skills (works on macOS + Linux when npm is on PATH)
 #   3. /usr/lib/node_modules/kimaki/skills (Linux VPS fallback when npm absent)
 #
+# Plugins dir resolution priority (mirrors skills resolution):
+#   1. KIMAKI_PLUGINS_DIR env var (explicit override)
+#   2. $(npm root -g)/kimaki/plugins
+#   3. /usr/lib/node_modules/kimaki/plugins (Linux VPS fallback when npm absent)
+#
 # Persistent skill source dir resolution priority:
 #   1. KIMAKI_SKILL_SOURCE_DIR env var (explicit override)
 #   2. $KIMAKI_DATA_DIR/kimaki-config/skills/ if KIMAKI_DATA_DIR set
 #   3. $HOME/.kimaki/kimaki-config/skills/ (local default)
 #   4. /opt/kimaki-config/skills/ (VPS default)
+#
+# Persistent plugin source dir resolution priority (mirrors skill source):
+#   1. KIMAKI_PLUGIN_SOURCE_DIR env var (explicit override)
+#   2. $KIMAKI_DATA_DIR/kimaki-config/plugins/ if KIMAKI_DATA_DIR set
+#   3. $HOME/.kimaki/kimaki-config/plugins/ (local default)
+#   4. /opt/kimaki-config/plugins/ (VPS default)
 set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Resolve npm-installed kimaki paths.
+# ----------------------------------------------------------------------------
+
+if command -v npm &>/dev/null; then
+  NPM_ROOT="$(npm root -g 2>/dev/null || true)"
+else
+  NPM_ROOT=""
+fi
 
 if [[ -n "${KIMAKI_SKILLS_DIR:-}" ]]; then
   SKILLS_DIR="$KIMAKI_SKILLS_DIR"
-elif command -v npm &>/dev/null; then
-  NPM_ROOT="$(npm root -g 2>/dev/null || true)"
-  if [[ -n "$NPM_ROOT" ]]; then
-    SKILLS_DIR="$NPM_ROOT/kimaki/skills"
-  else
-    SKILLS_DIR="/usr/lib/node_modules/kimaki/skills"
-  fi
+elif [[ -n "$NPM_ROOT" ]]; then
+  SKILLS_DIR="$NPM_ROOT/kimaki/skills"
 else
   SKILLS_DIR="/usr/lib/node_modules/kimaki/skills"
 fi
 
+if [[ -n "${KIMAKI_PLUGINS_DIR:-}" ]]; then
+  PLUGINS_DIR="$KIMAKI_PLUGINS_DIR"
+elif [[ -n "$NPM_ROOT" ]]; then
+  PLUGINS_DIR="$NPM_ROOT/kimaki/plugins"
+else
+  PLUGINS_DIR="/usr/lib/node_modules/kimaki/plugins"
+fi
+
 KILL_LIST="$(dirname "$0")/skills-kill-list.txt"
 
-if [[ ! -d "$SKILLS_DIR" ]]; then
-  echo "kimaki-config: skills dir not found at $SKILLS_DIR, skipping"
-  exit 0
-fi
-
-if [[ ! -f "$KILL_LIST" ]]; then
-  echo "kimaki-config: kill list not found at $KILL_LIST, skipping"
-  exit 0
-fi
+# ----------------------------------------------------------------------------
+# Pass 1: KILL — remove blacklisted bundled kimaki skills.
+# ----------------------------------------------------------------------------
 
 removed=0
-while IFS= read -r skill || [[ -n "$skill" ]]; do
-  # Skip comments and blank lines
-  [[ -z "$skill" || "$skill" == \#* ]] && continue
-  target="$SKILLS_DIR/$skill"
-  if [[ -d "$target" ]]; then
-    rm -rf "$target"
-    echo "kimaki-config: removed $skill"
-    removed=$((removed + 1))
-  fi
-done < "$KILL_LIST"
-
-# Restore pass — re-copy wp-coding-agents skills from the persistent source
-# dir. Idempotent: `rm -rf` before each `cp -r` so a stale copy in SKILLS_DIR
-# always gets replaced by the current source.
-if [[ -n "${KIMAKI_SKILL_SOURCE_DIR:-}" ]]; then
-  SOURCE_DIR="$KIMAKI_SKILL_SOURCE_DIR"
-elif [[ -n "${KIMAKI_DATA_DIR:-}" ]]; then
-  SOURCE_DIR="$KIMAKI_DATA_DIR/kimaki-config/skills"
-elif [[ -d "$HOME/.kimaki/kimaki-config/skills" ]]; then
-  SOURCE_DIR="$HOME/.kimaki/kimaki-config/skills"
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "kimaki-config: skills dir not found at $SKILLS_DIR, skipping kill pass"
+elif [[ ! -f "$KILL_LIST" ]]; then
+  echo "kimaki-config: kill list not found at $KILL_LIST, skipping kill pass"
 else
-  SOURCE_DIR="/opt/kimaki-config/skills"
+  while IFS= read -r skill || [[ -n "$skill" ]]; do
+    # Skip comments and blank lines
+    [[ -z "$skill" || "$skill" == \#* ]] && continue
+    target="$SKILLS_DIR/$skill"
+    if [[ -d "$target" ]]; then
+      rm -rf "$target"
+      echo "kimaki-config: removed skill $skill"
+      removed=$((removed + 1))
+    fi
+  done < "$KILL_LIST"
 fi
 
-restored=0
-if [[ -d "$SOURCE_DIR" ]]; then
-  for skill_dir in "$SOURCE_DIR"/*/; do
+# ----------------------------------------------------------------------------
+# Pass 2: RESTORE skills — re-copy wp-coding-agents skills from the
+# persistent source dir into the npm-managed skills dir. Idempotent: `rm -rf`
+# before each `cp -r` so a stale copy always gets replaced by the current
+# source.
+# ----------------------------------------------------------------------------
+
+if [[ -n "${KIMAKI_SKILL_SOURCE_DIR:-}" ]]; then
+  SKILL_SOURCE_DIR="$KIMAKI_SKILL_SOURCE_DIR"
+elif [[ -n "${KIMAKI_DATA_DIR:-}" ]]; then
+  SKILL_SOURCE_DIR="$KIMAKI_DATA_DIR/kimaki-config/skills"
+elif [[ -d "$HOME/.kimaki/kimaki-config/skills" ]]; then
+  SKILL_SOURCE_DIR="$HOME/.kimaki/kimaki-config/skills"
+else
+  SKILL_SOURCE_DIR="/opt/kimaki-config/skills"
+fi
+
+skills_restored=0
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "kimaki-config: skills dir not found at $SKILLS_DIR, skipping skill restore"
+elif [[ -d "$SKILL_SOURCE_DIR" ]]; then
+  for skill_dir in "$SKILL_SOURCE_DIR"/*/; do
     [[ -d "$skill_dir" ]] || continue
     skill_name="$(basename "$skill_dir")"
     if [[ -f "$skill_dir/SKILL.md" ]]; then
       target="$SKILLS_DIR/$skill_name"
       rm -rf "$target"
       cp -r "$skill_dir" "$target"
-      echo "kimaki-config: restored $skill_name"
-      restored=$((restored + 1))
+      echo "kimaki-config: restored skill $skill_name"
+      skills_restored=$((skills_restored + 1))
     fi
   done
 else
-  echo "kimaki-config: persistent skill source dir not found at $SOURCE_DIR, skipping restore"
+  echo "kimaki-config: persistent skill source dir not found at $SKILL_SOURCE_DIR, skipping skill restore"
 fi
 
-echo "kimaki-config: done ($removed skills removed, $restored skills restored)"
+# ----------------------------------------------------------------------------
+# Pass 3: RESTORE plugins — re-copy wp-coding-agents opencode plugins from
+# the persistent source dir into the npm-managed plugins dir.
+#
+# opencode.json references each plugin by absolute path at
+# $(npm root -g)/kimaki/plugins/<file>.ts. The kimaki npm package does NOT
+# ship a plugins/ dir, so this directory only ever exists because we put it
+# there. `npm update -g kimaki` wipes it clean every time.
+# ----------------------------------------------------------------------------
+
+if [[ -n "${KIMAKI_PLUGIN_SOURCE_DIR:-}" ]]; then
+  PLUGIN_SOURCE_DIR="$KIMAKI_PLUGIN_SOURCE_DIR"
+elif [[ -n "${KIMAKI_DATA_DIR:-}" ]]; then
+  PLUGIN_SOURCE_DIR="$KIMAKI_DATA_DIR/kimaki-config/plugins"
+elif [[ -d "$HOME/.kimaki/kimaki-config/plugins" ]]; then
+  PLUGIN_SOURCE_DIR="$HOME/.kimaki/kimaki-config/plugins"
+else
+  PLUGIN_SOURCE_DIR="/opt/kimaki-config/plugins"
+fi
+
+plugins_restored=0
+if [[ -d "$PLUGIN_SOURCE_DIR" ]]; then
+  # Ensure the npm-managed plugins dir exists before copying.
+  mkdir -p "$PLUGINS_DIR" 2>/dev/null || true
+  if [[ ! -d "$PLUGINS_DIR" ]]; then
+    echo "kimaki-config: could not create plugins dir at $PLUGINS_DIR, skipping plugin restore"
+  else
+    shopt -s nullglob
+    for plugin_file in "$PLUGIN_SOURCE_DIR"/*.ts; do
+      plugin_name="$(basename "$plugin_file")"
+      target="$PLUGINS_DIR/$plugin_name"
+      # Idempotent: only copy if missing or different. cmp returns 0 on match.
+      if ! cmp -s "$plugin_file" "$target" 2>/dev/null; then
+        cp "$plugin_file" "$target"
+        echo "kimaki-config: restored plugin $plugin_name"
+        plugins_restored=$((plugins_restored + 1))
+      fi
+    done
+    shopt -u nullglob
+  fi
+else
+  echo "kimaki-config: persistent plugin source dir not found at $PLUGIN_SOURCE_DIR, skipping plugin restore"
+fi
+
+echo "kimaki-config: done ($removed skills removed, $skills_restored skills restored, $plugins_restored plugins restored)"

--- a/tests/post-upgrade-restore.sh
+++ b/tests/post-upgrade-restore.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# tests/post-upgrade-restore.sh — smoke test for kimaki/post-upgrade.sh
+#
+# Verifies the three passes (kill, restore skills, restore plugins) using
+# temp-dir env overrides so the test never touches the real npm install or
+# user config.
+#
+# What we cover:
+#   1. Kill pass removes a blacklisted skill from the simulated skills dir.
+#   2. Skill restore pass copies a SKILL.md tree from the persistent source
+#      back into the (wiped) skills dir.
+#   3. Plugin restore pass copies *.ts files from the persistent source into
+#      the (wiped) plugins dir — the regression this script was added to fix.
+#   4. Plugin restore is idempotent — running again does not re-copy files
+#      that already match.
+#   5. Plugin restore creates the live plugins dir if it does not exist
+#      (the post-`npm update` reality).
+#
+# Run from anywhere:
+#   bash tests/post-upgrade-restore.sh
+#
+# Exit code: 0 on success, non-zero on first failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POST_UPGRADE="$SCRIPT_DIR/kimaki/post-upgrade.sh"
+
+if [[ ! -x "$POST_UPGRADE" ]]; then
+  echo "FAIL: $POST_UPGRADE is not executable"
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Simulated "npm-installed kimaki" layout — the targets the restore loop writes to.
+LIVE_SKILLS="$TMP/npm/kimaki/skills"
+LIVE_PLUGINS="$TMP/npm/kimaki/plugins"
+
+# Persistent kimaki-config layout — the source of truth.
+SRC_SKILLS="$TMP/config/skills"
+SRC_PLUGINS="$TMP/config/plugins"
+
+mkdir -p "$LIVE_SKILLS" "$SRC_SKILLS" "$SRC_PLUGINS"
+# Note: deliberately NOT creating LIVE_PLUGINS — the script must mkdir it.
+
+# Seed a blacklisted skill that the kill pass should remove.
+mkdir -p "$LIVE_SKILLS/blacklisted-skill"
+echo "stub" > "$LIVE_SKILLS/blacklisted-skill/SKILL.md"
+
+# Seed a skill in the persistent source that should be restored.
+mkdir -p "$SRC_SKILLS/restored-skill"
+cat > "$SRC_SKILLS/restored-skill/SKILL.md" <<'EOF'
+---
+name: restored-skill
+description: test fixture
+---
+body
+EOF
+
+# Seed two plugins in the persistent source that should be restored.
+cat > "$SRC_PLUGINS/test-plugin-a.ts" <<'EOF'
+// test-plugin-a.ts
+export default async () => ({})
+EOF
+cat > "$SRC_PLUGINS/test-plugin-b.ts" <<'EOF'
+// test-plugin-b.ts
+export default async () => ({})
+EOF
+
+# Build a temp skills-kill-list.txt next to a copied post-upgrade.sh so the
+# script's `dirname "$0"` lookup finds it.
+TEST_SCRIPT_DIR="$TMP/kimaki-config-dir"
+mkdir -p "$TEST_SCRIPT_DIR"
+cp "$POST_UPGRADE" "$TEST_SCRIPT_DIR/post-upgrade.sh"
+chmod +x "$TEST_SCRIPT_DIR/post-upgrade.sh"
+cat > "$TEST_SCRIPT_DIR/skills-kill-list.txt" <<'EOF'
+# test kill list
+blacklisted-skill
+EOF
+
+# Run the script with explicit env overrides so it never touches the real
+# npm install or user config.
+KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
+KIMAKI_PLUGINS_DIR="$LIVE_PLUGINS" \
+KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_PLUGIN_SOURCE_DIR="$SRC_PLUGINS" \
+  "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run1.log" 2>&1
+
+assert_missing() {
+  if [[ -e "$1" ]]; then
+    echo "FAIL: $1 should not exist"
+    cat "$TMP/run1.log"
+    exit 1
+  fi
+}
+
+assert_present() {
+  if [[ ! -e "$1" ]]; then
+    echo "FAIL: $1 should exist"
+    cat "$TMP/run1.log"
+    exit 1
+  fi
+}
+
+assert_log_contains() {
+  if ! grep -qF "$1" "$TMP/run1.log"; then
+    echo "FAIL: log should contain: $1"
+    cat "$TMP/run1.log"
+    exit 1
+  fi
+}
+
+# Pass 1: kill pass removed the blacklisted skill.
+assert_missing "$LIVE_SKILLS/blacklisted-skill"
+assert_log_contains "removed skill blacklisted-skill"
+
+# Pass 2: skill restore copied the SKILL.md tree.
+assert_present "$LIVE_SKILLS/restored-skill/SKILL.md"
+assert_log_contains "restored skill restored-skill"
+
+# Pass 3: plugin restore created the dir AND copied both plugins.
+assert_present "$LIVE_PLUGINS/test-plugin-a.ts"
+assert_present "$LIVE_PLUGINS/test-plugin-b.ts"
+assert_log_contains "restored plugin test-plugin-a.ts"
+assert_log_contains "restored plugin test-plugin-b.ts"
+
+# Idempotency: second run with the same state should restore zero plugins.
+KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
+KIMAKI_PLUGINS_DIR="$LIVE_PLUGINS" \
+KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_PLUGIN_SOURCE_DIR="$SRC_PLUGINS" \
+  "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run2.log" 2>&1
+
+if grep -q "restored plugin" "$TMP/run2.log"; then
+  echo "FAIL: second run should not re-restore unchanged plugins"
+  cat "$TMP/run2.log"
+  exit 1
+fi
+if ! grep -q "0 plugins restored" "$TMP/run2.log"; then
+  echo "FAIL: second run should report 0 plugins restored"
+  cat "$TMP/run2.log"
+  exit 1
+fi
+
+# Wipe the live plugins dir to simulate `npm update -g kimaki` and confirm
+# the next run rehydrates it from the persistent source — the actual fix.
+rm -rf "$LIVE_PLUGINS"
+
+KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
+KIMAKI_PLUGINS_DIR="$LIVE_PLUGINS" \
+KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_PLUGIN_SOURCE_DIR="$SRC_PLUGINS" \
+  "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run3.log" 2>&1
+
+if [[ ! -f "$LIVE_PLUGINS/test-plugin-a.ts" ]]; then
+  echo "FAIL: plugins dir should be rehydrated after simulated npm update"
+  cat "$TMP/run3.log"
+  exit 1
+fi
+if ! grep -q "2 plugins restored" "$TMP/run3.log"; then
+  echo "FAIL: rehydration run should report 2 plugins restored"
+  cat "$TMP/run3.log"
+  exit 1
+fi
+
+echo "PASS: tests/post-upgrade-restore.sh ($(grep -c '' "$TMP/run1.log" || true) lines run1, $(grep -c '' "$TMP/run3.log" || true) lines run3)"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -412,15 +412,39 @@ _sync_kimaki_config() {
     fi
   fi
 
-  # Copy plugins to KIMAKI_PLUGINS_DIR (the path opencode.json actually loads from).
+  # Copy plugins to two targets:
+  #   1. KIMAKI_CONFIG_DIR/plugins/ — the persistent source of truth that
+  #      survives `npm update -g kimaki`. post-upgrade.sh restores from here
+  #      on every kimaki restart.
+  #   2. KIMAKI_PLUGINS_DIR (= $(npm root -g)/kimaki/plugins on local,
+  #      /opt/kimaki-config/plugins on VPS) — the path opencode.json actually
+  #      loads from. On VPS this is the same as #1; on local it lives inside
+  #      the npm package and gets wiped on every kimaki update.
+  #
+  # Writing to both keeps post-upgrade.sh's restore loop working on local
+  # installs without changing the VPS layout (where the two paths coincide).
   if [ -d "$SCRIPT_DIR/kimaki/plugins" ]; then
     if [ "$DRY_RUN" = false ]; then
+      mkdir -p "$KIMAKI_CONFIG_DIR/plugins" 2>/dev/null || true
       mkdir -p "$KIMAKI_PLUGINS_DIR" 2>/dev/null || true
     fi
     for plugin_file in "$SCRIPT_DIR"/kimaki/plugins/*.ts; do
       [ -f "$plugin_file" ] || continue
       local name
       name=$(basename "$plugin_file")
+      # Persistent source of truth (survives npm update).
+      if [ "$DRY_RUN" = true ]; then
+        if ! cmp -s "$plugin_file" "$KIMAKI_CONFIG_DIR/plugins/$name" 2>/dev/null; then
+          echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_CONFIG_DIR/plugins/$name"
+        fi
+      else
+        if ! cmp -s "$plugin_file" "$KIMAKI_CONFIG_DIR/plugins/$name" 2>/dev/null; then
+          cp "$plugin_file" "$KIMAKI_CONFIG_DIR/plugins/$name"
+          log "  Updated $KIMAKI_CONFIG_DIR/plugins/$name (persistent source)"
+          UPDATED_ITEMS+=("kimaki-config/plugins/$name")
+        fi
+      fi
+      # Live target (where opencode.json points).
       if [ "$DRY_RUN" = true ]; then
         if ! cmp -s "$plugin_file" "$KIMAKI_PLUGINS_DIR/$name" 2>/dev/null; then
           echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_PLUGINS_DIR/$name"


### PR DESCRIPTION
## Summary

- Adds a third pass to `kimaki/post-upgrade.sh` that restores `dm-context-filter.ts` and `dm-agent-sync.ts` from a persistent `kimaki-config/plugins/` source dir into the npm-managed `$(npm root -g)/kimaki/plugins/` dir on every kimaki restart.
- Updates `upgrade.sh` to write plugins to **two** targets: the persistent `KIMAKI_CONFIG_DIR/plugins/` (source of truth) and the live `KIMAKI_PLUGINS_DIR` (where opencode.json points). Mirrors the two-target pattern skills already use.
- Adds `tests/post-upgrade-restore.sh` smoke test covering the three passes plus idempotency and the npm-wipe → rehydrate scenario, all in temp dirs so the test never touches the real npm install.

## Why

`opencode.json` on local Kimaki installs references opencode plugins by absolute path inside the npm install:

```json
"plugin": [
  "/Users/.../node_modules/kimaki/plugins/dm-context-filter.ts",
  "/Users/.../node_modules/kimaki/plugins/dm-agent-sync.ts"
]
```

The kimaki npm package does **not** ship a `plugins/` directory, so this dir only exists because `upgrade.sh` creates it. `npm update -g kimaki` then wipes it on every kimaki upgrade — exactly the same failure mode skills had before the existing restore loop was added.

Without these plugins running:
- `dm-context-filter.ts` does not strip Kimaki's worktree language → agents try `kimaki send --worktree` instead of `studio wp datamachine-code workspace worktree add`.
- `dm-context-filter.ts` does not strip cross-channel project discovery → agents can route minion sessions to other agents' channels.
- `dm-context-filter.ts` does not remove Kimaki's MEMORY.md injection / time-gap reminders → conflicts with Data Machine's memory layer.
- `dm-agent-sync.ts` does not recompose AGENTS.md at session start.

The symptom: on `intelligence-chubes4` (local Studio install) the plugin path in `opencode.json` pointed at a directory that did not exist on disk, so the filter ran zero times. Caught while debugging why the agent was offering `--worktree` advice that conflicts with DMC's worktree-native workspace.

## Behaviour

`post-upgrade.sh` now runs three passes against the npm-installed kimaki:

| Pass | Target | Source | Idempotent? |
|------|--------|--------|-------------|
| 1. KILL skills      | `$(npm root -g)/kimaki/skills/` | `skills-kill-list.txt` | yes (skips missing) |
| 2. RESTORE skills   | `$(npm root -g)/kimaki/skills/` | `kimaki-config/skills/`  | yes (`rm -rf` + `cp -r`) |
| 3. RESTORE plugins  | `$(npm root -g)/kimaki/plugins/` | `kimaki-config/plugins/` | yes (`cmp -s` skip) |

`upgrade.sh` writes plugins to both:

- `$KIMAKI_CONFIG_DIR/plugins/` — the persistent source of truth that survives `npm update -g kimaki`. `post-upgrade.sh` reads from here.
- `$KIMAKI_PLUGINS_DIR` (= `$(npm root -g)/kimaki/plugins` local, `/opt/kimaki-config/plugins` VPS) — the path opencode.json actually loads from.

On VPS the two paths coincide (both under `/opt/kimaki-config/`); on local they diverge, which is the exact reason this fix is needed.

## Tests

```bash
$ bash tests/post-upgrade-restore.sh
PASS: tests/post-upgrade-restore.sh (5 lines run1, 4 lines run3)
```

Covers:
1. Kill pass removes a blacklisted skill from the simulated skills dir.
2. Skill restore copies a `SKILL.md` tree from the persistent source.
3. Plugin restore copies `*.ts` files from the persistent source — the regression this PR fixes.
4. Plugin restore is idempotent — second run with no changes restores zero plugins.
5. Plugin restore creates the live plugins dir from scratch, simulating the post-`npm update -g kimaki` reality on local installs.

## Live verification

Ran the new `post-upgrade.sh` against the real npm install on `intelligence-chubes4`:

```
kimaki-config: removed skill egaki
... (15 more skills removed)
kimaki-config: restored skill data-machine
... (4 more skills restored)
kimaki-config: restored plugin dm-agent-sync.ts
kimaki-config: restored plugin dm-context-filter.ts
kimaki-config: done (16 skills removed, 5 skills restored, 2 plugins restored)
```

`ls $(npm root -g)/kimaki/plugins/` confirms both `.ts` files now present at the path `opencode.json` references. Subsequent opencode sessions pick up `dm-context-filter` automatically.

## Out of scope

- `dm-context-filter.ts` regex audit. The filter is correctly designed; it just was not running. Once it is reliably loaded across all installs, leftover leaks in the system prompt can be addressed in a follow-up.
- `homeboy.json` — wp-coding-agents is not homeboy-managed (manual `VERSION` + `docs/changelog.md`); no version bump per repo convention.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** drafted post-upgrade.sh restore loop and upgrade.sh two-target write, wrote the smoke test, ran end-to-end verification on a live local Studio install. Chris diagnosed the original symptom and confirmed the design.