### PR TITLE
fix(kimaki): add Data Machine session handoff

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -8,11 +8,13 @@
 #
 # Install layout:
 #   VPS:   /opt/kimaki-config/{plugins,post-upgrade.sh,skills-kill-list.txt}
+#          + /usr/local/bin/datamachine-kimaki-session
 #          + /etc/systemd/system/kimaki.service (ExecStartPre runs post-upgrade.sh)
 #   Local: $(npm root -g)/kimaki/plugins for plugins (lives inside the npm
 #          package; wiped on `npm update -g kimaki`),
 #          $KIMAKI_DATA_DIR/kimaki-config/ for post-upgrade.sh + kill list
 #          (executed inline at upgrade time — no launchd ExecStartPre hook),
+#          + $HOME/.local/bin/datamachine-kimaki-session
 #          + $HOME/Library/LaunchAgents/com.wp.kimaki.plist on macOS.
 
 # ============================================================================
@@ -48,6 +50,35 @@ bridge_install() {
   else
     _kimaki_install_systemd
   fi
+
+  _kimaki_sync_handoff_helper
+}
+
+_kimaki_sync_handoff_helper() {
+  [ -f "$SCRIPT_DIR/bridges/kimaki/bin/datamachine-kimaki-session" ] || return 0
+
+  local HELPER_TARGET
+  if [ "$LOCAL_MODE" = true ]; then
+    HELPER_TARGET="$SERVICE_HOME/.local/bin/datamachine-kimaki-session"
+  else
+    HELPER_TARGET="/usr/local/bin/datamachine-kimaki-session"
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/bin/datamachine-kimaki-session" "$HELPER_TARGET" 2>/dev/null; then
+      echo -e "${BLUE}[dry-run]${NC} Would update $HELPER_TARGET"
+    fi
+  else
+    mkdir -p "$(dirname "$HELPER_TARGET")"
+    if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/bin/datamachine-kimaki-session" "$HELPER_TARGET" 2>/dev/null; then
+      cp "$SCRIPT_DIR/bridges/kimaki/bin/datamachine-kimaki-session" "$HELPER_TARGET"
+      chmod +x "$HELPER_TARGET"
+      log "  Updated $HELPER_TARGET"
+      UPDATED_ITEMS+=("datamachine-kimaki-session helper")
+    fi
+  fi
+
+  RESOLVED_KIMAKI_HELPER="$HELPER_TARGET"
 }
 
 _kimaki_install_launchd() {
@@ -270,6 +301,12 @@ bridge_sync_config() {
       fi
     fi
   fi
+
+  # Install wp-coding-agents' Kimaki bridge helper. The helper is intentionally
+  # outside Kimaki's npm package so `npm update -g kimaki` cannot wipe it.
+  # It adapts DMC workspace checkouts into Kimaki thread metadata while keeping
+  # DMC generic and Kimaki unpatched.
+  _kimaki_sync_handoff_helper
 
   # On local, execute post-upgrade.sh inline to enforce the kill list.
   # On VPS, kimaki.service ExecStartPre runs it on next service restart.
@@ -588,5 +625,7 @@ bridge_vps_start_preamble() {
 # Verify-block addendum printed by upgrade.sh after the standard status line.
 bridge_verify_extra() {
   local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
+  local HELPER="${RESOLVED_KIMAKI_HELPER:-/usr/local/bin/datamachine-kimaki-session}"
   echo "test -f $PLUGINS_DIR/dm-context-filter.ts && test -f $PLUGINS_DIR/dm-agent-sync.ts   # DM OpenCode plugins installed"
+  echo "test -x $HELPER   # DMC Kimaki session handoff helper installed"
 }

--- a/bridges/kimaki/bin/datamachine-kimaki-session
+++ b/bridges/kimaki/bin/datamachine-kimaki-session
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: datamachine-kimaki-session --channel <id> --cwd <git-worktree> --prompt <text> [options]
+
+Start a Kimaki Discord session attached to an existing Data Machine Code
+workspace checkout. Data Machine Code owns repo/workspace creation; this helper
+only adapts the resulting checkout into Kimaki's thread metadata.
+
+Options:
+  --channel <id>       Discord channel ID for the current personal agent.
+  --cwd <path>         Existing git worktree/workspace checkout for the session.
+  --prompt <text>      Prompt to send to the new helper session.
+  --user <name>        Discord user display name to add to the thread.
+  --name <name>        Thread name. Defaults to a prompt preview.
+  --data-dir <path>    Kimaki data dir. Defaults to $KIMAKI_DATA_DIR or ~/.kimaki.
+  --dry-run            Validate inputs and print planned actions without sending.
+  --help               Show this help.
+EOF
+}
+
+channel=""
+cwd_path=""
+prompt=""
+user=""
+thread_name=""
+data_dir="${KIMAKI_DATA_DIR:-$HOME/.kimaki}"
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel)
+      channel="${2:-}"
+      shift 2
+      ;;
+    --cwd)
+      cwd_path="${2:-}"
+      shift 2
+      ;;
+    --prompt)
+      prompt="${2:-}"
+      shift 2
+      ;;
+    --user)
+      user="${2:-}"
+      shift 2
+      ;;
+    --name)
+      thread_name="${2:-}"
+      shift 2
+      ;;
+    --data-dir)
+      data_dir="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_value() {
+  local name="$1" value="$2"
+  if [[ -z "$value" ]]; then
+    echo "Missing required option: $name" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+require_value "--channel" "$channel"
+require_value "--cwd" "$cwd_path"
+require_value "--prompt" "$prompt"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required" >&2
+  exit 2
+fi
+
+if [[ "$dry_run" != true ]] && ! command -v kimaki >/dev/null 2>&1; then
+  echo "kimaki is required" >&2
+  exit 2
+fi
+
+if [[ "$dry_run" != true ]] && ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required" >&2
+  exit 2
+fi
+
+if [[ "$dry_run" != true && "$data_dir" != "$HOME/.kimaki" ]]; then
+  echo "Kimaki's send command uses the current user's ~/.kimaki data dir." >&2
+  echo "Run this helper as the Kimaki service user, or use the default data dir: $HOME/.kimaki" >&2
+  exit 2
+fi
+
+if [[ ! -d "$cwd_path" ]]; then
+  echo "Directory does not exist: $cwd_path" >&2
+  exit 2
+fi
+
+absolute_cwd="$(cd "$cwd_path" && pwd -P)"
+if ! git -C "$absolute_cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Directory is not inside a git checkout: $absolute_cwd" >&2
+  exit 2
+fi
+
+worktree_list="$(git -C "$absolute_cwd" worktree list --porcelain)"
+primary_path=""
+candidate_found=false
+current_worktree=""
+
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      current_worktree="${line#worktree }"
+      if [[ -z "$primary_path" ]]; then
+        primary_path="$current_worktree"
+      fi
+      resolved_current="$(cd "$current_worktree" 2>/dev/null && pwd -P || true)"
+      if [[ "$resolved_current" == "$absolute_cwd" ]]; then
+        candidate_found=true
+      fi
+      ;;
+  esac
+done <<< "$worktree_list"
+
+if [[ -z "$primary_path" ]]; then
+  echo "Could not resolve primary checkout for: $absolute_cwd" >&2
+  exit 2
+fi
+
+if [[ "$candidate_found" != true ]]; then
+  echo "Directory is not listed as a git worktree: $absolute_cwd" >&2
+  exit 2
+fi
+
+primary_path="$(cd "$primary_path" && pwd -P)"
+branch="$(git -C "$absolute_cwd" symbolic-ref --short HEAD 2>/dev/null || basename "$absolute_cwd")"
+
+if [[ -z "$thread_name" ]]; then
+  thread_name="$prompt"
+  if [[ ${#thread_name} -gt 80 ]]; then
+    thread_name="${thread_name:0:77}..."
+  fi
+fi
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  printf '%s' "$value"
+}
+
+sql_quote() {
+  local value="$1"
+  value="${value//\'/\'\'}"
+  printf "'%s'" "$value"
+}
+
+if [[ "$dry_run" == true ]]; then
+  cat <<EOF
+{
+  "channel": "$(json_escape "$channel")",
+  "cwd": "$(json_escape "$absolute_cwd")",
+  "primary": "$(json_escape "$primary_path")",
+  "branch": "$(json_escape "$branch")",
+  "dataDir": "$(json_escape "$data_dir")",
+  "threadName": "$(json_escape "$thread_name")"
+}
+EOF
+  exit 0
+fi
+
+send_args=(send --channel "$channel" --prompt "$prompt" --notify-only --name "$thread_name")
+if [[ -n "$user" ]]; then
+  send_args+=(--user "$user")
+fi
+
+send_output="$(kimaki "${send_args[@]}" 2>&1)"
+thread_url="$(printf '%s\n' "$send_output" | grep -Eo 'https://discord\.com/channels/[0-9]+/[0-9]+' | tail -1 || true)"
+thread_id="${thread_url##*/}"
+
+if [[ -z "$thread_url" || "$thread_id" == "$thread_url" ]]; then
+  echo "$send_output" >&2
+  echo "Could not parse created thread URL from kimaki output" >&2
+  exit 1
+fi
+
+db_path="$data_dir/discord-sessions.db"
+if [[ ! -f "$db_path" ]]; then
+  echo "Kimaki database not found: $db_path" >&2
+  exit 1
+fi
+
+sqlite3 "$db_path" <<SQL
+INSERT INTO thread_sessions (thread_id, session_id, source)
+VALUES ($(sql_quote "$thread_id"), '', 'kimaki')
+ON CONFLICT(thread_id) DO UPDATE SET session_id = thread_sessions.session_id;
+
+INSERT INTO thread_worktrees (thread_id, worktree_name, worktree_directory, project_directory, status, error_message)
+VALUES ($(sql_quote "$thread_id"), $(sql_quote "$branch"), $(sql_quote "$absolute_cwd"), $(sql_quote "$primary_path"), 'ready', NULL)
+ON CONFLICT(thread_id) DO UPDATE SET
+  worktree_name = excluded.worktree_name,
+  worktree_directory = excluded.worktree_directory,
+  project_directory = excluded.project_directory,
+  status = 'ready',
+  error_message = NULL;
+SQL
+
+kimaki send --thread "$thread_id" --prompt "$prompt" >/dev/null
+printf '%s\n' "$thread_url"

--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -13,11 +13,10 @@
 // 4. Worktree creation — ~150 tokens. We use feature branches in workspace repos.
 // 5. Cross-project commands — ~200 tokens. Single-project fleet servers.
 // 6. Waiting for sessions — ~150 tokens. Rarely used, discoverable via --help.
-// 7. Worktree conflicts — inline --worktree/--cwd examples in "starting new
-//    sessions from CLI", the orphan "Worktrees are useful..." lead-in, and the
-//    per-turn "## worktree" section. Data Machine Code manages its own
-//    workspace and worktrees; keeping Kimaki's worktree language around causes
-//    the agent to try using Kimaki worktrees instead of DM Code's workspace.
+// 7. Session/workspace conflicts — Kimaki's generic session, project, agent,
+//    and worktree docs describe Kimaki as the workspace orchestrator. On a Data
+//    Machine install, Data Machine Code owns workspace creation and Kimaki is
+//    the Discord/session bridge.
 // 8. Permissions — ~80 tokens describing which Discord roles can message the
 //    bot. The agent has no capability to act on this; pure metadata leakage.
 // 9. Upgrading kimaki — ~80 tokens of /upgrade-and-restart playbook. The user
@@ -41,11 +40,9 @@
 //   generic tunnel/dev-server section with the local/VPS WordPress boundary:
 //   use the existing site runtime by default; tunnel only for inbound public
 //   URLs like webhooks/OAuth callbacks or explicit browser previews.
-// - `## Minion Session Routing` — positive instruction telling the agent that
-//   all minion sessions go in the current channel. Defense in depth on top of
-//   the stripping above: even if the agent discovers channel IDs some other
-//   way (training data, --help output, user mention), the instruction steers
-//   it back to ${channelId}. Use --cwd to target a different repo dir.
+// - `## Data Machine Session Handoff` — positive instruction that exposes the
+//   Data Machine flow: create/reuse a DMC workspace checkout, then launch a
+//   Kimaki-backed helper session with the wp-coding-agents bridge helper.
 //
 // NOTE: "## debugging kimaki issues" is intentionally kept — when Kimaki itself
 // throws errors, the agent needs the kimaki.log path to investigate.
@@ -76,6 +73,7 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "## upgrading kimaki");
         result = stripSection(result, "## scheduled sends and task management");
         result = stripSection(result, "## running dev servers with tunnel access");
+        result = stripSection(result, "## starting new sessions from CLI");
         result = stripSection(result, "## creating worktrees");
         result = stripSection(result, "## worktree");
         result = stripSection(result, "## cross-project commands");
@@ -93,11 +91,8 @@ const fleetContextFilter: Plugin = async () => {
         result = stripAgentOverrideInlines(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");
-        // Append positive routing instruction so the agent never tries to
-        // discover or send sessions to other channels, even if it learns
-        // channel IDs from --help or training data.
         result = appendWordPressSiteRuntimeInstruction(result);
-        result = appendMinionRoutingInstruction(result);
+        result = appendDataMachineSessionHandoffInstruction(result);
         return result;
       });
     },
