### PR TITLE
test(kimaki): refresh systemd bridge snapshot

### DIFF
--- a/tests/__snapshots__/bridges/kimaki-systemd
+++ b/tests/__snapshots__/bridges/kimaki-systemd
@@ -9,6 +9,17 @@ WorkingDirectory=/var/www/site
 Environment=HOME=/home/chubes
 Environment=PATH=/usr/bin:/usr/local/bin:/bin
 Environment=KIMAKI_DATA_DIR=/home/chubes/.kimaki
+# Reap stray opencode-serve children left behind by the previous kimaki
+# process before starting a fresh one. Each kimaki session spawns its own
+# opencode-serve worker; if kimaki exits uncleanly (crash, OOM, manual
+# kill) those workers are reparented to PID 1 and keep running. They all
+# share $HOME/.local/share/opencode/auth.json, so concurrent OAuth
+# refreshes race each other — Anthropic rotates the refresh token on every
+# use, and the loser of the race gets HTTP 400 invalid_grant on its next
+# request. `pkill -u chubes` scopes the kill to this service's
+# user so multi-tenant hosts aren't sniped. The `-` prefix makes systemd
+# tolerate exit code 1 (no matches found, the happy path on a clean box).
+ExecStartPre=-/usr/bin/pkill -TERM -u chubes -f "opencode-ai/bin/.*serve"
 ExecStartPre=/opt/kimaki-config/post-upgrade.sh
 ExecStart=/usr/bin/kimaki --data-dir /home/chubes/.kimaki --auto-restart --no-critique
 Restart=always


### PR DESCRIPTION
## Summary
- Refresh the committed `kimaki-systemd` bridge snapshot to include the existing `opencode-serve` cleanup `ExecStartPre` line.
- Unblocks the bridge-render check before running the Homeboy release.

## Testing
- `./tests/bridge-render.sh --update`
- `./tests/bridge-render.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refreshed the snapshot and verified the bridge-render test output; Chris remains responsible for review and merge.