### PR TITLE
fix(kimaki): strip agent override minion examples

### DIFF
--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -29,6 +29,10 @@
 //    examples that survive section stripping. These let the agent discover
 //    other Discord channels and route minion sessions away from the current
 //    thread. See Extra-Chill/data-machine-code#49.
+// 12. Agent override inlines — `--agent <current_agent>` examples from the
+//    generic Kimaki prompt. On DM-managed sites the Discord channel owns the
+//    personal-agent binding; passing the runtime agent (for example `opencode`)
+//    bypasses that binding and starts the wrong kind of minion session.
 //
 // What it injects into the system prompt:
 // - `## Minion Session Routing` — positive instruction telling the agent that
@@ -71,6 +75,8 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "## cross-project commands");
         result = stripSection(result, "## reading other sessions");
         result = stripSection(result, "## waiting for a session to finish");
+        result = stripSection(result, "## running opencode commands via kimaki send");
+        result = stripSection(result, "## switching agents in the current session");
         result = stripSection(result, "## showing diffs");
         result = stripSection(result, "## about critique");
         result = stripSection(result, "### always show diff at end of session");
@@ -78,6 +84,7 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "### reviewing diffs with AI");
         result = stripWorktreeInlines(result);
         result = stripProjectDiscoveryInlines(result);
