### PR TITLE
fix(claude): symlink CLAUDE.md → AGENTS.md so Claude-model sessions inherit DM context

### DIFF
--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -375,6 +375,7 @@ _runtime_repair_opencode_json_additive() {
 runtime_generate_instructions() {
   if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/AGENTS.md" ]; then
     log "Phase 8: AGENTS.md already exists — skipping (delete to regenerate)"
+    _opencode_symlink_claude_md
     return
   fi
 
@@ -387,6 +388,7 @@ runtime_generate_instructions() {
     sync_homeboy_availability
     if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
       log "AGENTS.md composed from SectionRegistry"
+      _opencode_symlink_claude_md
       return
     fi
     warn "Compose failed — falling back to static template"
@@ -407,8 +409,26 @@ runtime_generate_instructions() {
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would generate AGENTS.md from template"
+    echo -e "${BLUE}[dry-run]${NC} Would symlink CLAUDE.md → AGENTS.md (Claude-model context)"
   else
     sed "s|{{WP_CLI_CMD}}|$wp_cli_display|g" "$agents_tmpl" > "$SITE_PATH/AGENTS.md"
+    _opencode_symlink_claude_md
+  fi
+}
+
+# Symlink CLAUDE.md → AGENTS.md so Claude-model opencode sessions inherit the
+# same DM context. OpenCode globs ["AGENTS.md", "CLAUDE.md", "CONTEXT.md"] from
+# cwd; Claude Code reads only CLAUDE.md. Relative target survives directory moves.
+# Skipped when CLAUDE.md is a regular file (claude-code/studio-code runtimes
+# manage their own template-based CLAUDE.md).
+# See: Extra-Chill/wp-coding-agents#108
+_opencode_symlink_claude_md() {
+  local agents_md="$SITE_PATH/AGENTS.md"
+  local claude_md="$SITE_PATH/CLAUDE.md"
+  [ -f "$agents_md" ] || return 0
+  if [ -L "$claude_md" ] || [ ! -e "$claude_md" ]; then
+    (cd "$SITE_PATH" && ln -sf AGENTS.md CLAUDE.md)
+    log "Symlinked CLAUDE.md → AGENTS.md (covers Claude-model opencode sessions)"
   fi
 }
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -537,10 +537,12 @@ regenerate_agents_md() {
 
   local AGENTS_MD="$SITE_PATH/AGENTS.md"
   local BACKUP="$SITE_PATH/AGENTS.md.backup.$TIMESTAMP"
+  local CLAUDE_MD="$SITE_PATH/CLAUDE.md"
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would backup $AGENTS_MD → $BACKUP"
     echo -e "${BLUE}[dry-run]${NC} Would run: $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG"
+    echo -e "${BLUE}[dry-run]${NC} Would symlink $CLAUDE_MD → AGENTS.md (Claude-model context)"
     return 0
   fi
 
@@ -573,6 +575,23 @@ regenerate_agents_md() {
     if [ -f "$BACKUP" ] && [ -f "$AGENTS_MD" ] && ! cmp -s "$BACKUP" "$AGENTS_MD"; then
       cp "$BACKUP" "$AGENTS_MD"
       warn "  Restored AGENTS.md from backup"
+    fi
+  fi
+
+  # Symlink CLAUDE.md → AGENTS.md so Claude-model sessions get the same DM context.
+  # OpenCode reads both filenames from the cwd glob (AGENTS.md, CLAUDE.md, CONTEXT.md),
+  # Claude Code reads only CLAUDE.md. Symlink keeps both runtimes covered without
+  # duplicating content or risking drift on AGENTS.md regeneration. Relative target
+  # ensures the symlink survives directory moves.
+  # See: Extra-Chill/wp-coding-agents#108
+  if [ -f "$AGENTS_MD" ]; then
+    # Skip if CLAUDE.md exists as a regular file (e.g. claude-code/studio-code runtimes
+    # generate their own CLAUDE.md from a template — don't clobber it).
+    if [ -L "$CLAUDE_MD" ] || [ ! -e "$CLAUDE_MD" ]; then
+      (cd "$SITE_PATH" && ln -sf AGENTS.md CLAUDE.md)
+      log "  Symlinked CLAUDE.md → AGENTS.md (covers Claude-model opencode sessions)"
+    else
+      log "  CLAUDE.md exists as a regular file — leaving it alone (runtime-managed)"
     fi
   fi
 }


### PR DESCRIPTION
Closes #108

## Problem

`upgrade.sh` Phase 5 regenerates `AGENTS.md` via `wp datamachine memory compose`, but `CLAUDE.md` is only generated by `hooks/dm-agent-sync.sh` which is gated to Claude Code's SessionStart hook. On opencode-runtime + kimaki-bridge installs, `CLAUDE.md` is never created.

### Empirical evidence

On the extrachill.com VPS, a fresh OpenCode session running `claude-opus-4-7` does **not** honor SOUL.md/MEMORY.md content and self-reports the DM bundle as "not in context." A side-by-side fresh session with the same config running `glm-5.1` self-identifies as **"Extra Chill Bot"** with phrasing pulled directly from SOUL.md.

AGENTS.md alone is insufficient for the Claude model — CLAUDE.md is needed.

## Why a symlink (Option 3)

Three options were considered in #108:

1. **Duplicate compose** — run `datamachine memory compose CLAUDE.md` alongside AGENTS.md. Risks drift if one compose succeeds and the other fails, plus duplicated bytes on disk.
2. **Refactor the hook** — pull `dm-agent-sync.sh` out of the Claude Code SessionStart gate and run it for opencode too. Larger blast radius, requires reworking the runtime hook contract.
3. **Symlink CLAUDE.md → AGENTS.md** ✅ — self-healing on regeneration, no duplication, no drift, minimal change. OpenCode reads both filenames; Claude Code reads CLAUDE.md.

OpenCode source globs `["AGENTS.md", "CLAUDE.md", "CONTEXT.md"]` upward from cwd (deduped), so writing CLAUDE.md is purely additive — it does not break opencode users and gives Claude-model users the context they need.

## Changes

### `upgrade.sh` Phase 5

After `wp datamachine memory compose AGENTS.md` succeeds, ensure `CLAUDE.md → AGENTS.md` symlink exists. Dry-run path prints the would-be action. Skips when `CLAUDE.md` is a regular file (claude-code/studio-code runtimes ship their own template-based CLAUDE.md).

### `runtimes/opencode.sh::runtime_generate_instructions`

Fresh installs via the opencode runtime now also create the symlink — both on the compose-success path and on the static-template fallback path. Extracted into helper `_opencode_symlink_claude_md` so it is called from every code path that writes AGENTS.md, including the "AGENTS.md already exists, skipping" branch (so existing installs get the symlink on next run even without a regeneration).

### Scope

- ✅ Tied to AGENTS.md regeneration, runs under `--agents-md-only` (verified via dry-run, see below)
- ✅ Relative target (`ln -sf AGENTS.md CLAUDE.md` from `$SITE_PATH`) — survives directory moves
- ✅ No CHANGELOG.md or VERSION edits (homeboy owns both)
- ✅ Idempotent — `ln -sf` overwrites an existing symlink, helper guards against clobbering a real `CLAUDE.md` file

## Verification

`./upgrade.sh --dry-run --agents-md-only` on extrachill.com:

```
[wp-coding-agents] Phase 5: Regenerating AGENTS.md...
[dry-run] Would backup /var/www/extrachill.com/AGENTS.md → ...AGENTS.md.backup.20260503-182449
[dry-run] Would run: wp datamachine memory compose AGENTS.md --allow-root
[dry-run] Would symlink /var/www/extrachill.com/CLAUDE.md → AGENTS.md (Claude-model context)
```

`bash -n` syntax check passes on both modified files.

`git diff origin/main` shows ONLY the symlink addition + dry-run handling. No unrelated edits.

## Acceptance criteria (from #108)

- [x] On opencode-runtime + kimaki-bridge installs, `CLAUDE.md` exists after `upgrade.sh` runs
- [x] `CLAUDE.md` content is identical to `AGENTS.md` (it is the same file via symlink)
- [x] Symlink is regenerated/preserved on subsequent `upgrade.sh` runs (idempotent)
- [x] Symlink uses a relative target so directory moves don't break it
- [x] Fresh installs via the opencode runtime also get the symlink
- [x] claude-code / studio-code runtimes that ship a real `CLAUDE.md` are not clobbered
- [x] `--agents-md-only` scope flag covers the symlink (it is part of Phase 5, not gated separately)
- [x] No changes to CHANGELOG.md or VERSION