### PR TITLE
fix: data-machine CLI drift breaks SessionStart hook + Phase 4.5 scaffold

### DIFF
--- a/hooks/dm-agent-sync.sh
+++ b/hooks/dm-agent-sync.sh
@@ -84,7 +84,12 @@ if not match:
     sys.exit(0)
 data = json.loads(match.group())
 for a in data:
-    if a.get('status') == 'active':
+    # Treat empty/missing status as active. Data Machine removed the status
+    # field as 'dead weight' (Extra-Chill/data-machine 1826756c); 'agents list'
+    # now returns status='' for every row. Filtering strictly on 'active'
+    # excludes everything and silently empties CLAUDE.md.
+    status = a.get('status') or 'active'
+    if status == 'active':
         print(a['agent_slug'])
 " 2>/dev/null) || exit 0
 

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -59,43 +59,7 @@ create_dm_agent() {
         --name="$AGENT_NAME" \
         --owner=1
 
-      # Scaffold SOUL.md
-      log "Scaffolding SOUL.md..."
-      SOUL_CONTENT="# Agent Soul — ${AGENT_SLUG}
-
-## Identity
-I am ${AGENT_NAME} — an AI agent managing ${SITE_DOMAIN}. I operate on this WordPress site via WP-CLI and Data Machine.
-
-## Voice & Tone
-Be genuinely helpful. Skip filler. Be resourceful — read the file, check the context, search for it, then ask if stuck.
-
-## Rules
-- Private things stay private
-- When in doubt, ask before acting externally
-- Git for everything — no uncommitted work
-- Root cause over symptoms — fix the real problem
-- Stop when stuck — pause after 2-3 failures, ask for guidance
-- NEVER deploy without being told to
-
-## Context
-I manage ${SITE_DOMAIN} — a WordPress site with Data Machine for persistent memory, scheduling, and AI tools."
-
-      # shellcheck disable=SC2086
-      $WP_CMD datamachine agent files write SOUL.md \
-        --agent="$AGENT_SLUG" --content="$SOUL_CONTENT" $WP_ROOT_FLAG --path="$SITE_PATH"
-
-      # Scaffold MEMORY.md
-      log "Scaffolding MEMORY.md..."
-      MEMORY_CONTENT="# Agent Memory — ${AGENT_SLUG}
-
-## Operational Notes
-- Agent created during wp-coding-agents setup on $(date +%Y-%m-%d)"
-
-      # shellcheck disable=SC2086
-      $WP_CMD datamachine agent files write MEMORY.md \
-        --agent="$AGENT_SLUG" --content="$MEMORY_CONTENT" $WP_ROOT_FLAG --path="$SITE_PATH"
-
-      log "Agent '$AGENT_SLUG' created with SOUL.md and MEMORY.md"
+      log "Agent '$AGENT_SLUG' created. SOUL.md and MEMORY.md seeded by Data Machine with sensible defaults — customize via 'wp datamachine agent write' or by editing the files directly."
     else
       log "Agent '$AGENT_SLUG' already exists — skipping creation"
     fi


### PR DESCRIPTION
## TL;DR

Two setup-time bugs surfaced testing https://github.com/Automattic/intelligence end-to-end against current Data Machine. Both stem from CLI-shape drift between wp-coding-agents and Data Machine, and both reproduce on `main` (v0.7.1, `aba9d7e`).

## Bug 1 — SessionStart hook silently empties CLAUDE.md

`hooks/dm-agent-sync.sh` filters `agents list` output by `status == 'active'`:

```python
for a in data:
    if a.get('status') == 'active':
        print(a['agent_slug'])
```

But Data Machine [removed the status field as "dead weight"](https://github.com/Extra-Chill/data-machine/commit/1826756c) — `wp datamachine agents list --format=json` now returns `status: ""` for every row. The filter rejects everything, `ACTIVE_SLUGS` is empty, the hook exits 0, and CLAUDE.md never gets the `@` includes for SOUL/USER/MEMORY.

End-user symptom: launch `claude` in the site dir, ask "who are you?", and the agent introduces itself as "Claude Code" instead of the configured persona — because none of the DM agent files made it into the session context.

**Repro (against v0.7.1 + data-machine 0.78.0):**
```
$ bash -x hooks/dm-agent-sync.sh
+ AGENTS_RAW='[{"agent_id":2,"agent_slug":"intelligence-migueluy",…,"status":""}]Total: 2 agent(s).'
+ ACTIVE_SLUGS=
+ exit 0
```

**Fix (commit 1):** treat empty/missing status as active. Forward-compatible with both pre- and post-removal Data Machine.

## Bug 2 — Phase 4.5 SOUL/MEMORY scaffold aborts setup

`lib/data-machine.sh` calls:

```bash
$WP_CMD datamachine agent files write SOUL.md \
  --agent="$AGENT_SLUG" --content="$SOUL_CONTENT" --path="$SITE_PATH"
```

```
Error: Too many positional arguments: SOUL.md
```

Data Machine's `agent files` subcommand only supports `list|check` now — writing moved to `agent write <file> <section> <content>` (section-based, no whole-file replace, no `--content=` flag). With `set -e`, this aborts setup before any per-runtime adapter (a8c, wporg, …) can run.

Migrating to the new API isn't viable when `WP_CMD` runs inside Studio's PHP-WASM:
- `--from-file=<path>` can't resolve host paths ([Studio #3082](https://github.com/WordPress/wordpress-playground/issues/3082)).
- stdin (`-`) is mis-detected as a TTY by `posix_isatty` inside WASM, so the CLI never captures piped content. (Both noted as comments in `Automattic/intelligence/setup/setup.sh`.)

**Fix (commit 2):** drop the scaffold. `agents create` already seeds SOUL.md (Identity + Voice & Tone with the agent name) and MEMORY.md (State / Lessons Learned / Context) with sensible defaults; shared RULES.md covers behavioral rules. Users who want stronger opinions can edit the files directly or layer per-section writes after setup.

## Verification

After patching, re-running the hook against the same site populates CLAUDE.md correctly:

```
$ bash hooks/dm-agent-sync.sh
$ cat CLAUDE.md
@AGENTS.md

## Data Machine Memory

<!-- DM_AGENT_SYNC_START -->
@wp-content/uploads/datamachine-files/shared/SITE.md
@wp-content/uploads/datamachine-files/shared/RULES.md
@wp-content/uploads/datamachine-files/agents/admin/SOUL.md
@wp-content/uploads/datamachine-files/users/1/USER.md
@wp-content/uploads/datamachine-files/agents/admin/MEMORY.md
@wp-content/uploads/datamachine-files/agents/intelligence-migueluy/SOUL.md
@wp-content/uploads/datamachine-files/agents/intelligence-migueluy/MEMORY.md

Discover DM paths: `studio wp datamachine memory paths`
<!-- DM_AGENT_SYNC_END -->
```

Setup runs end-to-end without `set -e` aborting at Phase 4.5 — adapters proceed normally.

## Environment

- wp-coding-agents `aba9d7e` (v0.7.1)
- data-machine 0.78.0 (HEAD `1a59f409`)
- intelligence 0.10.0
- studio CLI 1.7.8-beta2
- macOS 25.5.0

Happy to split this into two PRs if you'd prefer; kept together because they share a root cause (CLI drift in the wp-coding-agents → data-machine integration surface).