### PR TITLE
fix(agents): declare Homeboy availability before compose

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -67,3 +67,21 @@ create_dm_agent() {
     log "Dry-run: would create agent '$AGENT_SLUG' with SOUL.md and MEMORY.md"
   fi
 }
+
+sync_homeboy_availability() {
+  if [ "$DRY_RUN" = true ]; then
+    if command -v homeboy >/dev/null 2>&1; then
+      echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update datamachine_code_homeboy_available 1"
+    else
+      echo -e "${BLUE}[dry-run]${NC} $WP_CMD option delete datamachine_code_homeboy_available"
+    fi
+    return 0
+  fi
+
+  if command -v homeboy >/dev/null 2>&1; then
+    wp_cmd option update datamachine_code_homeboy_available 1 >/dev/null 2>&1 || \
+      warn "Could not record Homeboy availability for AGENTS.md compose"
+  else
+    wp_cmd option delete datamachine_code_homeboy_available >/dev/null 2>&1 || true
+  fi
+}

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -231,6 +231,7 @@ runtime_generate_instructions() {
   # Compose from Data Machine's SectionRegistry. DM is mandatory, so this is
   # the only source of truth for AGENTS.md content.
   if [ "$DRY_RUN" = false ]; then
+    sync_homeboy_availability
     if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
       log "AGENTS.md composed from SectionRegistry"
       return

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -351,6 +351,7 @@ runtime_generate_instructions() {
   # handles WP-CLI prefix resolution, multisite detection, and plugin sections
   # (intelligence, etc.) automatically at runtime.
   if [ "$DRY_RUN" = false ]; then
+    sync_homeboy_availability
     if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
       log "AGENTS.md composed from SectionRegistry"
       return

--- a/runtimes/studio-code.sh
+++ b/runtimes/studio-code.sh
@@ -300,6 +300,7 @@ runtime_generate_instructions() {
 
   # Compose from Data Machine's SectionRegistry. DM is mandatory.
   if [ "$DRY_RUN" = false ]; then
+    sync_homeboy_availability
     if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
       log "AGENTS.md composed from SectionRegistry"
       return

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -544,6 +544,8 @@ regenerate_agents_md() {
     return 0
   fi
 
+  sync_homeboy_availability
+
   # Backup existing (compose writes in-place to the registered location)
   if [ -f "$AGENTS_MD" ]; then
     cp "$AGENTS_MD" "$BACKUP"


### PR DESCRIPTION
## Summary
- Add a host-shell `sync_homeboy_availability` helper that records whether `homeboy` is available for the co-located coding-agent runtime.
- Call it before Data Machine composes AGENTS.md from setup/runtime instruction generation and upgrade regeneration paths.
- Delete the option when Homeboy is absent so non-Homeboy installs keep the generated section out.

## Why
Data Machine Code can now consume `datamachine_code_homeboy_available`, but Studio's WordPress PHP runtime cannot reliably discover host binaries itself. wp-coding-agents runs in the host shell and is the right layer to declare that signal before compose.

## Tests
- `bash -n lib/data-machine.sh && bash -n runtimes/opencode.sh && bash -n runtimes/claude-code.sh && bash -n runtimes/studio-code.sh && bash -n upgrade.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shell integration and PR description; Chris remains responsible for review and merge.
