### PR TITLE
fix(setup): retry-with-backoff git clones, force HTTPS for setup deps

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -29,3 +29,44 @@ write_file() {
     echo "$content" > "$file_path"
   fi
 }
+
+# Robust git clone for setup-time plugin/skill deps:
+#   - Pins HTTP/1.1 to dodge intermittent GitHub HTTP/2 500s seen during
+#     fresh setup runs.
+#   - Rewrites SSH-style URLs (git@github.com:…) to HTTPS so users with
+#     `gh auth status` reporting `Git operations protocol: ssh` but no SSH
+#     key registered don't hit cryptic `Permission denied (publickey)`.
+#   - Retries with exponential backoff (default 3 attempts: 2s, 4s, 8s)
+#     and cleans up partial directories between attempts.
+#
+# Usage: git_clone_with_retry <url> <dir> [extra git-clone args…]
+git_clone_with_retry() {
+  local url="$1"
+  local dir="$2"
+  shift 2 || true
+  local max_attempts=3
+  local delay=2
+  local attempt
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} git clone $url $dir $* (with HTTPS rewrite + HTTP/1.1 + retry)"
+    return 0
+  fi
+
+  for attempt in $(seq 1 "$max_attempts"); do
+    if git \
+        -c http.version=HTTP/1.1 \
+        -c "url.https://github.com/.insteadOf=git@github.com:" \
+        clone "$@" "$url" "$dir"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      warn "Clone of $url failed (attempt $attempt/$max_attempts); retrying in ${delay}s..."
+      rm -rf "$dir"
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+  done
+  warn "Clone of $url failed after $max_attempts attempts."
+  return 1
+}

--- a/lib/skills.sh
+++ b/lib/skills.sh
@@ -14,7 +14,8 @@ install_skills_from_repo() {
 
   local tmp_dir
   tmp_dir=$(mktemp -d)
-  if git clone --depth 1 "$repo_url" "$tmp_dir" 2>/dev/null; then
+  rmdir "$tmp_dir" 2>/dev/null || true  # git_clone_with_retry needs a non-existent target on retry.
+  if git_clone_with_retry "$repo_url" "$tmp_dir" --depth 1; then
     for skill_dir in "$tmp_dir"/*/; do
       local skill_name
       skill_name=$(basename "$skill_dir")

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -31,16 +31,8 @@ install_plugin() {
   local plugin_dir="$SITE_PATH/wp-content/plugins/$slug"
 
   if [ ! -d "$plugin_dir" ] || [ "$DRY_RUN" = true ]; then
-    # Prefer gh CLI for GitHub repos (avoids proxy/auth issues).
-    # Strip .git suffix first, then extract owner/repo — macOS sed doesn't
-    # handle the optional \(\.git\)\{0,1\} correctly (greedy [^/]* eats it).
-    local gh_nwo
-    gh_nwo=$(echo "$repo_url" | sed 's|\.git$||' | sed -n 's|^https://github\.com/\([^/]*/[^/]*\)$|\1|p')
-    if [ -n "$gh_nwo" ] && command -v gh &>/dev/null; then
-      run_cmd gh repo clone "$gh_nwo" "$plugin_dir"
-    else
-      run_cmd git clone "$repo_url" "$plugin_dir"
-    fi
+    git_clone_with_retry "$repo_url" "$plugin_dir" || \
+      warn "Clone failed for $slug — install will continue without it"
   elif [ -d "$plugin_dir/.git" ]; then
     log "Plugin $slug already exists — pulling latest..."
     run_cmd git -C "$plugin_dir" pull --ff-only 2>/dev/null || \


### PR DESCRIPTION
Closes #83.

## What

Add `git_clone_with_retry` in `lib/common.sh` and wire it into the two clone paths setup actually uses:
- `install_plugin` (`lib/wordpress.sh`) — drops the `gh repo clone` vs `git clone` branching.
- `install_skills_from_repo` (`lib/skills.sh`) — same resilience for the WordPress + Data Machine skill bundles cloned in Phase 8.5.

## Why

Two failure modes hit during a fresh end-to-end install:

### 1. `gh repo clone` follows the user's gh git_protocol setting

Users with `gh auth status` reporting `Git operations protocol: ssh` (often set during older interactive logins) and no SSH key registered hit a cryptic `Permission denied (publickey)` on every plugin clone:

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
failed to run git: exit status 128
```

The user has to register an SSH key, run `gh config set git_protocol https --host github.com`, or configure `url.https.insteadOf` before re-running setup. None of this is mentioned anywhere.

### 2. GitHub HTTP/2 transient 500s aren't retried

```
Cloning into 'data-machine'...
error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
fatal: expected 'packfile'
```

The same URL succeeds 5–10 seconds later. Pinning HTTP/1.1 dodges the issue entirely. Currently a single attempt fails the run and leaves a partial directory the user has to clean up.

## How

`git_clone_with_retry`:
- Pins `http.version=HTTP/1.1` on the per-invocation git config.
- Sets `url.https://github.com/.insteadOf=git@github.com:` so SSH-style URLs (explicit or constructed by gh) get rewritten transparently.
- Retries with exponential backoff (3 attempts: 2s, 4s, 8s), cleaning up the partial directory between attempts.
- Forwards extra args (used for `--depth 1` from the skills installer).
- DRY_RUN-aware (prints the rewritten command instead of executing).

`install_plugin` no longer needs the gh-vs-git branching — the helper handles HTTPS uniformly. gh stays used elsewhere for issue / PR work where its auth helper actually matters.

## Diff

```
lib/common.sh    +41   git_clone_with_retry helper
lib/wordpress.sh -10   drop gh-vs-git branch in install_plugin
lib/skills.sh    +2/-1 swap in helper, keep tmp_dir flow
─────────────
+45 / -11 across 3 files
```

## Verification

- Syntax (`bash -n`) clean on all three files.
- Smoke test: `git_clone_with_retry https://github.com/octocat/Hello-World.git $tmp --depth 1` clones successfully on first attempt against the live network.
- The `url.insteadOf` rewrite is the same workaround we used to manually unblock setup on a fresh Studio site against the real Extra-Chill plugin URLs (verified end-to-end during the discovery test that produced #79, #81, #83 in this batch).

Discovered while testing https://github.com/Automattic/intelligence end-to-end.