### PR TITLE
fix(kimaki): warn when context filter plugins are missing

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -588,5 +588,5 @@ bridge_vps_start_preamble() {
 # Verify-block addendum printed by upgrade.sh after the standard status line.
 bridge_verify_extra() {
   local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
-  echo "ls $PLUGINS_DIR   # plugin versions"
+  echo "test -f $PLUGINS_DIR/dm-context-filter.ts && test -f $PLUGINS_DIR/dm-agent-sync.ts   # DM OpenCode plugins installed"
 }

--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -73,6 +73,7 @@ else
 fi
 
 KILL_LIST="$(dirname "$0")/skills-kill-list.txt"
+REQUIRED_PLUGINS=(dm-context-filter.ts dm-agent-sync.ts)
 
 # ----------------------------------------------------------------------------
 # Pass 1: KILL — remove blacklisted bundled kimaki skills.
@@ -173,7 +174,20 @@ if [[ -d "$PLUGIN_SOURCE_DIR" ]]; then
     shopt -u nullglob
   fi
 else
-  echo "kimaki-config: persistent plugin source dir not found at $PLUGIN_SOURCE_DIR, skipping plugin restore"
+  echo "kimaki-config: WARNING: persistent plugin source dir not found at $PLUGIN_SOURCE_DIR; dm-context-filter.ts and dm-agent-sync.ts cannot be restored"
 fi
 
-echo "kimaki-config: done ($removed skills removed, $skills_restored skills restored, $plugins_restored plugins restored)"
+missing_required_plugins=0
+if [[ ! -d "$PLUGINS_DIR" ]]; then
+  echo "kimaki-config: WARNING: plugins dir not found at $PLUGINS_DIR; opencode.json plugin paths will be skipped by OpenCode"
+  missing_required_plugins=${#REQUIRED_PLUGINS[@]}
+else
+  for required_plugin in "${REQUIRED_PLUGINS[@]}"; do
+    if [[ ! -f "$PLUGINS_DIR/$required_plugin" ]]; then
+      echo "kimaki-config: WARNING: required OpenCode plugin missing at $PLUGINS_DIR/$required_plugin; opencode.json references will be silently skipped"
+      missing_required_plugins=$((missing_required_plugins + 1))
+    fi
+  done
+fi
+
+echo "kimaki-config: done ($removed skills removed, $skills_restored skills restored, $plugins_restored plugins restored, $missing_required_plugins required plugins missing)"

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -38,6 +38,14 @@ The user says something like:
 
 4. **Tell the user to restart the chat bridge themselves.** Active chat sessions die on restart, so the user picks the moment.
 
+5. **After restart, verify Kimaki's OpenCode plugins when Kimaki + OpenCode are in use.** The summary's verify block includes a `test -f .../dm-context-filter.ts && test -f .../dm-agent-sync.ts` command. Run it or ask the user to run it, then inspect the Kimaki startup logs for `kimaki-config: WARNING:` lines. Any warning about a missing persistent plugin source dir or missing required OpenCode plugin means `opencode.json` may reference plugin files OpenCode silently skipped.
+
+6. **Verify the filter behavior from the repo when available.** Run:
+   ```bash
+   node tests/effective-prompt/run.mjs
+   ```
+   Passing output (`OK — ... scenario(s)`) proves `dm-context-filter` still strips the Kimaki-only prompt sections the Data Machine agent should not see. If this fails after a Kimaki upgrade, fix the filter or refresh snapshots intentionally before calling the upgrade healthy.
+
 Run `./upgrade.sh --help` for scope flags (`--plugins-only`, `--skip-plugins`, `--kimaki-only`, `--skills-only`, `--agents-md-only`, `--repair-opencode-json`, etc.) and the full list of what the script touches and never touches.
 
 ## Never do

--- a/skills/wp-coding-agents-setup/SKILL.md
+++ b/skills/wp-coding-agents-setup/SKILL.md
@@ -226,6 +226,25 @@ claude --version
 studio --version
 ```
 
+### Kimaki OpenCode Plugins
+
+When setup uses **OpenCode + Kimaki**, verify that the plugin paths written to `opencode.json` exist on disk. OpenCode silently skips missing plugin files, so this is the explicit failure signal for a disabled Data Machine context filter.
+
+**VPS:**
+```bash
+test -f /opt/kimaki-config/plugins/dm-context-filter.ts && test -f /opt/kimaki-config/plugins/dm-agent-sync.ts
+journalctl -u kimaki -n 100 --no-pager | grep 'kimaki-config: WARNING' || true
+```
+
+**Local:**
+```bash
+KIMAKI_PLUGINS_DIR="$(npm root -g)/kimaki/plugins"
+test -f "$KIMAKI_PLUGINS_DIR/dm-context-filter.ts" && test -f "$KIMAKI_PLUGINS_DIR/dm-agent-sync.ts"
+grep 'kimaki-config: WARNING' "$HOME/.kimaki/kimaki.log" || true
+```
+
+If either `test -f` command fails, restart/re-run setup or upgrade before trusting a new OpenCode session. If the log contains a warning about the persistent plugin source dir or required OpenCode plugins, `dm-context-filter.ts` is not guaranteed to be active after restart.
+
 ### Site Reachable (VPS)
 
 ```bash

--- a/tests/post-upgrade-restore.sh
+++ b/tests/post-upgrade-restore.sh
@@ -114,6 +114,16 @@ assert_log_contains() {
   fi
 }
 
+assert_log_contains_file() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -qF "$needle" "$file"; then
+    echo "FAIL: $file should contain: $needle"
+    cat "$file"
+    exit 1
+  fi
+}
+
 # Pass 1: kill pass removed the blacklisted skill.
 assert_missing "$LIVE_SKILLS/blacklisted-skill"
 assert_log_contains "removed skill blacklisted-skill"
@@ -217,5 +227,19 @@ if ! grep -q "restored plugin home-plugin.ts" "$TMP/run4.log"; then
   cat "$TMP/run4.log"
   exit 1
 fi
+
+# Missing persistent source + missing required live plugins must be loud. OpenCode
+# silently skips absent plugin paths, so post-upgrade is the operator-facing signal.
+MISSING_SRC="$TMP/missing-config/plugins"
+MISSING_LIVE_PLUGINS="$TMP/missing-live/plugins"
+KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
+KIMAKI_PLUGINS_DIR="$MISSING_LIVE_PLUGINS" \
+KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_PLUGIN_SOURCE_DIR="$MISSING_SRC" \
+  "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/missing.log" 2>&1
+
+assert_log_contains_file "$TMP/missing.log" "WARNING: persistent plugin source dir not found at $MISSING_SRC; dm-context-filter.ts and dm-agent-sync.ts cannot be restored"
+assert_log_contains_file "$TMP/missing.log" "WARNING: plugins dir not found at $MISSING_LIVE_PLUGINS; opencode.json plugin paths will be skipped by OpenCode"
+assert_log_contains_file "$TMP/missing.log" "2 required plugins missing"
 
 echo "PASS: tests/post-upgrade-restore.sh ($(grep -c '' "$TMP/run1.log" || true) lines run1, $(grep -c '' "$TMP/run3.log" || true) lines run3)"


### PR DESCRIPTION
## Summary
- Warn during Kimaki post-upgrade when the persistent plugin source is missing or required OpenCode plugin files are absent.
- Replace the upgrade verify addendum with a concrete dm-context-filter/dm-agent-sync file check.
- Document setup/upgrade verification steps so operators can catch OpenCode silently skipping missing plugin paths.

Closes #86

## Tests
- bash tests/post-upgrade-restore.sh
- bash -n bridges/kimaki/post-upgrade.sh bridges/kimaki.sh tests/post-upgrade-restore.sh upgrade.sh setup.sh
- bash -n on all .sh files, matching CI syntax check
- bash tests/bridge-render.sh
- node tests/effective-prompt/run.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the warning/docs/test updates and ran focused validation. Chris remains responsible for review and merge.