### PR TITLE
fix(kimaki): prepend node bin dir on launchd PATH for nvm installs

### DIFF
--- a/lib/chat-bridge.sh
+++ b/lib/chat-bridge.sh
@@ -89,11 +89,13 @@ _install_kimaki_systemd() {
     KIMAKI_BIN=$(which kimaki 2>/dev/null || echo "/usr/bin/kimaki")
   fi
 
-  local KIMAKI_BIN_DIR
+  local KIMAKI_BIN_DIR NODE_BIN_DIR PATH_VALUE
   KIMAKI_BIN_DIR=$(dirname "$KIMAKI_BIN")
+  NODE_BIN_DIR=$(_resolve_node_bin_dir "$KIMAKI_BIN")
+  PATH_VALUE=$(_compose_path_value "$KIMAKI_BIN_DIR" "$NODE_BIN_DIR" /usr/local/bin /usr/bin /bin)
 
   local ENV_BLOCK="Environment=HOME=$SERVICE_HOME
-Environment=PATH=$KIMAKI_BIN_DIR:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR"
   if [ -n "$KIMAKI_BOT_TOKEN" ]; then
     ENV_BLOCK="$ENV_BLOCK

--- a/lib/chat-bridges.sh
+++ b/lib/chat-bridges.sh
@@ -52,6 +52,94 @@
 # ---------------------------------------------------------------------------
 
 # ===========================================================================
+# Path helpers — resolve binaries that the chat bridge's child processes need
+# at runtime (node for kimaki plugins, etc.) and assemble PATH strings without
+# duplicates so the rendered launchd / systemd files stay clean.
+# ===========================================================================
+
+# _resolve_node_bin_dir [<kimaki-bin-hint>]
+#
+# Prints the directory containing `node` to stdout, or empty if none found.
+# launchd inherits a minimal PATH, so plugins shelling out via `#!/usr/bin/env
+# node` need the node bin dir baked into the rendered plist. nvm users
+# install node under ~/.nvm/versions/node/<v>/bin/, which neither homebrew nor
+# /usr/local/bin/ cover — that gap is the bug this helper closes (#73).
+#
+# Resolution order:
+#   1. `command -v node` in the renderer's interactive shell.
+#   2. The node baked into the kimaki shim itself (parses `exec '<node>' …`
+#      from the shim's first non-shebang line).
+#   3. Empty — caller falls back to its existing PATH and warns.
+_resolve_node_bin_dir() {
+  local kimaki_hint="${1:-}"
+  local node_path=""
+
+  if command -v node >/dev/null 2>&1; then
+    node_path="$(command -v node)"
+  elif [ -n "$kimaki_hint" ] && [ -f "$kimaki_hint" ]; then
+    # Shim looks like:
+    #   #!/bin/sh
+    #   exec '/path/to/node' '--flag' … '/path/to/kimaki.js' "$@"
+    # Walk space-separated tokens on the `exec` line and pick the first
+    # single-quoted absolute path ending in /node. Pure bash so the helper
+    # works under launchd / minimal-PATH contexts where coreutils may be
+    # absent — only the shell's own builtins (read, case, IFS) are used.
+    local exec_line token stripped
+    while IFS= read -r exec_line; do
+      case "$exec_line" in
+        exec\ *)
+          # shellcheck disable=SC2086
+          set -- $exec_line
+          shift  # drop leading "exec"
+          for token in "$@"; do
+            stripped="${token#\'}"
+            stripped="${stripped%\'}"
+            case "$stripped" in
+              */node)
+                node_path="$stripped"
+                break
+                ;;
+            esac
+          done
+          break
+          ;;
+      esac
+    done < "$kimaki_hint"
+  fi
+
+  [ -n "$node_path" ] || return 0
+  [ -x "$node_path" ] || return 0
+  # Pure bash dirname so the helper works in minimal-PATH contexts.
+  local dir="${node_path%/*}"
+  [ -n "$dir" ] || dir="/"
+  printf '%s' "$dir"
+}
+
+# _compose_path_value <dir1> [<dir2> …]
+#
+# Joins directories into a colon-separated PATH value, dropping duplicates and
+# empties while preserving the first-occurrence order. Used by the launchd
+# renderer so prepending the node bin dir doesn't shadow homebrew/system paths
+# or generate `dir::dir` strings when the kimaki and node bins live in the
+# same directory (the pre-PR-#73 npm-global world).
+_compose_path_value() {
+  local seen="" out="" dir
+  for dir in "$@"; do
+    [ -n "$dir" ] || continue
+    case ":$seen:" in
+      *":$dir:"*) continue ;;
+    esac
+    seen="$seen:$dir"
+    if [ -z "$out" ]; then
+      out="$dir"
+    else
+      out="$out:$dir"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+# ===========================================================================
 # Registry — bridge identity data
 # ===========================================================================
 
