### PR TITLE
fix: point AGENTS.md regeneration at `datamachine memory compose`

### DIFF
--- a/hooks/dm-agent-sync.sh
+++ b/hooks/dm-agent-sync.sh
@@ -65,7 +65,7 @@ WP_CMD=$(detect_wp_cmd) || exit 0
 # guarantees AGENTS.md (and any sibling composable files) match live state
 # at the moment the coding-agent session starts.
 
-$WP_CMD datamachine agent compose >/dev/null 2>&1 || true
+$WP_CMD datamachine memory compose >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
 # Query active agents from Data Machine

--- a/kimaki/plugins/dm-agent-sync.ts
+++ b/kimaki/plugins/dm-agent-sync.ts
@@ -48,7 +48,7 @@ const dmAgentSync: Plugin = async ({ $ }) => {
         // edits, or other external processes would leave AGENTS.md stale.
         // Running compose here guarantees the file matches live state at the
         // moment OpenCode loads the session prompt.
-        await $`wp datamachine agent compose --allow-root 2>/dev/null`.quiet().nothrow();
+        await $`wp datamachine memory compose --allow-root 2>/dev/null`.quiet().nothrow();
 
         // Query all agents from Data Machine.
         const agentsRaw = await $`wp datamachine agents list --format=json --allow-root 2>/dev/null`.quiet().nothrow().text();

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -231,7 +231,7 @@ runtime_generate_instructions() {
   # Compose from Data Machine's SectionRegistry. DM is mandatory, so this is
   # the only source of truth for AGENTS.md content.
   if [ "$DRY_RUN" = false ]; then
-    if wp_cmd datamachine agent compose AGENTS.md 2>/dev/null; then
+    if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
       log "AGENTS.md composed from SectionRegistry"
       return
     fi

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -351,7 +351,7 @@ runtime_generate_instructions() {
   # handles WP-CLI prefix resolution, multisite detection, and plugin sections
   # (intelligence, etc.) automatically at runtime.
   if [ "$DRY_RUN" = false ]; then
-    if wp_cmd datamachine agent compose AGENTS.md 2>/dev/null; then
+    if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
       log "AGENTS.md composed from SectionRegistry"
       return
     fi

--- a/runtimes/studio-code.sh
+++ b/runtimes/studio-code.sh
@@ -300,7 +300,7 @@ runtime_generate_instructions() {
 
   # Compose from Data Machine's SectionRegistry. DM is mandatory.
   if [ "$DRY_RUN" = false ]; then
-    if wp_cmd datamachine agent compose AGENTS.md 2>/dev/null; then
+    if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
       log "AGENTS.md composed from SectionRegistry"
       return
     fi

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -147,7 +147,7 @@ These work in both VPS and local mode:
 
 - `--kimaki-only` — only sync the chat-bridge config (name kept for backwards compatibility — also handles cc-connect and telegram when they are the detected bridge)
 - `--skills-only` — only refresh agent skills (WordPress/agent-skills + Extra-Chill/data-machine-skills)
-- `--agents-md-only` — only regenerate AGENTS.md via `datamachine agent compose`
+- `--agents-md-only` — only regenerate AGENTS.md via `datamachine memory compose`
 
 ## Never do
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -737,7 +737,7 @@ regenerate_agents_md() {
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would backup $AGENTS_MD → $BACKUP"
-    echo -e "${BLUE}[dry-run]${NC} Would run: $WP_CMD datamachine agent compose AGENTS.md $WP_ROOT_FLAG"
+    echo -e "${BLUE}[dry-run]${NC} Would run: $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG"
     return 0
   fi
 
@@ -747,10 +747,10 @@ regenerate_agents_md() {
     log "  Backup: $BACKUP"
   fi
 
-  # `datamachine agent compose AGENTS.md` writes in-place to the registered
+  # `datamachine memory compose AGENTS.md` writes in-place to the registered
   # composable file path. It does NOT accept an arbitrary output path —
   # the filename must be a registered MemoryFileRegistry entry.
-  if (cd "$SITE_PATH" && $WP_CMD datamachine agent compose AGENTS.md $WP_ROOT_FLAG >/dev/null 2>&1); then
+  if (cd "$SITE_PATH" && $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG >/dev/null 2>&1); then
     if [ -f "$BACKUP" ] && cmp -s "$BACKUP" "$AGENTS_MD"; then
       log "  AGENTS.md unchanged"
       rm -f "$BACKUP" 2>/dev/null || true
@@ -763,7 +763,7 @@ regenerate_agents_md() {
       UPDATED_ITEMS+=("AGENTS.md")
     fi
   else
-    warn "  datamachine agent compose failed — AGENTS.md unchanged"
+    warn "  datamachine memory compose failed — AGENTS.md unchanged"
     # Restore from backup if compose wrote a partial file
     if [ -f "$BACKUP" ] && [ -f "$AGENTS_MD" ] && ! cmp -s "$BACKUP" "$AGENTS_MD"; then
       cp "$BACKUP" "$AGENTS_MD"


### PR DESCRIPTION
## Summary

Every callsite that regenerates `AGENTS.md` was running `datamachine agent compose AGENTS.md` — but that subcommand doesn't exist on the `agent` group. The compose verb lives at `datamachine memory compose` (alongside `paths`/`read`/`write`/`search`, fixed in Extra-Chill/data-machine-code#63).

The result: every regeneration entry-point silently failed because the CLI errors out on `'compose' is not a registered subcommand of 'datamachine agent'`. The 2>/dev/null wrappers hid it. AGENTS.md only got regenerated when something else (e.g. the Intelligence setup script directly invoking `compose`, also wrong but accidentally hitting the same failure path) happened to run.

Caught while doing a full audit of intelligence's setup scaffolding for staleness.

## Changes

10 callsites across 7 files:

- `upgrade.sh` — 4 occurrences (dry-run echo, in-place compose call, descriptive comment, failure warn)
- `runtimes/claude-code.sh` — first-run AGENTS.md regeneration after Phase 5
- `runtimes/studio-code.sh` — same
- `runtimes/opencode.sh` — same
- `hooks/dm-agent-sync.sh` — Claude Code `SessionStart` hook
- `kimaki/plugins/dm-agent-sync.ts` — kimaki `dm-agent-sync` plugin (used when running through kimaki, not Claude Code)
- `skills/upgrade-wp-coding-agents/SKILL.md` — operator instructions for `--agents-md-only`

Pure mechanical s/agent compose/memory compose/g.

## Verification

```
$ studio wp datamachine memory compose AGENTS.md --user=1
Success: Regenerated AGENTS.md at /wordpress/AGENTS.md (6 sections).

$ studio wp datamachine agent compose --help
Error: 'compose' is not a registered subcommand of 'datamachine agent'.
```

## Companion fixes

- Extra-Chill/data-machine-code#71 — same fix in DMC's convention copy header + `MemoryFileRegistry` description (the upstream that taught every consumer the wrong verb name).
- Automattic/intelligence (forthcoming) — `setup/setup.sh` + `setup/adapters/wporg.sh` had the same pair of callsites; folded into the broader Intelligence audit PR.

## Tests

No tests added — this is a mechanical CLI verb rename across user-facing scripts. Manually verified the regeneration command succeeds against live data-machine v0.82.x.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the patch and PR body. Chris confirmed the audit scope (intelligence + DMC + wp-coding-agents in one coordinated pass), Claude found the 10 callsites and verified the right verb against the running CLI.