@@ -371,26 +366,20 @@ Use \`kimaki tunnel\` only when the task specifically needs an inbound public UR
 }
 
 /**
- * Append a positive minion-session routing instruction.
- *
- * Stripping alone is not enough: the agent can still learn channel IDs from
- * `kimaki --help`, other agents' mentions, or training data. This instruction
- * is defense in depth — it tells the agent the *policy* (all minion sessions
- * go in this channel) so that even if a channel ID surfaces some other way,
- * the agent still routes correctly. Cross-repo work is handled by pointing
- * `--cwd` at a Data Machine Code workspace worktree, not by switching
- * channels.
+ * Append a positive Data Machine session handoff instruction.
  */
-function appendMinionRoutingInstruction(block: string): string {
+function appendDataMachineSessionHandoffInstruction(block: string): string {
   const instruction = `
 
-## Minion Session Routing
+## Data Machine Session Handoff
 
-All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run \`kimaki project list\`, \`kimaki project add\`, \`kimaki project create\`, or \`kimaki send --project\` — those are cross-project discovery commands that route sessions to other agents' channels.
+For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
 
-Do not pass \`--agent\` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example \`--agent opencode\`) bypasses the channel binding and starts the wrong kind of session.
+Typical flow:
 
-If a minion needs to work in a different repo directory, use \`kimaki send --cwd /path/to/repo\` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (\`studio wp datamachine-code workspace worktree add <repo> <branch>\`) — the worktree becomes the \`--cwd\` target for any follow-up minion session.
+1. Create the checkout with \`studio wp datamachine-code workspace worktree add <repo> <branch>\`.
+2. Start the helper session with \`datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'\`.
+3. Use the helper thread for the isolated task and bring the result back here.
 `;
   // Ensure exactly one blank line between existing content and the appendix.
   return block.replace(/\s*$/, "") + instruction;

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -45,38 +45,6 @@ kimaki user list --guild 1493321868415996064 --query "username"
 
 This returns user IDs you can use for Discord mentions.
 
