### PR TITLE
fix(kimaki): include user tool dirs in launchd PATH

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -446,7 +446,7 @@ bridge_render_launchd() {
   local kimaki_bin_dir node_bin_dir path_value
   kimaki_bin_dir="$(dirname "$KIMAKI_BIN")"
   node_bin_dir="$(_resolve_node_bin_dir "$KIMAKI_BIN")"
-  path_value="$(_compose_path_value "$kimaki_bin_dir" "$node_bin_dir" /opt/homebrew/bin /usr/local/bin /usr/bin /bin)"
+  path_value="$(_compose_path_value "$kimaki_bin_dir" "$node_bin_dir" "$HOME/.local/bin" "$HOME/.opencode/bin" "$HOME/.bun/bin" /opt/homebrew/bin /usr/local/bin /usr/bin /bin /usr/sbin /sbin)"
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/tests/__snapshots__/bridges/kimaki-launchd
+++ b/tests/__snapshots__/bridges/kimaki-launchd
@@ -23,7 +23,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/opt/homebrew/bin:/home/chubes/.local/bin:/home/chubes/.opencode/bin:/home/chubes/.bun/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>KIMAKI_DATA_DIR</key>
         <string>/home/chubes/.kimaki</string>
     </dict>


### PR DESCRIPTION
## Summary
- Add common user tool directories to the macOS Kimaki launchd PATH so launchd-started Kimaki can find `studio`, `opencode`, and `bun`.
- Keep the change scoped to the Kimaki launchd renderer and its snapshot; the VPS/systemd template remains unchanged.

## Tests
- `tests/bridge-render.sh`
- `bash -n bridges/kimaki.sh bridges/_dispatch.sh tests/bridge-render.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the launchd PATH regression from local Kimaki logs, drafted the launchd-only fix, and ran the focused render/syntax checks. Chris reviewed the behavior and requested the PR.