+        result = stripAgentOverrideInlines(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");
         // Append positive routing instruction so the agent never tries to
@@ -300,6 +307,38 @@ function stripProjectDiscoveryInlines(block: string): string {
 }
 
 /**
+ * Remove generic Kimaki agent override examples from surviving sections.
+ *
+ * On Data Machine-managed sites the Discord channel selects the personal
+ * agent. Passing `--agent <current_agent>` teaches the runtime agent to turn
+ * the synthetic reminder value (often `opencode`) into a real session routing
+ * override, bypassing the channel-bound Franklin agent.
+ */
+function stripAgentOverrideInlines(block: string): string {
+  let result = block;
+
+  // Delete the generic instruction that recommends passing the current runtime
+  // agent to spawned sessions.
+  result = result.replace(
+    /\n+Prefer passing the current agent with `--agent <current_agent>`[^\n]*\n/g,
+    "\n"
+  );
+
+  // Remove the generic "pick an agent" example from the surviving start-new-
+  // sessions section; normal minions should rely on the channel binding.
+  result = result.replace(
+    /\n+Use --agent to specify which agent to use for the session:[\s\S]*?\nkimaki send --channel [^\n]* --agent [^\n]*\n/g,
+    "\n"
+  );
+
+  // Surviving `kimaki send` examples should rely on channel routing. This
+  // keeps examples usable while removing the footgun.
+  result = result.replace(/ --agent <current_agent>/g, "");
+
+  return result;
+}
+
+/**
  * Append a positive minion-session routing instruction.
  *
  * Stripping alone is not enough: the agent can still learn channel IDs from
@@ -316,6 +355,8 @@ function appendMinionRoutingInstruction(block: string): string {
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run \`kimaki project list\`, \`kimaki project add\`, \`kimaki project create\`, or \`kimaki send --project\` — those are cross-project discovery commands that route sessions to other agents' channels.
+
+Do not pass \`--agent\` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example \`--agent opencode\`) bypasses the channel binding and starts the wrong kind of session.
 
 If a minion needs to work in a different repo directory, use \`kimaki send --cwd /path/to/repo\` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (\`studio wp datamachine-code workspace worktree add <repo> <branch>\`) — the worktree becomes the \`--cwd\` target for any follow-up minion session.
 `;

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -49,55 +49,33 @@ This returns user IDs you can use for Discord mentions.
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt "follow-up prompt"
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --session <session_id> --prompt "follow-up prompt"
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
 
 Use --user to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --agent <current_agent> --user "chubes"
-
-Use --agent to specify which agent to use for the session:
-
-kimaki send --channel 1493345787894038649 --prompt "Plan the refactor of the auth module" --agent plan --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
 
 Available agents:
 - `build`: default coding agent
 - `plan`: planning agent
-
-## running opencode commands via kimaki send
-
-You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
-
-kimaki send --thread <thread_id> --prompt "/review fix the auth module" --agent <current_agent>
-kimaki send --channel 1493345787894038649 --prompt "/build-cmd update dependencies" --agent <current_agent> --user "chubes"
-
-The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
-
-## switching agents in the current session
-
-The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
-
-You can also switch agents via `kimaki send`:
-
-kimaki send --thread <thread_id> --prompt "/<agentname>-agent" --agent <current_agent>
 
 # List all registered projects with their channel IDs
 kimaki project list --json  # machine-readable output
@@ -125,7 +103,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt "Run the tests" --wait --agent <current_agent>
+kimaki send --thread <thread_id> --prompt "Run the tests" --wait
 ```
 
 The command exits with the session markdown on stdout once the model finishes responding.
@@ -350,5 +328,7 @@ intelligence-chubes4 personal agent
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+
+Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
 
 If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -49,55 +49,33 @@ This returns user IDs you can use for Discord mentions.
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt "follow-up prompt"
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --session <session_id> --prompt "follow-up prompt"
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
 
 Use --user to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --agent <current_agent> --user "chubes"
-
-Use --agent to specify which agent to use for the session:
-
-kimaki send --channel 1493345787894038649 --prompt "Plan the refactor of the auth module" --agent plan --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
 
 Available agents:
 - `build`: default coding agent
 - `plan`: planning agent
-
-## running opencode commands via kimaki send
-
-You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
-
-kimaki send --thread <thread_id> --prompt "/review fix the auth module" --agent <current_agent>
-kimaki send --channel 1493345787894038649 --prompt "/build-cmd update dependencies" --agent <current_agent> --user "chubes"
-
-The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
-
-## switching agents in the current session
-
-The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
-
-You can also switch agents via `kimaki send`:
-
-kimaki send --thread <thread_id> --prompt "/<agentname>-agent" --agent <current_agent>
 
 ## submodules
 
@@ -242,5 +220,7 @@ intelligence-chubes4 personal agent
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+
+Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
 
 If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -47,51 +47,29 @@ This returns user IDs you can use for Discord mentions.
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt "follow-up prompt"
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --session <session_id> --prompt "follow-up prompt"
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
 
 Use --user to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --agent <current_agent> --user "chubes"
-
-Use --agent to specify which agent to use for the session:
-
-kimaki send --channel 1493345787894038649 --prompt "Plan the refactor of the auth module" --agent plan --user "chubes"
-
-## running opencode commands via kimaki send
-
-You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
-
-kimaki send --thread <thread_id> --prompt "/review fix the auth module" --agent <current_agent>
-kimaki send --channel 1493345787894038649 --prompt "/build-cmd update dependencies" --agent <current_agent> --user "chubes"
-
-The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
-
-## switching agents in the current session
-
-The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
-
-You can also switch agents via `kimaki send`:
-
-kimaki send --thread <thread_id> --prompt "/<agentname>-agent" --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
 
 # List all registered projects with their channel IDs
 kimaki project list --json  # machine-readable output
@@ -119,7 +97,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt "Run the tests" --wait --agent <current_agent>
+kimaki send --thread <thread_id> --prompt "Run the tests" --wait
 ```
 
 The command exits with the session markdown on stdout once the model finishes responding.
@@ -340,5 +318,7 @@ Examples:
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+
+Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
 
 If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -47,51 +47,29 @@ This returns user IDs you can use for Discord mentions.
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt "follow-up prompt"
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --session <session_id> --prompt "follow-up prompt"
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
 
 Use --user to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --agent <current_agent> --user "chubes"
-
-Use --agent to specify which agent to use for the session:
-
-kimaki send --channel 1493345787894038649 --prompt "Plan the refactor of the auth module" --agent plan --user "chubes"
-
-## running opencode commands via kimaki send
-
-You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
-
-kimaki send --thread <thread_id> --prompt "/review fix the auth module" --agent <current_agent>
-kimaki send --channel 1493345787894038649 --prompt "/build-cmd update dependencies" --agent <current_agent> --user "chubes"
-
-The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
-
-## switching agents in the current session
-
-The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
-
-You can also switch agents via `kimaki send`:
-
-kimaki send --thread <thread_id> --prompt "/<agentname>-agent" --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
 
 ## submodules
 
@@ -232,5 +210,7 @@ Examples:
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+
+Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
 
 If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -73,12 +73,22 @@ function stripProjectDiscoveryInlines(block) {
   return result
 }
 
+function stripAgentOverrideInlines(block) {
+  let result = block
+  result = result.replace(/\n+Prefer passing the current agent with `--agent <current_agent>`[^\n]*\n/g, "\n")
+  result = result.replace(/\n+Use --agent to specify which agent to use for the session:[\s\S]*?\nkimaki send --channel [^\n]* --agent [^\n]*\n/g, "\n")
+  result = result.replace(/ --agent <current_agent>/g, "")
+  return result
+}
+
 function appendMinionRoutingInstruction(block) {
   const instruction = `
 
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run \`kimaki project list\`, \`kimaki project add\`, \`kimaki project create\`, or \`kimaki send --project\` — those are cross-project discovery commands that route sessions to other agents' channels.
+
+Do not pass \`--agent\` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example \`--agent opencode\`) bypasses the channel binding and starts the wrong kind of session.
 
 If a minion needs to work in a different repo directory, use \`kimaki send --cwd /path/to/repo\` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (\`studio wp datamachine-code workspace worktree add <repo> <branch>\`) — the worktree becomes the \`--cwd\` target for any follow-up minion session.
 `
@@ -96,6 +106,8 @@ function currentFilter(block) {
   r = stripSection(r, "## cross-project commands")
   r = stripSection(r, "## reading other sessions")
   r = stripSection(r, "## waiting for a session to finish")
+  r = stripSection(r, "## running opencode commands via kimaki send")
+  r = stripSection(r, "## switching agents in the current session")
   r = stripSection(r, "## showing diffs")
   r = stripSection(r, "## about critique")
   r = stripSection(r, "### always show diff at end of session")
@@ -103,6 +115,7 @@ function currentFilter(block) {
   r = stripSection(r, "### reviewing diffs with AI")
   r = stripWorktreeInlines(r)
   r = stripProjectDiscoveryInlines(r)
+  r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
   r = appendMinionRoutingInstruction(r)
   return r
@@ -134,6 +147,8 @@ function brokenFilter(block) {
   r = stripSectionBroken(r, "## cross-project commands")
   r = stripSectionBroken(r, "## reading other sessions")
   r = stripSectionBroken(r, "## waiting for a session to finish")
+  r = stripSectionBroken(r, "## running opencode commands via kimaki send")
+  r = stripSectionBroken(r, "## switching agents in the current session")
   r = stripSectionBroken(r, "## showing diffs")
   r = stripSectionBroken(r, "## about critique")
   r = stripSectionBroken(r, "### always show diff at end of session")
@@ -141,6 +156,7 @@ function brokenFilter(block) {
   r = stripSectionBroken(r, "### reviewing diffs with AI")
   r = stripWorktreeInlines(r)
   r = stripProjectDiscoveryInlines(r)
+  r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
   r = appendMinionRoutingInstruction(r)
   return r

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -74,6 +74,7 @@ const VERBOSE = args.includes("--verbose")
 const DEFAULT_TRIGGERS = [
   { name: "worktree", pattern: "(?i)worktree" },
   { name: "--cwd",    pattern: "--cwd"        },
+  { name: "--agent",  pattern: "--agent"      },
 ]
 
 const DEFAULT_ALLOW_LEAK_SECTIONS = [


### PR DESCRIPTION
## Summary
- Strip generic Kimaki `--agent <current_agent>` examples from Data Machine-managed prompts so minion sessions rely on the Discord channel's personal-agent binding.
- Remove opencode command/switch-agent prompt sections that teach runtime-agent overrides in this environment.
- Extend the effective-prompt harness to treat `--agent` as a leak and refresh snapshots.

## Why
On Franklin sessions, `<current_agent>` can resolve to the runtime agent (`opencode`). Passing that to `kimaki send` bypasses the channel-bound Franklin agent and starts the wrong kind of minion session.

## Tests
- `node tests/effective-prompt/run.mjs --update && node tests/effective-prompt/run.mjs`
- `bash tests/bridge-render.sh`
- `bash tests/path-helpers.sh`
- `bash tests/post-upgrade-restore.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the prompt-filter change, updated prompt snapshots, and ran local smoke tests. Chris reviewed the direction and remains responsible for the change.