### PR TITLE
fix(kimaki): follow Data Machine memory CLI drift

### DIFF
--- a/bridges/kimaki/plugins/dm-agent-sync.ts
+++ b/bridges/kimaki/plugins/dm-agent-sync.ts
@@ -19,7 +19,7 @@ interface DmAgent {
   agent_slug: string;
   agent_name: string;
   owner_id: number;
-  status: string;
+  status?: string;
   agent_config?: {
     default_model?: string;
     tool_policy?: Record<string, boolean>;
@@ -65,12 +65,13 @@ const dmAgentSync: Plugin = async ({ $ }) => {
         if (!config.agent) config.agent = {};
 
         for (const agent of agents) {
-          if (agent.status !== "active") continue;
+          const status = agent.status || "active";
+          if (status !== "active") continue;
 
           // Get agent file paths.
           let paths: DmPaths;
           try {
-            paths = await $`wp datamachine agent paths --agent=${agent.agent_slug} --format=json --allow-root 2>/dev/null`.quiet().json();
+            paths = await $`wp datamachine memory paths --agent=${agent.agent_slug} --format=json --allow-root 2>/dev/null`.quiet().json();
           } catch {
             continue;
           }

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -59,7 +59,7 @@ create_dm_agent() {
         --name="$AGENT_NAME" \
         --owner=1
 
-      log "Agent '$AGENT_SLUG' created. SOUL.md and MEMORY.md seeded by Data Machine with sensible defaults — customize via 'wp datamachine agent write' or by editing the files directly."
+      log "Agent '$AGENT_SLUG' created. SOUL.md and MEMORY.md seeded by Data Machine with sensible defaults — customize via 'wp datamachine memory write' or by editing the files directly."
     else
       log "Agent '$AGENT_SLUG' already exists — skipping creation"
     fi


### PR DESCRIPTION
## Summary
- Mirrors PR #79's empty-status handling in the OpenCode/Kimaki agent sync plugin.
- Updates the plugin to call `wp datamachine memory paths`, which is the current Data Machine path-discovery command.
- Corrects the setup log message to point at `wp datamachine memory write` instead of the non-existent `agent write` command.

## Tests
- `bash -n lib/data-machine.sh hooks/dm-agent-sync.sh`
- `git diff --check`
- `homeboy audit wp-coding-agents --path /Users/chubes/Developer/wp-coding-agents@fix-opencode-dm-status-drift --changed-since origin/main`
- `homeboy lint wp-coding-agents --path /Users/chubes/Developer/wp-coding-agents@fix-opencode-dm-status-drift` (not configured: component has no extensions)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Follow-up review of PR #79, identifying the sibling OpenCode/Kimaki drift, drafting the patch, and running local checks. Chris remains responsible for review and merge.