-## starting new sessions from CLI
-
-To start a new thread/session in this channel pro-grammatically, run:
-
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
-
-You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-
-To send a prompt to an existing thread instead of creating a new one:
-
-kimaki send --thread <thread_id> --prompt "follow-up prompt"
-
-Use this when you already have the Discord thread ID.
-
-To send to the thread associated with a known session:
-
-kimaki send --session <session_id> --prompt "follow-up prompt"
-
-Use this when you have the OpenCode session ID.
-
-Use --notify-only to create a notification thread without starting an AI session:
-
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
-
-Use --user to add a specific Discord user to the new thread:
-
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
-
-Available agents:
-- `build`: default coding agent
-- `plan`: planning agent
-
 # List all registered projects with their channel IDs
 kimaki project list --json  # machine-readable output
 
@@ -103,7 +71,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt "Run the tests" --wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
 ```
 
 The command exits with the session markdown on stdout once the model finishes responding.
@@ -243,17 +211,26 @@ Discord supports: headings, bold, italic, strikethrough, code blocks, inline cod
 
 NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
 
-### callouts for important content
+## Callouts in Kimaki Discord
 
-Prefer `<callout>` over `<aside>`, blockquotes, or plain bold text when you need a highlighted warning, action item, limitation, or gist box. `<callout>` is a Kimaki-specific rendering primitive, so it is more explicit and more likely to render the way you want.
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
 
-You can wrap important markdown in:
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
 
 ```md
 <callout accent="#f59e0b">
-## Warning
-- Tests still fail
-- I left TODO markers in the code
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
 </callout>
 ```
 
@@ -333,10 +310,12 @@ On local WordPress Studio installs, use Studio and `studio wp` against the exist
 
 Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
 
-## Minion Session Routing
+## Data Machine Session Handoff
 
-All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
 
-Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
+Typical flow:
 
-If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.
+1. Create the checkout with `studio wp datamachine-code workspace worktree add <repo> <branch>`.
+2. Start the helper session with `datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'`.
+3. Use the helper thread for the isolated task and bring the result back here.

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -45,38 +45,6 @@ kimaki user list --guild 1493321868415996064 --query "username"
 
 This returns user IDs you can use for Discord mentions.
 
-## starting new sessions from CLI
-
-To start a new thread/session in this channel pro-grammatically, run:
-
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
-
-You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-
-To send a prompt to an existing thread instead of creating a new one:
-
-kimaki send --thread <thread_id> --prompt "follow-up prompt"
-
-Use this when you already have the Discord thread ID.
-
-To send to the thread associated with a known session:
-
-kimaki send --session <session_id> --prompt "follow-up prompt"
-
-Use this when you have the OpenCode session ID.
-
-Use --notify-only to create a notification thread without starting an AI session:
-
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
-
-Use --user to add a specific Discord user to the new thread:
-
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
-
-Available agents:
-- `build`: default coding agent
-- `plan`: planning agent
-
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
@@ -135,17 +103,26 @@ Discord supports: headings, bold, italic, strikethrough, code blocks, inline cod
 
 NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
 
