### PR TITLE
Register Homeboy project during setup

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Homeboy project registration for the installed WordPress site.
+
+homeboy_slugify() {
+  printf '%s' "$1" | sed 's|https\?://||; s|/.*$||; s|\..*$||' | \
+    tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//'
+}
+
+homeboy_json_escape() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  printf '%s' "$value"
+}
+
+homeboy_project_json() {
+  local domain base_path server_id
+  domain="$(homeboy_json_escape "$1")"
+  base_path="$(homeboy_json_escape "$2")"
+  server_id="$(homeboy_json_escape "${3:-}")"
+
+  printf '{"domain":"%s","base_path":"%s"' "$domain" "$base_path"
+  if [ -n "$server_id" ]; then
+    printf ',"server_id":"%s"' "$server_id"
+  fi
+  printf '}'
+}
+
+homeboy_server_json() {
+  local user port
+  user="$(homeboy_json_escape "$1")"
+  port="$2"
+  printf '{"host":"localhost","user":"%s","port":%s}' "$user" "$port"
+}
+
+homeboy_project_id() {
+  if [ -n "${HOMEBOY_PROJECT_ID:-}" ]; then
+    printf '%s' "$HOMEBOY_PROJECT_ID"
+  elif [ -n "${AGENT_SLUG:-}" ]; then
+    printf '%s' "$AGENT_SLUG"
+  else
+    homeboy_slugify "${SITE_DOMAIN:-$SITE_PATH}"
+  fi
+}
+
+homeboy_server_id() {
+  if [ "$LOCAL_MODE" = true ]; then
+    printf 'local'
+    return 0
+  fi
+
+  if [ -n "${HOMEBOY_SERVER_ID:-}" ]; then
+    printf '%s' "$HOMEBOY_SERVER_ID"
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = false ] && homeboy server show "$SITE_DOMAIN" >/dev/null 2>&1; then
+    printf '%s' "$SITE_DOMAIN"
+  fi
+
+  return 0
+}
+
+ensure_homeboy_local_server() {
+  if [ "$LOCAL_MODE" != true ]; then
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} homeboy server set local --json '{\"host\":\"localhost\",\"user\":\"$(whoami)\",\"port\":22}'"
+    return 0
+  fi
+
+  if homeboy server show local >/dev/null 2>&1; then
+    homeboy server set local --json "$(homeboy_server_json "$(whoami)" 22)" >/dev/null
+  else
+    homeboy server create local --host localhost --user "$(whoami)" --port 22 >/dev/null
+  fi
+}
+
+setup_homeboy_project() {
+  if [ "${HOMEBOY_MODE:-auto}" = "disabled" ]; then
+    log "Skipping Homeboy project setup (--no-homeboy)"
+    return 0
+  fi
+
+  if ! command -v homeboy >/dev/null 2>&1; then
+    if [ "${HOMEBOY_MODE:-auto}" = "enabled" ]; then
+      error "Homeboy project setup requested, but the 'homeboy' command was not found"
+    fi
+    log "Skipping Homeboy project setup (homeboy not installed)"
+    return 0
+  fi
+
+  local project_id server_id spec
+  project_id="$(homeboy_project_id)"
+  HOMEBOY_PROJECT_ID="$project_id"
+  server_id="$(homeboy_server_id)"
+  HOMEBOY_SERVER_ID_RESOLVED="$server_id"
+  spec="$(homeboy_project_json "$SITE_DOMAIN" "$SITE_PATH" "$server_id")"
+
+  log "Phase 4.6: Creating/updating Homeboy project '$project_id' for WordPress site"
+  log "Homeboy project target: domain=$SITE_DOMAIN path=$SITE_PATH${server_id:+ server=$server_id}"
+
+  ensure_homeboy_local_server
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} homeboy project set $project_id --json '$spec' || homeboy project create $project_id $SITE_DOMAIN --base-path '$SITE_PATH'${server_id:+ --server-id $server_id}"
+    return 0
+  fi
+
+  if homeboy project show "$project_id" >/dev/null 2>&1; then
+    homeboy project set "$project_id" --json "$spec" >/dev/null
+    log "Updated Homeboy project '$project_id'"
+  else
+    if [ -n "$server_id" ]; then
+      homeboy project create "$project_id" "$SITE_DOMAIN" --base-path "$SITE_PATH" --server-id "$server_id" >/dev/null
+    else
+      homeboy project create "$project_id" "$SITE_DOMAIN" --base-path "$SITE_PATH" >/dev/null
+    fi
+    log "Created Homeboy project '$project_id'"
+  fi
+}

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -37,6 +37,16 @@ print_summary() {
   echo "  Code tools:  data-machine-code (workspace, GitHub, git)"
   echo "  Workspace:   $DM_WORKSPACE_DIR (created on first use)"
   echo ""
+  if [ "${HOMEBOY_MODE:-auto}" != "disabled" ] && [ -n "${HOMEBOY_PROJECT_ID:-}" ]; then
+    echo "Homeboy:"
+    echo "  Project:     $HOMEBOY_PROJECT_ID"
+    echo "  Site path:   $SITE_PATH"
+    if [ -n "${HOMEBOY_SERVER_ID_RESOLVED:-}" ]; then
+      echo "  Server:      $HOMEBOY_SERVER_ID_RESOLVED"
+    fi
+    echo "  Show:        homeboy project show $HOMEBOY_PROJECT_ID"
+    echo ""
+  fi
   echo "Agent:"
   if [ "$LOCAL_MODE" = true ]; then
     echo "  User:     $(whoami) (local)"

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect wordpress infrastructure data-machine skills summary; do
+for lib in common detect wordpress infrastructure data-machine homeboy skills summary; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -58,6 +58,8 @@ INSTALL_SKILLS=true
 SKILLS_ONLY=false
 RUNTIME_ONLY=false
 RUNTIME=""
+HOMEBOY_MODE="auto"
+HOMEBOY_PROJECT_ID="${HOMEBOY_PROJECT_ID:-}"
 DETECTED_RUNTIMES=()
 IS_STUDIO=false
 
@@ -124,6 +126,18 @@ while [[ $# -gt 0 ]]; do
       INSTALL_SKILLS=false
       shift
       ;;
+    --with-homeboy)
+      HOMEBOY_MODE="enabled"
+      shift
+      ;;
+    --no-homeboy)
+      HOMEBOY_MODE="disabled"
+      shift
+      ;;
+    --homeboy-project-id)
+      HOMEBOY_PROJECT_ID="$2"
+      shift 2
+      ;;
     --runtime-only)
       RUNTIME_ONLY=true
       MODE="existing"