@@ -298,8 +386,10 @@ bridge_render_launchd() {
 _render_launchd_kimaki() {
   local label="$1"
   [ "$label" = "com.wp.kimaki" ] || { echo "kimaki has no label '$label'" >&2; return 1; }
-  local kimaki_bin_dir
+  local kimaki_bin_dir node_bin_dir path_value
   kimaki_bin_dir="$(dirname "$KIMAKI_BIN")"
+  node_bin_dir="$(_resolve_node_bin_dir "$KIMAKI_BIN")"
+  path_value="$(_compose_path_value "$kimaki_bin_dir" "$node_bin_dir" /opt/homebrew/bin /usr/local/bin /usr/bin /bin)"
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -326,7 +416,7 @@ _render_launchd_kimaki() {
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>$kimaki_bin_dir:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>$path_value</string>
         <key>KIMAKI_DATA_DIR</key>
         <string>$KIMAKI_DATA_DIR</string>$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
         <key>KIMAKI_BOT_TOKEN</key>

--- a/tests/bridge-render.sh
+++ b/tests/bridge-render.sh
@@ -126,10 +126,12 @@ capture_old_multi_setup() {
 # Helpers for rebuilding env blocks equivalent to the legacy installers
 # ---------------------------------------------------------------------------
 kimaki_env_block() {
-  local kimaki_bin_dir
+  local kimaki_bin_dir node_bin_dir path_value
   kimaki_bin_dir=$(dirname "$KIMAKI_BIN")
+  node_bin_dir=$(_resolve_node_bin_dir "$KIMAKI_BIN")
+  path_value=$(_compose_path_value "$kimaki_bin_dir" "$node_bin_dir" /usr/local/bin /usr/bin /bin)
   local out="Environment=HOME=$SERVICE_HOME
-Environment=PATH=$kimaki_bin_dir:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=$path_value
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR"
   if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then
     out="$out

--- a/tests/path-helpers.sh
+++ b/tests/path-helpers.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# tests/path-helpers.sh — unit tests for _resolve_node_bin_dir and
+# _compose_path_value in lib/chat-bridges.sh.
+#
+# These helpers compose the PATH baked into kimaki's launchd plist /
+# systemd unit. Bug repro for nvm-managed installs: when KIMAKI_BIN points
+# at a standalone shim (e.g. ~/.kimaki/bin/kimaki) whose dir does NOT contain
+# `node`, plugins shelling out via #!/usr/bin/env node fail with
+# "env: node: No such file or directory" because launchd inherits a
+# minimal PATH. _resolve_node_bin_dir closes that gap; _compose_path_value
+# keeps the rendered PATH free of duplicates and empties.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+# shellcheck disable=SC1091
+source lib/chat-bridges.sh
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  ok   $label"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL $label"
+    echo "       expected: '$expected'"
+    echo "       actual:   '$actual'"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# ---------------------------------------------------------------------------
+# _compose_path_value — pure string composition, no filesystem
+# ---------------------------------------------------------------------------
+echo "==> _compose_path_value"
+
+assert_eq "single dir" \
+  "/opt/bin" \
+  "$(_compose_path_value /opt/bin)"
+
+assert_eq "two distinct dirs" \
+  "/opt/bin:/usr/bin" \
+  "$(_compose_path_value /opt/bin /usr/bin)"
+
+assert_eq "drops duplicate (npm-global case: kimaki and node share dir)" \
+  "/usr/bin:/bin" \
+  "$(_compose_path_value /usr/bin /usr/bin /bin)"
+
+assert_eq "drops empty entries (no node found)" \
+  "/opt/kimaki/bin:/usr/bin:/bin" \
+  "$(_compose_path_value /opt/kimaki/bin "" /usr/bin /bin)"
+
+assert_eq "preserves first-occurrence order" \
+  "/a:/b:/c" \
+  "$(_compose_path_value /a /b /c /a /b)"
+
+assert_eq "all empty" \
+  "" \
+  "$(_compose_path_value "" "" "")"
+
+# ---------------------------------------------------------------------------
+# _resolve_node_bin_dir — depends on filesystem state
+# ---------------------------------------------------------------------------
+echo "==> _resolve_node_bin_dir"
+
+# Build a fake nvm-style layout: shim at .kimaki/bin/kimaki that exec's
+# a node that lives elsewhere (e.g. ~/.nvm/versions/node/v24/bin/node).
+NVM_BIN_DIR="$TMPDIR_TEST/nvm/versions/node/v24/bin"
+KIMAKI_SHIM_DIR="$TMPDIR_TEST/kimaki/bin"
+mkdir -p "$NVM_BIN_DIR" "$KIMAKI_SHIM_DIR"
+
+# Fake node — must be executable so `[ -x ]` passes.
+cat > "$NVM_BIN_DIR/node" <<'EOF'
+#!/bin/sh
+echo "fake node"
+EOF
+chmod +x "$NVM_BIN_DIR/node"
+
+# Fake kimaki shim — same shape as the real one (exec '<node>' … '<entrypoint>')
+cat > "$KIMAKI_SHIM_DIR/kimaki" <<EOF
+#!/bin/sh
+exec '$NVM_BIN_DIR/node' '--heapsnapshot-near-heap-limit=3' '$NVM_BIN_DIR/kimaki' "\$@"
+EOF
+chmod +x "$KIMAKI_SHIM_DIR/kimaki"
+
+# Test 1: kimaki shim resolution path. Force `command -v node` to miss by
+# stripping PATH so the helper falls back to parsing the shim.
+saved_path="$PATH"
+PATH="/nonexistent"
+assert_eq "follows kimaki shim when no node on PATH (nvm case)" \
+  "$NVM_BIN_DIR" \
+  "$(_resolve_node_bin_dir "$KIMAKI_SHIM_DIR/kimaki")"
+PATH="$saved_path"
+
+# Test 2: command -v wins when node IS on PATH.
+PATH="$NVM_BIN_DIR:$saved_path"
+assert_eq "uses command -v when node is on PATH" \
+  "$NVM_BIN_DIR" \
+  "$(_resolve_node_bin_dir "$KIMAKI_SHIM_DIR/kimaki")"
+PATH="$saved_path"
+
+# Test 3: missing shim, no node on PATH → empty.
+PATH="/nonexistent"
+assert_eq "empty when no node anywhere" \
+  "" \
+  "$(_resolve_node_bin_dir "/no/such/kimaki")"
+PATH="$saved_path"
+
+# Test 4: shim that exec's a non-existent node → empty (passes -x check).
+BROKEN_SHIM="$TMPDIR_TEST/broken/kimaki"
+mkdir -p "$(dirname "$BROKEN_SHIM")"
+cat > "$BROKEN_SHIM" <<'EOF'
+#!/bin/sh
+exec '/no/such/node' '/no/such/kimaki.js' "$@"
+EOF
+chmod +x "$BROKEN_SHIM"
+PATH="/nonexistent"
+assert_eq "empty when shim references missing node binary" \
+  "" \
+  "$(_resolve_node_bin_dir "$BROKEN_SHIM")"
+PATH="$saved_path"
+
+# Test 5: no hint argument at all — relies on `command -v node` only.
+PATH="$NVM_BIN_DIR:$saved_path"
+assert_eq "no-hint: uses command -v" \
+  "$NVM_BIN_DIR" \
+  "$(_resolve_node_bin_dir)"
+PATH="$saved_path"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAILED: $FAIL of $((PASS+FAIL)) assertion(s)"
+  exit 1
+fi
+echo "OK: $PASS / $PASS assertions passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -952,12 +952,17 @@ _update_kimaki_systemd() {
   local KIMAKI_BIN
   KIMAKI_BIN=$(which kimaki 2>/dev/null || echo "/usr/bin/kimaki")
   local KIMAKI_CONFIG_DIR="/opt/kimaki-config"
-  local KIMAKI_BIN_DIR
+  local KIMAKI_BIN_DIR NODE_BIN_DIR PATH_VALUE
   KIMAKI_BIN_DIR=$(dirname "$KIMAKI_BIN")
+  NODE_BIN_DIR=$(_resolve_node_bin_dir "$KIMAKI_BIN")
+  PATH_VALUE=$(_compose_path_value "$KIMAKI_BIN_DIR" "$NODE_BIN_DIR" /usr/local/bin /usr/bin /bin)
   CURRENT_ENV=$(_ensure_systemd_path_contains "$CURRENT_ENV" "$KIMAKI_BIN_DIR")
+  if [ -n "$NODE_BIN_DIR" ]; then
+    CURRENT_ENV=$(_ensure_systemd_path_contains "$CURRENT_ENV" "$NODE_BIN_DIR")
+  fi
 
   local TEMPLATE_ENV="Environment=HOME=$SERVICE_HOME
-Environment=PATH=$KIMAKI_BIN_DIR:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR"
 
   local MERGED_ENV


### PR DESCRIPTION
## Summary

PR #68 prepended `dirname(KIMAKI_BIN)` to the launchd plist's `PATH` so kimaki could find its own binary at runtime. PR #70 then relocated `KIMAKI_BIN` from `~/.nvm/.../bin/kimaki` to a stable shim at `~/.kimaki/bin/kimaki` — but `~/.kimaki/bin/` doesn't ship a sibling `node`. On nvm-managed Macs that broke every plugin or subprocess that shells out via `#!/usr/bin/env node` because launchd inherits a minimal PATH and `node` lives only under `~/.nvm/versions/node/<v>/bin/`.

Symptom on the upgraded host (intelligence-chubes4):

```
$ tail ~/.kimaki/kimaki.error.log
env: node: No such file or directory
env: node: No such file or directory
…
```

Repros on every nvm-managed install after running `./upgrade.sh` and bootstrapping the new plist.

## Fix

Two new helpers in `lib/chat-bridges.sh`:

- **`_resolve_node_bin_dir [<kimaki-shim-hint>]`** — returns the directory containing `node`, or empty.
  1. Try `command -v node` (works on the install machine where the upgrade script runs, even when launchd later inherits a minimal PATH because the value is baked into the rendered plist).
  2. Fall back to parsing the kimaki shim's `exec '<node>' …` line in **pure bash** so the helper works in minimal-PATH contexts where `dirname` / `awk` / `grep` may be absent.
  3. Empty when no node anywhere — caller falls back gracefully.

- **`_compose_path_value <dir1> [<dir2> …]`** — joins dirs into a colon-separated PATH, dropping empties and duplicates while preserving first-occurrence order. Keeps the rendered string clean when kimaki and node share a directory (the pre-PR-#68 npm-global world).

Wired into the three places that compose the kimaki PATH:

| File | Function | Path |
|---|---|---|
| `lib/chat-bridges.sh` | `_render_launchd_kimaki` | install + upgrade |
| `lib/chat-bridge.sh` | `_install_kimaki_systemd` | VPS install |
| `upgrade.sh` | `_update_kimaki_systemd` | VPS upgrade |

When the node bin dir differs from the kimaki bin dir (the new `~/.kimaki/bin/kimaki` + `~/.nvm/.../bin/node` world) **both** dirs land on PATH. When they match (npm-global), the duplicate is dropped so the rendered file stays byte-identical to the pre-fix output.

## Tests

- **`tests/path-helpers.sh` (new)** — 11 assertions covering both helpers across npm-global, nvm shim parsing, missing-node fallback, broken-shim fallback, and the no-hint code path. Tests deliberately set `PATH=/nonexistent` to confirm the helpers don't depend on coreutils.
- **`tests/bridge-render.sh`** — updated to call the same helpers in `kimaki_env_block`, so the byte-equivalence guard between the legacy installers and the new generators still holds (8/8 snapshots green).

```
$ ./tests/path-helpers.sh
==> _compose_path_value
  ok   single dir
  ok   two distinct dirs
  ok   drops duplicate (npm-global case: kimaki and node share dir)
  ok   drops empty entries (no node found)
  ok   preserves first-occurrence order
  ok   all empty
==> _resolve_node_bin_dir
  ok   follows kimaki shim when no node on PATH (nvm case)
  ok   uses command -v when node is on PATH
  ok   empty when no node anywhere
  ok   empty when shim references missing node binary
  ok   no-hint: uses command -v
OK: 11 / 11 assertions passed

$ ./tests/bridge-render.sh
==> diffs
  ok   cc-connect-launchd
  ok   cc-connect-systemd
  ok   kimaki-launchd
  ok   kimaki-systemd
  ok   telegram-bot-launchd
  ok   telegram-bot-systemd
  ok   telegram-serve-launchd
  ok   telegram-serve-systemd
OK: all snapshots byte-identical
```

## End-to-end verification

On `intelligence-chubes4` (Studio, macOS, nvm-managed node), simulating a clean machine with `PATH=/opt/homebrew/bin:/usr/bin:/bin`:

```
Before this PR (just PR #68 + #70):
  <string>/Users/chubes/.kimaki/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
  → plugin spawns 'env node' → ENOENT, env: node: No such file or directory

After this PR:
  <string>/Users/chubes/.kimaki/bin:/Users/chubes/.nvm/versions/node/v24.13.1/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
  → plugin spawns 'env node' → resolves correctly
```

## Out of scope

- Doesn't touch the cc-connect or telegram bridges — only kimaki spawns Node subprocesses that go through `#!/usr/bin/env node`. cc-connect's binary path resolution is fine as-is.
- Doesn't add a `--node-bin` override flag. If anyone needs to force a specific node (Volta, fnm, asdf), a follow-up could expose `NODE_BIN` env override; for now the auto-detection covers nvm + homebrew + npm-global, which is every install pattern we ship today.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted the helpers, the bash-pure shim parser, the test fixture, and this PR body. Chris reviewed each edit, ran the full test suite, and verified the rendered plist on the live install before merging.
