### PR TITLE
fix(setup): skip wp-env-based plugin builds when Docker is unavailable

### DIFF
--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -69,8 +69,21 @@ install_plugin_dependencies() {
     log "Building $slug JS assets..."
     run_cmd npm install --prefix "$plugin_dir" || \
       warn "npm install failed for $slug"
-    run_cmd npm run build --prefix "$plugin_dir" || \
-      warn "npm build failed for $slug — admin pages may not work"
+
+    # Some plugins' `npm run build` is a wp-env/Docker wrapper around steps
+    # we already ran natively (e.g. mcp-adapter's build is just `composer
+    # install` inside wp-env). Studio installs don't have Docker, so wp-env
+    # fails loudly on the canonical setup path. Skip the build in that
+    # case — the host-side composer install above already produced the
+    # runtime artifacts.
+    local build_script
+    build_script=$(jq -r '.scripts.build // ""' "$plugin_dir/package.json" 2>/dev/null)
+    if echo "$build_script" | grep -q "wp-env" && ! docker info &>/dev/null; then
+      log "Skipping $slug build — script requires wp-env (Docker daemon not reachable)."
+    else
+      run_cmd npm run build --prefix "$plugin_dir" || \
+        warn "npm build failed for $slug — admin pages may not work"
+    fi
   fi
 }
 


### PR DESCRIPTION
Closes #81.

## What

Detect when a plugin's `npm run build` script depends on `wp-env` and skip it when `docker info` can't reach the daemon. Falls back to the regular warn-on-failure path for plain `wp-scripts build` (unchanged for plugins like `data-machine`).

## Why

Phase 4 of `setup.sh` unconditionally runs `npm run build` on every plugin with a `package.json`. `mcp-adapter`'s build script is:

```
wp-env run tests-cli --env-cwd=… composer install --no-dev --optimize-autoloader
```

That's a wp-env/Docker wrapper around the composer install we already ran natively a few lines earlier in `install_plugin_dependencies`. On Studio installs (canonical local-dev target per the README) Docker isn't available, and the build fails loudly:

```
ℹ Starting 'composer install --no-dev --optimize-autoloader' on the tests-cli container.
open /Users/miguel/.wp-env/<hash>/docker-compose.yml: no such file or directory
✖ Command failed with exit code 1
[wp-coding-agents] npm build failed for mcp-adapter — admin pages may not work
```

Setup completes (the failure is non-fatal) but the user sees an alarming error message on the canonical setup path and wonders if something is broken. Skipping a build that can't run is friendlier than failing it — and lossless, because the host-side composer install above already produced the runtime artifacts mcp-adapter actually needs.

## Diff

`lib/wordpress.sh` — `install_plugin_dependencies` gains one conditional branch around the existing `npm run build` call. +15 / -2.

```diff
+    local build_script
+    build_script=\$(jq -r '.scripts.build // ""' "\$plugin_dir/package.json" 2>/dev/null)
+    if echo "\$build_script" | grep -q "wp-env" && ! docker info &>/dev/null; then
+      log "Skipping \$slug build — script requires wp-env (Docker daemon not reachable)."
+    else
       run_cmd npm run build --prefix "\$plugin_dir" || \
         warn "npm build failed for \$slug — admin pages may not work"
+    fi
```

## Tested

Verified the gate logic against the live install at `~/Studio/intelligence-migueluy/wp-content/plugins/mcp-adapter` — `docker info` returns non-zero, build script contains `wp-env`, branch lands in the SKIP arm. `bash -n` syntax check clean.

Discovered while testing https://github.com/Automattic/intelligence end-to-end on a fresh Studio site.