-### callouts for important content
+## Callouts in Kimaki Discord
 
-Prefer `<callout>` over `<aside>`, blockquotes, or plain bold text when you need a highlighted warning, action item, limitation, or gist box. `<callout>` is a Kimaki-specific rendering primitive, so it is more explicit and more likely to render the way you want.
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
 
-You can wrap important markdown in:
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
 
 ```md
 <callout accent="#f59e0b">
-## Warning
-- Tests still fail
-- I left TODO markers in the code
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
 </callout>
 ```
 
@@ -225,10 +202,12 @@ On local WordPress Studio installs, use Studio and `studio wp` against the exist
 
 Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
 
-## Minion Session Routing
+## Data Machine Session Handoff
 
-All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
 
-Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
+Typical flow:
 
-If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.
+1. Create the checkout with `studio wp datamachine-code workspace worktree add <repo> <branch>`.
+2. Start the helper session with `datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'`.
+3. Use the helper thread for the isolated task and bring the result back here.

--- a/tests/effective-prompt/__snapshots__/default.raw.txt
+++ b/tests/effective-prompt/__snapshots__/default.raw.txt
@@ -68,40 +68,41 @@ This returns user IDs you can use for Discord mentions.
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user 'chubes'
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
 Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
+When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell.
 
 IMPORTANT: NEVER use `--worktree` unless the user explicitly asks for a worktree. Default to creating normal threads without worktrees.
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user 'chubes'
 
 Use --user to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --user 'chubes'
 
 Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
 
-kimaki send --channel 1493345787894038649 --prompt "Add dark mode support" --worktree dark-mode --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --user 'chubes'
 
 Use --cwd to start a session in an existing git worktree directory (must be a worktree of the project):
 
-kimaki send --channel 1493345787894038649 --prompt "Continue work on feature" --cwd /path/to/existing-worktree --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Continue work on feature' --cwd /path/to/existing-worktree --agent <current_agent> --user 'chubes'
 
 Important:
 - NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
@@ -112,7 +113,7 @@ Important:
 
 Use --agent to specify which agent to use for the session:
 
-kimaki send --channel 1493345787894038649 --prompt "Plan the refactor of the auth module" --agent plan --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --user 'chubes'
 
 
 Available agents:
@@ -123,8 +124,8 @@ Available agents:
 
 You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
 
-kimaki send --thread <thread_id> --prompt "/review fix the auth module" --agent <current_agent>
-kimaki send --channel 1493345787894038649 --prompt "/build-cmd update dependencies" --agent <current_agent> --user "chubes"
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user 'chubes'
 
 The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
 
@@ -134,14 +135,14 @@ The user can switch the active agent mid-session using the Discord slash command
 
 You can also switch agents via `kimaki send`:
 
-kimaki send --thread <thread_id> --prompt "/<agentname>-agent" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
 
 ## scheduled sends and task management
 
 Use `--send-at` to schedule a one-time or recurring task:
 
-kimaki send --channel 1493345787894038649 --prompt "Reminder: review open PRs" --send-at "2026-03-01T09:00:00Z" --agent <current_agent> --user "chubes"
-kimaki send --channel 1493345787894038649 --prompt "Run weekly test suite and summarize failures" --send-at "0 9 * * 1" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Reminder: review open PRs' --send-at '2026-03-01T09:00:00Z' --agent <current_agent> --user 'chubes'
+kimaki send --channel 1493345787894038649 --prompt 'Run weekly test suite and summarize failures' --send-at '0 9 * * 1' --agent <current_agent> --user 'chubes'
 
 ALL scheduling is in UTC. Dates must be UTC ISO format ending with `Z`. Cron expressions also fire in UTC (e.g. `0 9 * * 1` means 9:00 UTC every Monday).
 When the user specifies a time without a timezone, ask them to confirm their timezone or the UTC equivalent. Never guess the user's timezone.
@@ -177,14 +178,14 @@ kimaki task delete <id>
 
 Use case patterns:
 - Reminder flows: create deadline reminders in this channel with one-time `--send-at`; mention only if action is required.
-- Proactive reminders: when you encounter time-sensitive information during your work (e.g. creating an API key that expires in 90 days, a certificate with an expiration date, a trial period ending, a deadline mentioned in code comments), proactively schedule a `--notify-only` reminder before the expiration so the user gets notified in time. For example, if you generate an API key expiring on 2026-06-01, schedule a reminder a few days before: `kimaki send --channel 1493345787894038649 --prompt "Reminder: <@USER_ID> the API key created on 2026-03-01 expires on 2026-06-01. Renew it before it breaks production." --send-at "2026-05-28T09:00:00Z" --notify-only --agent <current_agent>`. Always tell the user you scheduled the reminder so they know.
+- Proactive reminders: when you encounter time-sensitive information during your work (e.g. creating an API key that expires in 90 days, a certificate with an expiration date, a trial period ending, a deadline mentioned in code comments), proactively schedule a `--notify-only` reminder before the expiration so the user gets notified in time. For example, if you generate an API key expiring on 2026-06-01, schedule a reminder a few days before: `kimaki send --channel 1493345787894038649 --prompt 'Reminder: <@USER_ID> the API key created on 2026-03-01 expires on 2026-06-01. Renew it before it breaks production.' --send-at '2026-05-28T09:00:00Z' --notify-only --agent <current_agent>`. Always tell the user you scheduled the reminder so they know.
 - Weekly QA: schedule "run full test suite, inspect failures, post summary, and mention @username only when failures require review".
 - Weekly benchmark automation: schedule a benchmark prompt that runs model evals, writes JSON outputs in the repo, commits results, and mentions only for regressions.
 - Recurring maintenance: use cron `--send-at` for repetitive tasks like rotating secrets, checking dependency updates, running security audits, or cleaning up stale branches. Example: `--send-at "0 9 1 * *"` to run on the 1st of every month.
 - Quiet no-op checks: if a recurring task checks something and finds nothing to report, let it post a brief final summary and then archive the session with `kimaki session archive --session ses_EFFECTIVE_PROMPT_TEST`. Example: a scheduled email triage run that finds no new emails should archive itself so it does not add noise to Discord.
 - Thread reminders: when the user says "remind me about this in 2 hours" (or any duration), use `--send-at` with `--thread` to resurface the current thread. Compute the future UTC time and send a mention so Discord shows a notification:
 
