### PR TITLE
fix(kimaki): fall back when data-dir sources are missing

### DIFF
--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -35,13 +35,13 @@
 #
 # Persistent skill source dir resolution priority:
 #   1. KIMAKI_SKILL_SOURCE_DIR env var (explicit override)
-#   2. $KIMAKI_DATA_DIR/kimaki-config/skills/ if KIMAKI_DATA_DIR set
+#   2. $KIMAKI_DATA_DIR/kimaki-config/skills/ if KIMAKI_DATA_DIR set and dir exists
 #   3. $HOME/.kimaki/kimaki-config/skills/ (local default)
 #   4. /opt/kimaki-config/skills/ (VPS default)
 #
 # Persistent plugin source dir resolution priority (mirrors skill source):
 #   1. KIMAKI_PLUGIN_SOURCE_DIR env var (explicit override)
-#   2. $KIMAKI_DATA_DIR/kimaki-config/plugins/ if KIMAKI_DATA_DIR set
+#   2. $KIMAKI_DATA_DIR/kimaki-config/plugins/ if KIMAKI_DATA_DIR set and dir exists
 #   3. $HOME/.kimaki/kimaki-config/plugins/ (local default)
 #   4. /opt/kimaki-config/plugins/ (VPS default)
 set -euo pipefail
@@ -105,7 +105,7 @@ fi
 
 if [[ -n "${KIMAKI_SKILL_SOURCE_DIR:-}" ]]; then
   SKILL_SOURCE_DIR="$KIMAKI_SKILL_SOURCE_DIR"
-elif [[ -n "${KIMAKI_DATA_DIR:-}" ]]; then
+elif [[ -n "${KIMAKI_DATA_DIR:-}" && -d "$KIMAKI_DATA_DIR/kimaki-config/skills" ]]; then
   SKILL_SOURCE_DIR="$KIMAKI_DATA_DIR/kimaki-config/skills"
 elif [[ -d "$HOME/.kimaki/kimaki-config/skills" ]]; then
   SKILL_SOURCE_DIR="$HOME/.kimaki/kimaki-config/skills"
@@ -144,7 +144,7 @@ fi
 
 if [[ -n "${KIMAKI_PLUGIN_SOURCE_DIR:-}" ]]; then
   PLUGIN_SOURCE_DIR="$KIMAKI_PLUGIN_SOURCE_DIR"
-elif [[ -n "${KIMAKI_DATA_DIR:-}" ]]; then
+elif [[ -n "${KIMAKI_DATA_DIR:-}" && -d "$KIMAKI_DATA_DIR/kimaki-config/plugins" ]]; then
   PLUGIN_SOURCE_DIR="$KIMAKI_DATA_DIR/kimaki-config/plugins"
 elif [[ -d "$HOME/.kimaki/kimaki-config/plugins" ]]; then
   PLUGIN_SOURCE_DIR="$HOME/.kimaki/kimaki-config/plugins"

--- a/tests/post-upgrade-restore.sh
+++ b/tests/post-upgrade-restore.sh
@@ -15,6 +15,8 @@
 #      that already match.
 #   5. Plugin restore creates the live plugins dir if it does not exist
 #      (the post-`npm update` reality).
+#   6. KIMAKI_DATA_DIR is only a hint: if its kimaki-config source dirs do
+#      not exist, skills and plugins fall through to HOME/.kimaki/kimaki-config.
 #
 # Run from anywhere:
 #   bash tests/post-upgrade-restore.sh
@@ -162,6 +164,57 @@ fi
 if ! grep -q "2 plugins restored" "$TMP/run3.log"; then
   echo "FAIL: rehydration run should report 2 plugins restored"
   cat "$TMP/run3.log"
+  exit 1
+fi
+
+# Regression: KIMAKI_DATA_DIR may point at a real kimaki data dir that does not
+# contain kimaki-config. In that case the derived paths must not short-circuit
+# the source resolution chain; HOME/.kimaki/kimaki-config should still win.
+FALLBACK_HOME="$TMP/fallback-home"
+FALLBACK_DATA="$TMP/fallback-data"
+FALLBACK_LIVE_SKILLS="$TMP/fallback-live/skills"
+FALLBACK_LIVE_PLUGINS="$TMP/fallback-live/plugins"
+mkdir -p \
+  "$FALLBACK_DATA" \
+  "$FALLBACK_HOME/.kimaki/kimaki-config/skills/home-skill" \
+  "$FALLBACK_HOME/.kimaki/kimaki-config/plugins" \
+  "$FALLBACK_LIVE_SKILLS"
+cat > "$FALLBACK_HOME/.kimaki/kimaki-config/skills/home-skill/SKILL.md" <<'EOF'
+---
+name: home-skill
+description: fallback fixture
+---
+body
+EOF
+cat > "$FALLBACK_HOME/.kimaki/kimaki-config/plugins/home-plugin.ts" <<'EOF'
+// home-plugin.ts
+export default async () => ({})
+EOF
+
+HOME="$FALLBACK_HOME" \
+KIMAKI_DATA_DIR="$FALLBACK_DATA" \
+KIMAKI_SKILLS_DIR="$FALLBACK_LIVE_SKILLS" \
+KIMAKI_PLUGINS_DIR="$FALLBACK_LIVE_PLUGINS" \
+  "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run4.log" 2>&1
+
+if [[ ! -f "$FALLBACK_LIVE_SKILLS/home-skill/SKILL.md" ]]; then
+  echo "FAIL: missing KIMAKI_DATA_DIR skills source should fall through to HOME source"
+  cat "$TMP/run4.log"
+  exit 1
+fi
+if [[ ! -f "$FALLBACK_LIVE_PLUGINS/home-plugin.ts" ]]; then
+  echo "FAIL: missing KIMAKI_DATA_DIR plugins source should fall through to HOME source"
+  cat "$TMP/run4.log"
+  exit 1
+fi
+if ! grep -q "restored skill home-skill" "$TMP/run4.log"; then
+  echo "FAIL: fallback run should restore the HOME-backed skill"
+  cat "$TMP/run4.log"
+  exit 1
+fi
+if ! grep -q "restored plugin home-plugin.ts" "$TMP/run4.log"; then
+  echo "FAIL: fallback run should restore the HOME-backed plugin"
+  cat "$TMP/run4.log"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Treat KIMAKI_DATA_DIR as a source-location hint in post-upgrade.sh instead of an unconditional directive.
- Keep explicit KIMAKI_SKILL_SOURCE_DIR and KIMAKI_PLUGIN_SOURCE_DIR overrides unchanged.
- Extend the post-upgrade smoke to prove missing KIMAKI_DATA_DIR-derived source dirs fall through to HOME/.kimaki/kimaki-config for both skills and plugins.

Closes #85

## Tests

- bash tests/post-upgrade-restore.sh
- bash -n bridges/kimaki/post-upgrade.sh tests/post-upgrade-restore.sh
- bash tests/path-helpers.sh
- bash tests/bridge-render.sh
- node tests/effective-prompt/run.mjs

Notes: shellcheck is not installed in this environment. homeboy lint could not run because this component has no configured Homeboy extension.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the shell fallback fix, updated the smoke coverage, ran focused verification, and prepared the PR. Chris remains responsible for review and merge.