@@ -185,6 +199,10 @@ OPTIONS:
   --multisite        Convert to WordPress Multisite (subdirectory by default)
   --subdomain        Use subdomain multisite (requires wildcard DNS; use with --multisite)
   --no-skills        Skip WordPress agent skills installation
+  --with-homeboy     Create/update a Homeboy project for this WordPress site
+  --no-homeboy       Skip Homeboy project setup, even if homeboy is installed
+  --homeboy-project-id <id>
+                     Override Homeboy project ID (default: agent/site slug)
   --skills-only      Only run skills installation on existing site
   --skip-ssl         Skip SSL/HTTPS configuration
   --root             Run agent as root (default)
@@ -201,6 +219,8 @@ ENVIRONMENT VARIABLES:
   DB_PASS            Database password (auto-generated if not set)
   AGENT_SLUG         Override agent slug (default: derived from domain)
   AGENT_NAME         Override agent display name (default: blogname)
+  HOMEBOY_PROJECT_ID Override Homeboy project ID (default: agent/site slug)
+  HOMEBOY_SERVER_ID  Homeboy server ID for VPS project registration
   OPENCODE_MODEL     Override default model (e.g., anthropic/claude-sonnet-4-20250514)
   OPENCODE_SMALL_MODEL  Override small model (e.g., anthropic/claude-haiku-4-5)
   KIMAKI_BOT_TOKEN          Discord bot token (skip interactive setup)
@@ -299,6 +319,7 @@ if [ "$RUNTIME_ONLY" != true ]; then
   install_data_machine
   create_dm_agent
   install_extra_plugins
+  setup_homeboy_project
   setup_nginx
   setup_ssl
   setup_service_permissions


### PR DESCRIPTION
## Summary
- Add setup flags for Homeboy project registration: `--with-homeboy`, `--no-homeboy`, and `--homeboy-project-id`.
- Create or update a Homeboy project for the installed WordPress site when Homeboy is available or explicitly requested.
- Use the local Homeboy server identity for local/Studio installs and keep output distinct from attached component repos.

## Testing
- `bash -n setup.sh lib/homeboy.sh lib/summary.sh`
- `HOMEBOY_PROJECT_ID=wca-issue-95-dry-run EXISTING_WP=/tmp/wca-fake-site ./setup.sh --local --dry-run --with-homeboy --no-chat --no-skills --runtime opencode`
- `EXISTING_WP=/tmp/wca-fake-site ./setup.sh --local --dry-run --no-homeboy --no-chat --no-skills --runtime opencode`
- `bash -c 'source lib/common.sh; source lib/homeboy.sh; homeboy_project_json "example.com" "/tmp/path with spaces" local; printf "\n"; homeboy_server_json "user name" 22'`
- `PATH=/usr/bin:/bin bash -c 'DRY_RUN=true; HOMEBOY_MODE=enabled; source lib/common.sh; source lib/homeboy.sh; setup_homeboy_project'` (expected failure when requested but Homeboy is absent)
- `tests/path-helpers.sh`
- `tests/bridge-render.sh`
- `tests/kimaki-session-helper-smoke.sh`
- `./setup.sh --help`
- `homeboy project create --help`
- `homeboy project show intelligence-chubes4`
- `homeboy status --path .`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing setup-script changes, drafting shell helpers, running targeted verification, and preparing this PR description. Chris remains responsible for review and merge.

Fixes #95