-kimaki send --session ses_EFFECTIVE_PROMPT_TEST --prompt "Reminder: <@USER_ID> you asked to be reminded about this thread." --send-at "<future_UTC_time>" --notify-only --agent <current_agent>
+kimaki send --session ses_EFFECTIVE_PROMPT_TEST --prompt 'Reminder: <@USER_ID> you asked to be reminded about this thread.' --send-at '<future_UTC_time>' --notify-only --agent <current_agent>
 
 Replace `<future_UTC_time>` with the computed UTC ISO timestamp. The `--notify-only` flag creates just a notification message without starting a new AI session. The `<@userId>` mention ensures the user gets a Discord notification.
 
@@ -199,7 +200,7 @@ ONLY create worktrees when the user explicitly asks for one. Never proactively u
 When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt "your task description" --worktree worktree-name --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --user 'chubes'
 ```
 
 This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
@@ -215,7 +216,7 @@ Critical recursion guard:
 Use `--cwd` to start a session in an existing git worktree directory instead of creating a new one:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt "Continue work on feature X" --cwd /path/to/existing-worktree --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Continue work on feature X' --cwd /path/to/existing-worktree --agent <current_agent> --user 'chubes'
 ```
 
 The path must be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses the worktree as its working directory. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing one.
@@ -229,7 +230,7 @@ This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
 When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt "Continuing from previous session: <summary of current task and state>" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --user 'chubes'
 ```
 
 The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
@@ -271,10 +272,13 @@ Then use grep/read tools on the file to find what you need.
 
 When the user references another project by name, run `kimaki project list` to find its directory path and channel ID. Then read files, search code, or run commands directly in that directory. If the project is not listed, use `kimaki project add /path/to/repo` to register it and create a Discord channel for it. Do not add subfolders of an existing project — only add root project directories.
 
+When the user uses `#project-name` syntax, they usually mean a Kimaki project channel. Use `kimaki project list --json` to resolve the `channel_name` to its repo working directory. Try the lookup yourself before acting, for example filter by `channel_name` with jq: `kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'`.
+
 ```bash
 # List all registered projects with their channel IDs
 kimaki project list
 kimaki project list --json  # machine-readable output
+kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'
 
 # Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
 kimaki project create my-new-app
@@ -287,10 +291,10 @@ To send a task to another project:
 
 ```bash
 # Send to a specific channel
-kimaki send --channel <channel_id> --prompt "Plan how to update the API client to v2" --agent <current_agent>
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
 
 # Or use --project to resolve from directory
-kimaki send --project /path/to/other-repo --prompt "Plan how to bump version to 1.2.0" --agent <current_agent>
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
 ```
 
 When sending prompts to other projects, always ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
@@ -313,10 +317,10 @@ If your Bash tool timeout triggers anyway, fall back to reading the session outp
 
 ```bash
 # Start a session and wait for it to finish
-kimaki send --channel <channel_id> --prompt "Fix the auth bug" --wait --agent <current_agent>
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait --agent <current_agent>
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt "Run the tests" --wait --agent <current_agent>
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
 ```
 
 The command exits with the session markdown on stdout once the model finishes responding.
@@ -539,17 +543,26 @@ Discord supports: headings, bold, italic, strikethrough, code blocks, inline cod
 
 NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
 
-### callouts for important content
+## Callouts in Kimaki Discord
 
-Prefer `<callout>` over `<aside>`, blockquotes, or plain bold text when you need a highlighted warning, action item, limitation, or gist box. `<callout>` is a Kimaki-specific rendering primitive, so it is more explicit and more likely to render the way you want.
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
 
-You can wrap important markdown in:
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
 
 ```md
 <callout accent="#f59e0b">
-## Warning
-- Tests still fail
-- I left TODO markers in the code
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
 </callout>
 ```
 

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -43,34 +43,6 @@ kimaki user list --guild <guildId> --query "username"
 
 This returns user IDs you can use for Discord mentions.
 
-## starting new sessions from CLI
-
-To start a new thread/session in this channel pro-grammatically, run:
-
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
-
-You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-
-To send a prompt to an existing thread instead of creating a new one:
-
-kimaki send --thread <thread_id> --prompt "follow-up prompt"
-
-Use this when you already have the Discord thread ID.
-
-To send to the thread associated with a known session:
-
-kimaki send --session <session_id> --prompt "follow-up prompt"
-
-Use this when you have the OpenCode session ID.
-
-Use --notify-only to create a notification thread without starting an AI session:
-
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
-
-Use --user to add a specific Discord user to the new thread:
-
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
-
 # List all registered projects with their channel IDs
 kimaki project list --json  # machine-readable output
 
@@ -97,7 +69,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt "Run the tests" --wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
 ```
 
 The command exits with the session markdown on stdout once the model finishes responding.
@@ -237,17 +209,26 @@ Discord supports: headings, bold, italic, strikethrough, code blocks, inline cod
 
 NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
 
-### callouts for important content
+## Callouts in Kimaki Discord
 
-Prefer `<callout>` over `<aside>`, blockquotes, or plain bold text when you need a highlighted warning, action item, limitation, or gist box. `<callout>` is a Kimaki-specific rendering primitive, so it is more explicit and more likely to render the way you want.
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
 
-You can wrap important markdown in:
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
 
 ```md
 <callout accent="#f59e0b">
-## Warning
-- Tests still fail
-- I left TODO markers in the code
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
 </callout>
 ```
 
@@ -323,10 +304,12 @@ On local WordPress Studio installs, use Studio and `studio wp` against the exist
 
 Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
 
-## Minion Session Routing
+## Data Machine Session Handoff
 
