### PR TITLE
Attach DMC primary checkouts as Homeboy components

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -69,19 +69,138 @@ create_dm_agent() {
 }
 
 sync_homeboy_availability() {
+  local homeboy_available=false
+
+  if command -v homeboy >/dev/null 2>&1; then
+    homeboy_available=true
+  fi
+
   if [ "$DRY_RUN" = true ]; then
-    if command -v homeboy >/dev/null 2>&1; then
+    if [ "$homeboy_available" = true ]; then
       echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update datamachine_code_homeboy_available 1"
     else
       echo -e "${BLUE}[dry-run]${NC} $WP_CMD option delete datamachine_code_homeboy_available"
     fi
+    sync_homeboy_project_components
     return 0
   fi
 
-  if command -v homeboy >/dev/null 2>&1; then
+  if [ "$homeboy_available" = true ]; then
     wp_cmd option update datamachine_code_homeboy_available 1 >/dev/null 2>&1 || \
       warn "Could not record Homeboy availability for AGENTS.md compose"
+    sync_homeboy_project_components
   else
     wp_cmd option delete datamachine_code_homeboy_available >/dev/null 2>&1 || true
   fi
+}
+
+discover_dm_workspace_dir() {
+  if [ -n "${DATAMACHINE_WORKSPACE_PATH:-}" ]; then
+    DM_WORKSPACE_DIR="$DATAMACHINE_WORKSPACE_PATH"
+    return 0
+  fi
+
+  if [ "${DRY_RUN:-false}" = true ] || [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
+    return 0
+  fi
+
+  local workspace_path
+  workspace_path=$(wp_cmd datamachine-code workspace path 2>/dev/null || true)
+  if [ -n "$workspace_path" ]; then
+    DM_WORKSPACE_DIR="$workspace_path"
+  fi
+}
+
+homeboy_project_id() {
+  if [ -n "${HOMEBOY_PROJECT_ID:-}" ]; then
+    printf '%s\n' "$HOMEBOY_PROJECT_ID"
+    return 0
+  fi
+
+  if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/homeboy.json" ]; then
+    return 1
+  fi
+
+  python3 - "$SITE_PATH/homeboy.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    project_id = json.load(handle).get("id", "")
+
+if project_id:
+    print(project_id)
+PY
+}
+
+sync_homeboy_project_components() {
+  if ! command -v homeboy >/dev/null 2>&1; then
+    return 0
+  fi
+
+  discover_dm_workspace_dir
+
+  local project_id
+  if ! project_id=$(homeboy_project_id); then
+    warn "Homeboy project config not found at site root — skipping DMC component attachment"
+    return 0
+  fi
+
+  if [ -z "${DM_WORKSPACE_DIR:-}" ]; then
+    warn "DMC workspace path not configured — skipping Homeboy component attachment"
+    return 0
+  fi
+
+  if [ ! -d "$DM_WORKSPACE_DIR" ]; then
+    warn "DMC workspace path does not exist ($DM_WORKSPACE_DIR) — skipping Homeboy component attachment"
+    return 0
+  fi
+
+  log "Attaching Homeboy components from DMC workspace: $DM_WORKSPACE_DIR"
+
+  local attached=0
+  local skipped=0
+  local failed=0
+  local repo_path repo_name
+
+  shopt -s nullglob
+  for repo_path in "$DM_WORKSPACE_DIR"/*; do
+    [ -d "$repo_path" ] || continue
+    repo_name=$(basename "$repo_path")
+
+    if [ -n "${SITE_PATH:-}" ] && [ "$repo_path" = "$SITE_PATH" ]; then
+      log "  skipped $repo_name: site project root"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [[ "$repo_name" == *"@"* ]]; then
+      log "  skipped $repo_name: worktree skipped"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [ ! -f "$repo_path/homeboy.json" ]; then
+      log "  skipped $repo_name: no homeboy.json"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [ "${DRY_RUN:-false}" = true ]; then
+      echo -e "${BLUE}[dry-run]${NC} homeboy project components attach-path $project_id $repo_path"
+      attached=$((attached + 1))
+      continue
+    fi
+
+    if homeboy project components attach-path "$project_id" "$repo_path" >/dev/null; then
+      log "  attached $repo_name"
+      attached=$((attached + 1))
+    else
+      warn "  failed $repo_name: homeboy attach-path failed"
+      failed=$((failed + 1))
+    fi
+  done
+  shopt -u nullglob
+
+  log "Homeboy component sync complete: $attached attached, $skipped skipped, $failed failed"
 }

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# tests/homeboy-components.sh — unit test for DMC workspace Homeboy component attachment.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/data-machine.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SITE_PATH="$TMP/site"
+DM_WORKSPACE_DIR="$TMP/workspace"
+WP_CMD="wp"
+DRY_RUN=false
+mkdir -p "$SITE_PATH" "$DM_WORKSPACE_DIR"
+
+cat > "$SITE_PATH/homeboy.json" <<'JSON'
+{"id":"site-project"}
+JSON
+
+mkdir -p \
+  "$DM_WORKSPACE_DIR/alpha" \
+  "$DM_WORKSPACE_DIR/beta" \
+  "$DM_WORKSPACE_DIR/alpha@feature" \
+  "$DM_WORKSPACE_DIR/no-metadata"
+
+cat > "$DM_WORKSPACE_DIR/alpha/homeboy.json" <<'JSON'
+{"id":"alpha"}
+JSON
+cat > "$DM_WORKSPACE_DIR/beta/homeboy.json" <<'JSON'
+{"id":"beta"}
+JSON
+cat > "$DM_WORKSPACE_DIR/alpha@feature/homeboy.json" <<'JSON'
+{"id":"alpha-feature"}
+JSON
+
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/homeboy" <<'SH'
+#!/bin/sh
+if [ "$1 $2 $3" = "project components attach-path" ]; then
+  printf '%s|%s\n' "$4" "$5" >> "$HOMEBOY_ATTACH_LOG"
+  exit 0
+fi
+exit 2
+SH
+chmod +x "$FAKE_BIN/homeboy"
+
+HOMEBOY_ATTACH_LOG="$TMP/attached.log"
+export HOMEBOY_ATTACH_LOG
+PATH="$FAKE_BIN:$PATH"
+
+assert_contains() {
+  local needle="$1" file="$2"
+  if ! grep -qF "$needle" "$file"; then
+    echo "FAIL: expected '$needle' in $file"
+    cat "$file"
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1" file="$2"
+  if grep -qF "$needle" "$file"; then
+    echo "FAIL: unexpected '$needle' in $file"
+    cat "$file"
+    exit 1
+  fi
+}
+
+sync_homeboy_project_components > "$TMP/output.log"
+
+assert_contains "site-project|$DM_WORKSPACE_DIR/alpha" "$HOMEBOY_ATTACH_LOG"
+assert_contains "site-project|$DM_WORKSPACE_DIR/beta" "$HOMEBOY_ATTACH_LOG"
+assert_not_contains "alpha@feature" "$HOMEBOY_ATTACH_LOG"
+assert_not_contains "no-metadata" "$HOMEBOY_ATTACH_LOG"
+
+assert_contains "skipped alpha@feature: worktree skipped" "$TMP/output.log"
+assert_contains "skipped no-metadata: no homeboy.json" "$TMP/output.log"
+assert_contains "Homeboy component sync complete: 2 attached, 2 skipped, 0 failed" "$TMP/output.log"
+
+DRY_RUN=true
+HOMEBOY_ATTACH_LOG="$TMP/dry-run-attached.log"
+export HOMEBOY_ATTACH_LOG
+sync_homeboy_project_components > "$TMP/dry-run-output.log"
+
+if [ -f "$HOMEBOY_ATTACH_LOG" ]; then
+  echo "FAIL: dry-run should not call homeboy attach-path"
+  cat "$HOMEBOY_ATTACH_LOG"
+  exit 1
+fi
+assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/alpha" "$TMP/dry-run-output.log"
+assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/beta" "$TMP/dry-run-output.log"
+
+echo "OK: Homeboy component attachment skips worktrees and metadata-less repos"


### PR DESCRIPTION
## Summary
- Discover the configured Data Machine Code workspace path before Homeboy component sync.
- Attach only primary workspace directories that already contain `homeboy.json` via `homeboy project components attach-path`.
- Report skipped directories, including `@` worktrees and repos without `homeboy.json`, while supporting dry-run/fake Homeboy verification.

## Testing
- `bash -n lib/data-machine.sh tests/homeboy-components.sh setup.sh upgrade.sh`
- `bash -c 'set -e; while IFS= read -r -d "" f; do bash -n "$f"; done < <(find . -type f -name "*.sh" -not -path "./.git/*" -print0)'`
- `./tests/homeboy-components.sh`
- `./tests/bridge-render.sh`
- `./tests/path-helpers.sh`
- Real DMC workspace discovery against `/Users/chubes/Studio/intelligence-chubes4` with a fake `homeboy` binary, confirming `/Users/chubes/Developer` discovery without mutating live Homeboy config.

## Notes
- `homeboy lint` was attempted, but this component has no Homeboy extensions configured, so Homeboy returned `Component 'wp-coding-agents' has no extensions configured`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the shell changes and targeted tests; Chris remains responsible for review and merge.

Fixes #96