### PR TITLE
fix(kimaki): add WordPress runtime guidance

### DIFF
--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -5,8 +5,10 @@
 //
 // What it removes from the system prompt:
 // 1. Scheduling — ~500 tokens of --send-at, cron, task management instructions.
-// 2. Tunnel / dev server — ~500 tokens about kimaki tunnel and tmux. Not needed
-//    on production WordPress VPS where the site is already live.
+// 2. Tunnel / dev server — ~500 tokens about kimaki tunnel and tmux. DM-managed
+//    WordPress installs already have a site runtime (Studio locally, a live
+//    site on VPS). Tunnels are task-specific for inbound public URLs like
+//    webhooks/OAuth callbacks, not the default way to interact with the site.
 // 3. Critique — ~900 tokens of diff-sharing instructions. We use GitHub PRs.
 // 4. Worktree creation — ~150 tokens. We use feature branches in workspace repos.
 // 5. Cross-project commands — ~200 tokens. Single-project fleet servers.
@@ -35,6 +37,10 @@
 //    bypasses that binding and starts the wrong kind of minion session.
 //
 // What it injects into the system prompt:
+// - `## WordPress Site Runtime` — positive instruction replacing Kimaki's
+//   generic tunnel/dev-server section with the local/VPS WordPress boundary:
+//   use the existing site runtime by default; tunnel only for inbound public
+//   URLs like webhooks/OAuth callbacks or explicit browser previews.
 // - `## Minion Session Routing` — positive instruction telling the agent that
 //   all minion sessions go in the current channel. Defense in depth on top of
 //   the stripping above: even if the agent discovers channel IDs some other
@@ -90,6 +96,7 @@ const fleetContextFilter: Plugin = async () => {
         // Append positive routing instruction so the agent never tries to
         // discover or send sessions to other channels, even if it learns
         // channel IDs from --help or training data.
+        result = appendWordPressSiteRuntimeInstruction(result);
         result = appendMinionRoutingInstruction(result);
         return result;
       });
@@ -336,6 +343,31 @@ function stripAgentOverrideInlines(block: string): string {
   result = result.replace(/ --agent <current_agent>/g, "");
 
   return result;
+}
+
+/**
+ * Append positive WordPress runtime guidance after stripping Kimaki's generic
+ * tunnel/dev-server section.
+ *
+ * Local and VPS installs intentionally use different plugin paths, but the
+ * runtime policy is the same: the WordPress site already exists. Local Studio
+ * agents should use Studio's site runtime and `studio wp`; VPS agents should
+ * use the live site and `wp`. A tunnel is still useful when the task needs an
+ * inbound public URL, but it is not the default path for interacting with the
+ * site.
+ */
+function appendWordPressSiteRuntimeInstruction(block: string): string {
+  const instruction = `
+
+## WordPress Site Runtime
+
+This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
+
+On local WordPress Studio installs, use Studio and \`studio wp\` against the existing site. On VPS installs, use the live WordPress site and \`wp\` in the configured site path.
+
+Use \`kimaki tunnel\` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
+`;
+  return block.replace(/\s*$/, "") + instruction;
 }
 
 /**

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -325,6 +325,14 @@ Examples:
 intelligence-chubes4 personal agent
 </channel-topic>
 
+## WordPress Site Runtime
+
+This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
+
+On local WordPress Studio installs, use Studio and `studio wp` against the existing site. On VPS installs, use the live WordPress site and `wp` in the configured site path.
+
+Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
+
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -217,6 +217,14 @@ Examples:
 intelligence-chubes4 personal agent
 </channel-topic>
 
+## WordPress Site Runtime
+
+This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
+
+On local WordPress Studio installs, use Studio and `studio wp` against the existing site. On VPS installs, use the live WordPress site and `wp` in the configured site path.
+
+Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
+
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -315,6 +315,14 @@ Examples:
 - If a plan has multiple strategy of implementation show these as options
 - After a genuinely ambiguous request where you cannot infer intent: offer the different approaches
 
+## WordPress Site Runtime
+
+This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
+
+On local WordPress Studio installs, use Studio and `studio wp` against the existing site. On VPS installs, use the live WordPress site and `wp` in the configured site path.
+
+Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
+
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -207,6 +207,14 @@ Examples:
 - If a plan has multiple strategy of implementation show these as options
 - After a genuinely ambiguous request where you cannot infer intent: offer the different approaches
 
+## WordPress Site Runtime
+
+This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
+
+On local WordPress Studio installs, use Studio and `studio wp` against the existing site. On VPS installs, use the live WordPress site and `wp` in the configured site path.
+
+Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
+
 ## Minion Session Routing
 
 All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -95,6 +95,20 @@ If a minion needs to work in a different repo directory, use \`kimaki send --cwd
   return block.replace(/\s*$/, "") + instruction
 }
 
+function appendWordPressSiteRuntimeInstruction(block) {
+  const instruction = `
+
+## WordPress Site Runtime
+
+This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
+
+On local WordPress Studio installs, use Studio and \`studio wp\` against the existing site. On VPS installs, use the live WordPress site and \`wp\` in the configured site path.
+
+Use \`kimaki tunnel\` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
+`
+  return block.replace(/\s*$/, "") + instruction
+}
+
 function currentFilter(block) {
   let r = block
   r = stripSection(r, "## permissions")
@@ -117,6 +131,7 @@ function currentFilter(block) {
   r = stripProjectDiscoveryInlines(r)
   r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
+  r = appendWordPressSiteRuntimeInstruction(r)
   r = appendMinionRoutingInstruction(r)
   return r
 }
@@ -158,6 +173,7 @@ function brokenFilter(block) {
   r = stripProjectDiscoveryInlines(r)
   r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
+  r = appendWordPressSiteRuntimeInstruction(r)
   r = appendMinionRoutingInstruction(r)
   return r
 }


### PR DESCRIPTION
## Summary
- Replaces Kimaki's stripped generic tunnel/dev-server guidance with Data Machine-specific WordPress runtime guidance.
- Documents the local Studio vs VPS boundary: use the existing WordPress site runtime by default, and reserve `kimaki tunnel` for inbound public URLs like webhooks, OAuth callbacks, or explicit browser previews.
- Updates effective-prompt snapshots so the wrapper plugin proves the generic tunnel section is removed and the WordPress runtime section is injected.

## Tests
- `node tests/effective-prompt/run.mjs --update && node tests/effective-prompt/run.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the plugin wording, updated the prompt-filter harness mirror, refreshed snapshots, and ran the focused regression harness. Chris reviewed the direction and corrected the target layer.