-All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
 
-Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
+Typical flow:
 
-If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.
+1. Create the checkout with `studio wp datamachine-code workspace worktree add <repo> <branch>`.
+2. Start the helper session with `datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'`.
+3. Use the helper thread for the isolated task and bring the result back here.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -43,34 +43,6 @@ kimaki user list --guild <guildId> --query "username"
 
 This returns user IDs you can use for Discord mentions.
 
-## starting new sessions from CLI
-
-To start a new thread/session in this channel pro-grammatically, run:
-
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --user "chubes"
-
-You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-
-To send a prompt to an existing thread instead of creating a new one:
-
-kimaki send --thread <thread_id> --prompt "follow-up prompt"
-
-Use this when you already have the Discord thread ID.
-
-To send to the thread associated with a known session:
-
-kimaki send --session <session_id> --prompt "follow-up prompt"
-
-Use this when you have the OpenCode session ID.
-
-Use --notify-only to create a notification thread without starting an AI session:
-
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --user "chubes"
-
-Use --user to add a specific Discord user to the new thread:
-
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --user "chubes"
-
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
@@ -129,17 +101,26 @@ Discord supports: headings, bold, italic, strikethrough, code blocks, inline cod
 
 NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
 
-### callouts for important content
+## Callouts in Kimaki Discord
 
-Prefer `<callout>` over `<aside>`, blockquotes, or plain bold text when you need a highlighted warning, action item, limitation, or gist box. `<callout>` is a Kimaki-specific rendering primitive, so it is more explicit and more likely to render the way you want.
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
 
-You can wrap important markdown in:
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
 
 ```md
 <callout accent="#f59e0b">
-## Warning
-- Tests still fail
-- I left TODO markers in the code
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
 </callout>
 ```
 
@@ -215,10 +196,12 @@ On local WordPress Studio installs, use Studio and `studio wp` against the exist
 
 Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
 
-## Minion Session Routing
+## Data Machine Session Handoff
 
-All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run `kimaki project list`, `kimaki project add`, `kimaki project create`, or `kimaki send --project` — those are cross-project discovery commands that route sessions to other agents' channels.
+For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
 
-Do not pass `--agent` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example `--agent opencode`) bypasses the channel binding and starts the wrong kind of session.
+Typical flow:
 
-If a minion needs to work in a different repo directory, use `kimaki send --cwd /path/to/repo` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (`studio wp datamachine-code workspace worktree add <repo> <branch>`) — the worktree becomes the `--cwd` target for any follow-up minion session.
+1. Create the checkout with `studio wp datamachine-code workspace worktree add <repo> <branch>`.
+2. Start the helper session with `datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'`.
+3. Use the helper thread for the isolated task and bring the result back here.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
@@ -66,40 +66,41 @@ This returns user IDs you can use for Discord mentions.
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt "your prompt here" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user 'chubes'
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
 Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
+When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell.
 
 IMPORTANT: NEVER use `--worktree` unless the user explicitly asks for a worktree. Default to creating normal threads without worktrees.
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt "follow-up prompt" --agent <current_agent>
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt "User cancelled subscription" --notify-only --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user 'chubes'
 
 Use --user to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt "Review the latest CI failure" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --user 'chubes'
 
 Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
 
-kimaki send --channel 1493345787894038649 --prompt "Add dark mode support" --worktree dark-mode --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --user 'chubes'
 
 Use --cwd to start a session in an existing git worktree directory (must be a worktree of the project):
 
-kimaki send --channel 1493345787894038649 --prompt "Continue work on feature" --cwd /path/to/existing-worktree --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Continue work on feature' --cwd /path/to/existing-worktree --agent <current_agent> --user 'chubes'
 
 Important:
 - NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
@@ -110,15 +111,15 @@ Important:
 
 Use --agent to specify which agent to use for the session:
 
-kimaki send --channel 1493345787894038649 --prompt "Plan the refactor of the auth module" --agent plan --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --user 'chubes'
 
 
 ## running opencode commands via kimaki send
 
 You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
 
-kimaki send --thread <thread_id> --prompt "/review fix the auth module" --agent <current_agent>
-kimaki send --channel 1493345787894038649 --prompt "/build-cmd update dependencies" --agent <current_agent> --user "chubes"
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user 'chubes'
 
 The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
 
@@ -128,14 +129,14 @@ The user can switch the active agent mid-session using the Discord slash command
 
 You can also switch agents via `kimaki send`:
 
-kimaki send --thread <thread_id> --prompt "/<agentname>-agent" --agent <current_agent>
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
 
 ## scheduled sends and task management
 
 Use `--send-at` to schedule a one-time or recurring task:
 
-kimaki send --channel 1493345787894038649 --prompt "Reminder: review open PRs" --send-at "2026-03-01T09:00:00Z" --agent <current_agent> --user "chubes"
-kimaki send --channel 1493345787894038649 --prompt "Run weekly test suite and summarize failures" --send-at "0 9 * * 1" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Reminder: review open PRs' --send-at '2026-03-01T09:00:00Z' --agent <current_agent> --user 'chubes'
+kimaki send --channel 1493345787894038649 --prompt 'Run weekly test suite and summarize failures' --send-at '0 9 * * 1' --agent <current_agent> --user 'chubes'
 
 ALL scheduling is in UTC. Dates must be UTC ISO format ending with `Z`. Cron expressions also fire in UTC (e.g. `0 9 * * 1` means 9:00 UTC every Monday).
 When the user specifies a time without a timezone, ask them to confirm their timezone or the UTC equivalent. Never guess the user's timezone.
@@ -171,14 +172,14 @@ kimaki task delete <id>
 
 Use case patterns:
 - Reminder flows: create deadline reminders in this channel with one-time `--send-at`; mention only if action is required.
