### PR TITLE
fix(kimaki): reap orphaned opencode-serve children on service start

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -467,6 +467,17 @@ Type=simple
 User=$SERVICE_USER
 WorkingDirectory=$SITE_PATH
 $env_block
+# Reap stray opencode-serve children left behind by the previous kimaki
+# process before starting a fresh one. Each kimaki session spawns its own
+# opencode-serve worker; if kimaki exits uncleanly (crash, OOM, manual
+# kill) those workers are reparented to PID 1 and keep running. They all
+# share \$HOME/.local/share/opencode/auth.json, so concurrent OAuth
+# refreshes race each other — Anthropic rotates the refresh token on every
+# use, and the loser of the race gets HTTP 400 invalid_grant on its next
+# request. \`pkill -u $SERVICE_USER\` scopes the kill to this service's
+# user so multi-tenant hosts aren't sniped. The \`-\` prefix makes systemd
+# tolerate exit code 1 (no matches found, the happy path on a clean box).
+ExecStartPre=-/usr/bin/pkill -TERM -u $SERVICE_USER -f "opencode-ai/bin/.*serve"
 ExecStartPre=$KIMAKI_CONFIG_DIR/post-upgrade.sh
 ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique
 Restart=always


### PR DESCRIPTION
## Summary

Each kimaki session spawns its own `opencode-serve` worker. If kimaki exits uncleanly (crash, OOM, manual kill, upgrade) those workers are reparented to PID 1 and keep running indefinitely. On `extrachill.com` we observed **14 stale opencode-serve processes** accumulated over 5 days.

All workers share `$HOME/.local/share/opencode/auth.json`. Concurrent OAuth refreshes race each other — Anthropic rotates the refresh token on every use, and whichever process loses the race gets:

```
HTTP 400 from https://platform.claude.com/v1/oauth/token:
{"error": "invalid_grant", "error_description": "Refresh token not found or invalid"}
```

User-visible symptom: kimaki "drops" its anthropic auth every few minutes whenever any active session triggers a refresh while another holds a stale in-memory copy.

## Fix

One new `ExecStartPre` in the kimaki.service template at `bridges/kimaki.sh::bridge_render_systemd`:

```ini
ExecStartPre=-/usr/bin/pkill -TERM -u $SERVICE_USER -f "opencode-ai/bin/.*serve"
```

Runs before the existing `post-upgrade.sh` hook on every kimaki start. Sends SIGTERM to any opencode-serve owned by the service user. The `-` prefix lets systemd tolerate exit 1 (no matches — the happy path on a clean install). The `-u $SERVICE_USER` filter prevents sniping anything outside this service's own children on multi-tenant hosts.

## Verified

- Rendered template against `SERVICE_USER=root` and confirmed `systemd-analyze verify` exits clean.
- Pattern `opencode-ai/bin/.*serve` matches both wrapper (`node /usr/lib/.../opencode serve ...`) and inner binary (`/usr/lib/.../.opencode serve ...`) variants — both forms appear in the same process tree.
- Pattern does NOT match the kimaki main process or one-shot `opencode` CLI invocations (no `serve` arg).

## Migration

Existing installs pick up the new template on next `upgrade.sh` run. `bridge_update_systemd` (Phase 5) detects the changed unit via `_smart_update_systemd_unit`, writes a backup, daemon-reloads, and prompts the operator for a manual restart per the existing pattern. No new migration code required.

## Out of scope

- **Local launchd installs.** No equivalent `ExecStartPre` hook on macOS. Kimaki on laptops doesn't accumulate zombies the way long-lived VPS installs do — the user restarts kimaki by closing the terminal, which reaps the children.
- **Single-flight refresh / file-locking the HTTP round-trip.** That's a kimaki-package concern (`anthropic-auth-plugin.ts` lives in `remorses/kimaki`), not a harness concern.
- **Promoting opencode-serve to its own systemd unit** (the proper fix that eliminates the race entirely, mirroring how the telegram bridge already works). Much bigger refactor; tracked as future work.

## Affects all OAuth providers

Worth flagging: `auth.json` is the **universal** opencode credential store — anthropic, openai, openrouter, etc. all live in that one file, all rewritten as a unit on every refresh. So this race breaks every OAuth provider equally, not just Anthropic. The fix is provider-agnostic.