### PR TITLE
fix(kimaki): strip project routing guidance

### DIFF
--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -25,11 +25,12 @@
 //    --project` / `session search --channel <id>`. These are cross-project
 //    discovery vectors; on a single-project fleet server the agent only ever
 //    needs to list sessions in the current project (no flags required).
-// 11. Project discovery inlines — scattered `kimaki project list|add|create`,
-//    `kimaki send --project`, and bare `kimaki send --channel <channel_id>`
-//    examples that survive section stripping. These let the agent discover
-//    other Discord channels and route minion sessions away from the current
-//    thread. See Extra-Chill/data-machine-code#49.
+// 11. Project discovery/guidance inlines — scattered prose and examples for
+//    `kimaki project list|add|create`, `kimaki send --project`, bare
+//    `kimaki send --channel <channel_id>`, `#project-name` resolution, and
+//    "project channel" routing. These let the agent discover other Discord
+//    channels and route minion sessions away from the current thread. See
+//    Extra-Chill/data-machine-code#49.
 // 12. Agent override inlines — `--agent <current_agent>` examples from the
 //    generic Kimaki prompt. On DM-managed sites the Discord channel owns the
 //    personal-agent binding; passing the runtime agent (for example `opencode`)
@@ -244,7 +245,7 @@ function stripWorktreeInlines(block: string): string {
 }
 
 /**
- * Remove project / channel discovery examples that survive section stripping.
+ * Remove project / channel discovery guidance that survives section stripping.
  *
  * The system prompt bakes the current channel ID into most `kimaki send`
  * examples via `${channelId}`, which is the safe/correct form for this
@@ -257,6 +258,8 @@ function stripWorktreeInlines(block: string): string {
  *   - `kimaki send --channel <channel_id>` with a literal `<channel_id>`
  *     placeholder (as opposed to the baked-in current-channel ID) — teaches
  *     the agent it can pick a channel freely.
+ *   - `#project-name` / "project channel" prose — teaches the agent to treat
+ *     repo/project channels as valid routing targets.
  *
  * On DM-managed sites the current Discord thread is the only correct target
  * for minion sessions. Cross-repo work uses DM Code's workspace worktrees,
@@ -267,6 +270,28 @@ function stripWorktreeInlines(block: string): string {
  */
 function stripProjectDiscoveryInlines(block: string): string {
   let result = block;
+
+  // If upstream renames the cross-project section, strip its distinctive prose
+  // before deleting leftover command lines below.
+  result = result.replace(
+    /\n+When the user references another project by name,[\s\S]*?root project directories\.\n/g,
+    "\n"
+  );
+
+  result = result.replace(
+    /\n+When the user uses `#project-name` syntax,[\s\S]*?before acting,[^\n]*\n/g,
+    "\n"
+  );
+
+  result = result.replace(
+    /\n+To send a task to another project:[\s\S]*?(?=\n\S|$)/g,
+    "\n"
+  );
+
+  result = result.replace(
+    /\n+When sending prompts to other projects,[^\n]*\n/g,
+    "\n"
+  );
 
   // Standalone `kimaki project ...` commands on their own lines (inside any
   // surviving section or orphaned between sections). Covers list|add|create.
@@ -302,6 +327,13 @@ function stripProjectDiscoveryInlines(block: string): string {
   // dominant content (starts with command + --project).
   result = result.replace(
     /\n+kimaki (?:session|task) [^\n]*--project [^\n]*\n/g,
+    "\n"
+  );
+
+  // Remove any whole-line project-routing prose that may survive if Kimaki
+  // changes surrounding headings or examples.
+  result = result.replace(
+    /\n+[^\n]*(?:project channel|cross-project|#project-name|other project|another project)[^\n]*\n/gi,
     "\n"
   );
 

--- a/tests/effective-prompt/README.md
+++ b/tests/effective-prompt/README.md
@@ -2,8 +2,9 @@
 
 Pluggable harness that renders the kimaki opencode system prompt, runs the
 `dm-context-filter` plugin over it, snapshots the result, and asserts that
-no banned phrases (`worktree`, `--cwd`, etc) leak into the filtered prompt
-that an opencode session actually sees.
+no banned phrases (`worktree`, `--cwd`, `kimaki project`, `--project`,
+`#project-name`, etc) leak into the filtered prompt that an opencode session
+actually sees.
 
 ## Why
 
@@ -49,8 +50,8 @@ Each scenario is a JSON file in `scenarios/`. Override any of:
 - **`baseline`** — name from `filters.mjs`. Default
   `"broken-stripsection"` (proves new filter strips strictly more).
 - **`triggers`** — array of `{ name, pattern }`. Pattern is a JS regex
-  string; prefix with `(?i)` for case-insensitive. Default: `worktree`
-  + `--cwd`.
+  string; prefix with `(?i)` for case-insensitive. Default: `worktree`,
+  `--cwd`, `--agent`, and Kimaki project/channel routing guidance.
 - **`allowLeakInSection`** — array of section headings (e.g. `"## Minion
   Session Routing"`) where trigger matches are intentional and must not
   count as leaks.

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -53,20 +53,15 @@ kimaki project list --json  # machine-readable output
 # Add an existing directory as a project
 ```
 
-To send a task to another project:
-
 ```bash
 # Send to a specific channel
 
 # Or use --project to resolve from directory
 ```
 
-When sending prompts to other projects, always ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
-
 Use cases:
 - **Updating a fork or dependency** the user maintains locally
 - **Coordinating changes** across related repos (e.g., SDK + docs)
-- **Delegating subtasks** to isolated sessions in other projects
 
 # Start a session and wait for it to finish
 
@@ -77,7 +72,6 @@ kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
 The command exits with the session markdown on stdout once the model finishes responding.
 
 Use `--wait` when you need to:
-- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
 - **Run a task in a separate worktree** and use the result in your current session
 - **Chain sessions sequentially** where the next depends on the previous output
 

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -51,20 +51,15 @@ kimaki project list --json  # machine-readable output
 # Add an existing directory as a project
 ```
 
-To send a task to another project:
-
 ```bash
 # Send to a specific channel
 
 # Or use --project to resolve from directory
 ```
 
-When sending prompts to other projects, always ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
-
 Use cases:
 - **Updating a fork or dependency** the user maintains locally
 - **Coordinating changes** across related repos (e.g., SDK + docs)
-- **Delegating subtasks** to isolated sessions in other projects
 
 # Start a session and wait for it to finish
 
@@ -75,7 +70,6 @@ kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
 The command exits with the session markdown on stdout once the model finishes responding.
 
 Use `--wait` when you need to:
-- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
 - **Run a task in a separate worktree** and use the result in your current session
 - **Chain sessions sequentially** where the next depends on the previous output
 

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -20,7 +20,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const PLUGIN_PATH = join(__dirname, "..", "..", "kimaki", "plugins", "dm-context-filter.ts")
+const PLUGIN_PATH = join(__dirname, "..", "..", "bridges", "kimaki", "plugins", "dm-context-filter.ts")
 
 // ---------------------------------------------------------------------------
 // "current" filter — extract the filter helpers from the live plugin
@@ -65,11 +65,16 @@ function stripWorktreeInlines(block) {
 
 function stripProjectDiscoveryInlines(block) {
   let result = block
+  result = result.replace(/\n+When the user references another project by name,[\s\S]*?root project directories\.\n/g, "\n")
+  result = result.replace(/\n+When the user uses `#project-name` syntax,[\s\S]*?before acting,[^\n]*\n/g, "\n")
+  result = result.replace(/\n+To send a task to another project:[\s\S]*?(?=\n\S|$)/g, "\n")
+  result = result.replace(/\n+When sending prompts to other projects,[^\n]*\n/g, "\n")
   result = result.replace(/\n+kimaki project (?:list|add|create)[^\n]*\n/g, "\n")
   result = result.replace(/\n+kimaki send --project [^\n]*\n/g, "\n")
   result = result.replace(/\n+kimaki send --channel <channel_id>[^\n]*\n/g, "\n")
   result = result.replace(/\n+kimaki session search [^\n]*--channel <channel_id>[^\n]*\n/g, "\n")
   result = result.replace(/\n+kimaki (?:session|task) [^\n]*--project [^\n]*\n/g, "\n")
+  result = result.replace(/\n+[^\n]*(?:project channel|cross-project|#project-name|other project|another project)[^\n]*\n/gi, "\n")
   return result
 }
 

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -9,8 +9,8 @@
 // kimaki-shipped system prompt. Three things make it durable:
 //
 //   1. It loads the LIVE installed kimaki module (not a copy), so a
-//      kimaki upgrade that introduces new --worktree language fails the
-//      next test run.
+//      kimaki upgrade that introduces new --worktree or project-routing
+//      language fails the next test run.
 //   2. It loads the LIVE plugin source from kimaki/plugins/, so a filter
 //      change in this repo immediately reflows the snapshots.
 //   3. It writes named .txt snapshots to __snapshots__/, so reviewers
@@ -27,7 +27,8 @@
 //     "broken-stripsection" (the regex-only stripSection that misfires
 //     on fenced bash comments). The harness asserts the baseline
 //     strips strictly LESS than the current filter.
-//   - triggers: array of { name, pattern }. Default: worktree + --cwd.
+//   - triggers: array of { name, pattern }. Default: worktree, --cwd,
+//     --agent, and Kimaki project/channel routing language.
 //     Lines matching any trigger in the filtered output count as leaks.
 //   - allowLeakInSection: array of section headings where trigger
 //     matches are intentional (e.g. the appended Minion Routing note
@@ -72,9 +73,16 @@ const VERBOSE = args.includes("--verbose")
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TRIGGERS = [
-  { name: "worktree", pattern: "(?i)worktree" },
-  { name: "--cwd",    pattern: "--cwd"        },
-  { name: "--agent",  pattern: "--agent"      },
+  { name: "worktree",        pattern: "(?i)worktree"             },
+  { name: "--cwd",           pattern: "--cwd"                    },
+  { name: "--agent",         pattern: "--agent"                  },
+  { name: "kimaki project",  pattern: "kimaki project"           },
+  { name: "--project",       pattern: "--project"                },
+  { name: "project channel", pattern: "(?i)project channel"      },
+  { name: "cross-project",   pattern: "(?i)cross-project"        },
+  { name: "#project-name",   pattern: "#project-name"            },
+  { name: "other project",   pattern: "(?i)other project"        },
+  { name: "another project", pattern: "(?i)another project"      },
 ]
 
 const DEFAULT_ALLOW_LEAK_SECTIONS = [


### PR DESCRIPTION
## Summary
- Harden `dm-context-filter` so Data Machine-managed agents do not receive Kimaki project/channel routing guidance, even if upstream prompt headings drift.
- Expand effective-prompt regression triggers to fail on `kimaki project`, `--project`, `#project-name`, `project channel`, and related cross-project routing language.
- Refresh prompt snapshots and document the expanded leak checks.

## Testing
- `node tests/effective-prompt/run.mjs`
- `node --check tests/effective-prompt/run.mjs`
- `node --check tests/effective-prompt/filters.mjs`

## Known unrelated issue
- `./tests/bridge-render.sh` currently fails on `kimaki-systemd` snapshot drift for the existing `ExecStartPre=-/usr/bin/pkill ... opencode-serve` line from `main`; this PR does not change that template.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the filter/test changes and ran local verification; Chris remains responsible for review and merge.