-- Proactive reminders: when you encounter time-sensitive information during your work (e.g. creating an API key that expires in 90 days, a certificate with an expiration date, a trial period ending, a deadline mentioned in code comments), proactively schedule a `--notify-only` reminder before the expiration so the user gets notified in time. For example, if you generate an API key expiring on 2026-06-01, schedule a reminder a few days before: `kimaki send --channel 1493345787894038649 --prompt "Reminder: <@USER_ID> the API key created on 2026-03-01 expires on 2026-06-01. Renew it before it breaks production." --send-at "2026-05-28T09:00:00Z" --notify-only --agent <current_agent>`. Always tell the user you scheduled the reminder so they know.
+- Proactive reminders: when you encounter time-sensitive information during your work (e.g. creating an API key that expires in 90 days, a certificate with an expiration date, a trial period ending, a deadline mentioned in code comments), proactively schedule a `--notify-only` reminder before the expiration so the user gets notified in time. For example, if you generate an API key expiring on 2026-06-01, schedule a reminder a few days before: `kimaki send --channel 1493345787894038649 --prompt 'Reminder: <@USER_ID> the API key created on 2026-03-01 expires on 2026-06-01. Renew it before it breaks production.' --send-at '2026-05-28T09:00:00Z' --notify-only --agent <current_agent>`. Always tell the user you scheduled the reminder so they know.
 - Weekly QA: schedule "run full test suite, inspect failures, post summary, and mention @username only when failures require review".
 - Weekly benchmark automation: schedule a benchmark prompt that runs model evals, writes JSON outputs in the repo, commits results, and mentions only for regressions.
 - Recurring maintenance: use cron `--send-at` for repetitive tasks like rotating secrets, checking dependency updates, running security audits, or cleaning up stale branches. Example: `--send-at "0 9 1 * *"` to run on the 1st of every month.
 - Quiet no-op checks: if a recurring task checks something and finds nothing to report, let it post a brief final summary and then archive the session with `kimaki session archive --session ses_MINIMAL`. Example: a scheduled email triage run that finds no new emails should archive itself so it does not add noise to Discord.
 - Thread reminders: when the user says "remind me about this in 2 hours" (or any duration), use `--send-at` with `--thread` to resurface the current thread. Compute the future UTC time and send a mention so Discord shows a notification:
 
-kimaki send --session ses_MINIMAL --prompt "Reminder: <@USER_ID> you asked to be reminded about this thread." --send-at "<future_UTC_time>" --notify-only --agent <current_agent>
+kimaki send --session ses_MINIMAL --prompt 'Reminder: <@USER_ID> you asked to be reminded about this thread.' --send-at '<future_UTC_time>' --notify-only --agent <current_agent>
 
 Replace `<future_UTC_time>` with the computed UTC ISO timestamp. The `--notify-only` flag creates just a notification message without starting a new AI session. The `<@userId>` mention ensures the user gets a Discord notification.
 
@@ -193,7 +194,7 @@ ONLY create worktrees when the user explicitly asks for one. Never proactively u
 When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt "your task description" --worktree worktree-name --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --user 'chubes'
 ```
 
 This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
@@ -209,7 +210,7 @@ Critical recursion guard:
 Use `--cwd` to start a session in an existing git worktree directory instead of creating a new one:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt "Continue work on feature X" --cwd /path/to/existing-worktree --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Continue work on feature X' --cwd /path/to/existing-worktree --agent <current_agent> --user 'chubes'
 ```
 
 The path must be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses the worktree as its working directory. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing one.
@@ -223,7 +224,7 @@ This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
 When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt "Continuing from previous session: <summary of current task and state>" --agent <current_agent> --user "chubes"
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --user 'chubes'
 ```
 
 The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
@@ -265,10 +266,13 @@ Then use grep/read tools on the file to find what you need.
 
 When the user references another project by name, run `kimaki project list` to find its directory path and channel ID. Then read files, search code, or run commands directly in that directory. If the project is not listed, use `kimaki project add /path/to/repo` to register it and create a Discord channel for it. Do not add subfolders of an existing project — only add root project directories.
 
+When the user uses `#project-name` syntax, they usually mean a Kimaki project channel. Use `kimaki project list --json` to resolve the `channel_name` to its repo working directory. Try the lookup yourself before acting, for example filter by `channel_name` with jq: `kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'`.
+
 ```bash
 # List all registered projects with their channel IDs
 kimaki project list
 kimaki project list --json  # machine-readable output
+kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'
 
 # Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
 kimaki project create my-new-app
@@ -281,10 +285,10 @@ To send a task to another project:
 
 ```bash
 # Send to a specific channel
-kimaki send --channel <channel_id> --prompt "Plan how to update the API client to v2" --agent <current_agent>
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
 
 # Or use --project to resolve from directory
-kimaki send --project /path/to/other-repo --prompt "Plan how to bump version to 1.2.0" --agent <current_agent>
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
 ```
 
 When sending prompts to other projects, always ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
@@ -307,10 +311,10 @@ If your Bash tool timeout triggers anyway, fall back to reading the session outp
 
 ```bash
 # Start a session and wait for it to finish
-kimaki send --channel <channel_id> --prompt "Fix the auth bug" --wait --agent <current_agent>
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait --agent <current_agent>
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt "Run the tests" --wait --agent <current_agent>
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
 ```
 
 The command exits with the session markdown on stdout once the model finishes responding.
@@ -533,17 +537,26 @@ Discord supports: headings, bold, italic, strikethrough, code blocks, inline cod
 
 NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
 
-### callouts for important content
+## Callouts in Kimaki Discord
 
-Prefer `<callout>` over `<aside>`, blockquotes, or plain bold text when you need a highlighted warning, action item, limitation, or gist box. `<callout>` is a Kimaki-specific rendering primitive, so it is more explicit and more likely to render the way you want.
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
 
-You can wrap important markdown in:
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
 
 ```md
 <callout accent="#f59e0b">
-## Warning
-- Tests still fail
-- I left TODO markers in the code
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
 </callout>
 ```
 

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -81,16 +81,18 @@ function stripAgentOverrideInlines(block) {
   return result
 }
 
-function appendMinionRoutingInstruction(block) {
+function appendDataMachineSessionHandoffInstruction(block) {
   const instruction = `
 
-## Minion Session Routing
+## Data Machine Session Handoff
 
-All minion sessions for this agent go in THIS Discord channel — the one this session is running in. NEVER send sessions to other channels, even if you happen to know another channel ID. Do not run \`kimaki project list\`, \`kimaki project add\`, \`kimaki project create\`, or \`kimaki send --project\` — those are cross-project discovery commands that route sessions to other agents' channels.
+For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
 
-Do not pass \`--agent\` when spawning normal minion sessions. The channel selects the personal agent. Passing the runtime agent (for example \`--agent opencode\`) bypasses the channel binding and starts the wrong kind of session.
+Typical flow:
 
-If a minion needs to work in a different repo directory, use \`kimaki send --cwd /path/to/repo\` so the session stays in this channel but operates on a different checkout. For code changes in external repos, prefer Data Machine Code's workspace worktrees (\`studio wp datamachine-code workspace worktree add <repo> <branch>\`) — the worktree becomes the \`--cwd\` target for any follow-up minion session.
+1. Create the checkout with \`studio wp datamachine-code workspace worktree add <repo> <branch>\`.
+2. Start the helper session with \`datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'\`.
+3. Use the helper thread for the isolated task and bring the result back here.
 `
   return block.replace(/\s*$/, "") + instruction
 }
@@ -115,6 +117,7 @@ function currentFilter(block) {
   r = stripSection(r, "## upgrading kimaki")
   r = stripSection(r, "## scheduled sends and task management")
   r = stripSection(r, "## running dev servers with tunnel access")
+  r = stripSection(r, "## starting new sessions from CLI")
   r = stripSection(r, "## creating worktrees")
   r = stripSection(r, "## worktree")
   r = stripSection(r, "## cross-project commands")
@@ -132,7 +135,7 @@ function currentFilter(block) {
   r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
   r = appendWordPressSiteRuntimeInstruction(r)
-  r = appendMinionRoutingInstruction(r)
+  r = appendDataMachineSessionHandoffInstruction(r)
   return r
 }
 
@@ -157,6 +160,7 @@ function brokenFilter(block) {
   r = stripSectionBroken(r, "## upgrading kimaki")
   r = stripSectionBroken(r, "## scheduled sends and task management")
   r = stripSectionBroken(r, "## running dev servers with tunnel access")
+  r = stripSectionBroken(r, "## starting new sessions from CLI")
   r = stripSectionBroken(r, "## creating worktrees")
   r = stripSectionBroken(r, "## worktree")
   r = stripSectionBroken(r, "## cross-project commands")
@@ -174,7 +178,7 @@ function brokenFilter(block) {
   r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
   r = appendWordPressSiteRuntimeInstruction(r)
-  r = appendMinionRoutingInstruction(r)
+  r = appendDataMachineSessionHandoffInstruction(r)
   return r
 }
 

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -78,10 +78,9 @@ const DEFAULT_TRIGGERS = [
 ]
 
 const DEFAULT_ALLOW_LEAK_SECTIONS = [
-  // The filter intentionally appends this section with both `worktree` and
-  // `--cwd` in it, pointing agents at DMC's workspace. Counting it as a
-  // leak would defeat the purpose.
-  "## Minion Session Routing",
+  // The filter intentionally appends this section with DMC workspace handoff
+  // language and the bridge helper's `--cwd` option.
+  "## Data Machine Session Handoff",
 ]
 
 const DEFAULT_SCENARIO = {

--- a/tests/kimaki-session-helper-smoke.sh
+++ b/tests/kimaki-session-helper-smoke.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$ROOT/bridges/kimaki/bin/datamachine-kimaki-session"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+primary="$TMP/repo"
+worktree="$TMP/repo@helper-smoke"
+
+git init -q "$primary"
+git -C "$primary" -c user.name='Test User' -c user.email='test@example.test' commit --allow-empty -qm 'initial'
+git -C "$primary" worktree add -q -b helper-smoke "$worktree"
+
+output="$($HELPER \
+  --channel 123456789 \
+  --cwd "$worktree" \
+  --prompt 'Smoke helper handoff' \
+  --data-dir "$TMP/kimaki" \
+  --dry-run)"
+
+case "$output" in
+  *'"cwd":'*"$worktree"*'"primary":'*"$primary"*'"branch": "helper-smoke"'*)
+    echo "kimaki-session-helper smoke: PASS"
+    ;;
+  *)
+    echo "kimaki-session-helper smoke: FAIL" >&2
+    echo "$output" >&2
+    exit 1
+    ;;
+esac

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -736,7 +736,10 @@ _print_verify_block() {
     # Optional per-bridge addendum (e.g. kimaki's `ls plugins/` line). Falls
     # back to `<binary> --version` for bridges that don't define the hook.
     if bridge_has_hook verify_extra; then
-      log "  $(bridge_verify_extra)"
+      while IFS= read -r cmd; do
+        [ -n "$cmd" ] || continue
+        log "  $cmd"
+      done < <(bridge_verify_extra)
     else
       local primary
       primary=$(bridge_binaries | awk '{print $1}')


### PR DESCRIPTION
## Summary
- Add a `datamachine-kimaki-session` bridge helper that launches Kimaki sessions against existing DMC workspace checkouts without teaching DMC about Kimaki.
- Install and verify the helper through the existing Kimaki bridge adapter during setup/upgrade.
- Strip Kimaki's generic session/worktree affordances from the effective prompt and replace them with positive Data Machine session handoff guidance.

## Testing
- `node tests/effective-prompt/run.mjs`
- `tests/kimaki-session-helper-smoke.sh`
- `tests/bridge-render.sh`
- `tests/post-upgrade-restore.sh`
- `git diff --check`
- `./upgrade.sh --dry-run --wp-path "/Users/chubes/Studio/intelligence-chubes4" --kimaki-only`
- `bridges/kimaki/bin/datamachine-kimaki-session --channel 1493345787894038649 --cwd "/Users/chubes/Developer/wp-coding-agents@fix-dmc-kimaki-worktree-boundary" --prompt 'Smoke handoff dry run' --dry-run`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the Kimaki/DMC boundary, drafting the bridge helper and prompt filter changes, and running local verification. Chris reviewed the direction and remains responsible for the change.