### PR TITLE
Preserve Data Machine context in Kimaki sessions

### DIFF
--- a/bridges/kimaki/plugins/dm-agent-sync.ts
+++ b/bridges/kimaki/plugins/dm-agent-sync.ts
@@ -43,140 +43,155 @@ interface DmPaths {
 const dmAgentSync: Plugin = async ({ $ }) => {
   return {
     config: async (config) => {
-      try {
-        // Refresh composable files before the session reads them.
-        // DM SectionRegistry callbacks render live state (configured sources,
-        // skills, config). DM's own invalidation hooks cover state changes
-        // that happen inside a WordPress request, but cron jobs, direct DB
-        // edits, or other external processes would leave AGENTS.md stale.
-        // Running compose here guarantees the file matches live state at the
-        // moment OpenCode loads the session prompt.
-        await $`wp datamachine memory compose --allow-root 2>/dev/null`.quiet().nothrow();
-
-        // Query all agents from Data Machine.
-        const agentsRaw = await $`wp datamachine agents list --format=json --allow-root 2>/dev/null`.quiet().nothrow().text();
-
-        // wp datamachine agents list appends a summary line ("Total: N agent(s).")
-        // after the JSON array. Strip it to get valid JSON.
-        const jsonMatch = agentsRaw.match(/\[[\s\S]*\]/);
-        if (!jsonMatch) {
-          return;
-        }
-
-        const agents: DmAgent[] = JSON.parse(jsonMatch[0]);
-        if (!agents.length) {
-          return;
-        }
-
-        // Ensure agent config object exists.
-        if (!config.agent) {
-          config.agent = {};
-        }
-
-        for (const agent of agents) {
-          const status = agent.status || "active";
-          if (status !== "active") {
-            continue;
-          }
-
-          // Get agent file paths.
-          let paths: DmPaths;
-          try {
-            paths = await $`wp datamachine memory paths --agent=${agent.agent_slug} --format=json --allow-root 2>/dev/null`.quiet().json();
-          } catch {
-            continue;
-          }
-
-          if (!paths?.relative_files?.length) {
-            continue;
-          }
-
-          // Build the prompt from discovered files (layered: AGENTS.md → SITE.md → SOUL.md → MEMORY.md → USER.md).
-          const prompt = [
-            "{file:./AGENTS.md}",
-            ...paths.relative_files.map((f: string) => `{file:./${f}}`),
-          ].join("\n");
-
-          // Resolve model from agent config.
-          const agentModel =
-            agent.agent_config?.default_model ||
-            (agent.agent_config?.model?.default
-              ? `${agent.agent_config.model.default.provider}/${agent.agent_config.model.default.model}`
-              : undefined);
-
-          // Resolve tool policy from agent config.
-          const tools = agent.agent_config?.tool_policy;
-
-          // Register as both "build" and "plan" variants for the agent.
-          // The first agent becomes the default build/plan agents.
-          // Additional agents get their own named entries.
-          const agentSlug = agent.agent_slug;
-
-          // Build agent entry.
-          const buildEntry: Record<string, unknown> = {
-            prompt,
-            mode: "primary" as const,
-          };
-          if (agentModel) {
-            buildEntry.model = agentModel;
-          }
-          if (tools) {
-            buildEntry.tools = tools;
-          }
-
-          // Check if this agent is already defined in the config (user override).
-          // Don't overwrite explicit user config — only fill in missing agents.
-          if (config.agent.build && config.agent.plan && agents.length === 1) {
-            // Single agent + build/plan already defined = user has configured it.
-            // Still update the prompt to ensure file paths are current.
-            if (!isUserOverride(config.agent.build)) {
-              config.agent.build.prompt = prompt;
-            }
-            if (!isUserOverride(config.agent.plan)) {
-              config.agent.plan.prompt = prompt;
-            }
-            continue;
-          }
-
-          // For multi-agent setups, register each agent by slug.
-          // First active agent also populates build/plan defaults if not set.
-          if (!config.agent.build) {
-            config.agent.build = { ...buildEntry };
-          }
-          if (!config.agent.plan) {
-            config.agent.plan = {
-              prompt,
-              mode: "primary" as const,
-              ...(agentModel ? { model: agentModel } : {}),
-              ...(tools ? { tools } : {}),
-            };
-          }
-
-          // Always register by slug name for the switcher.
-          if (!config.agent[agentSlug]) {
-            config.agent[agentSlug] = {
-              ...buildEntry,
-              description: `Data Machine agent: ${agent.agent_name}`,
-            };
-          }
-        }
-      } catch {
-        // If WP-CLI is unavailable or Data Machine isn't installed, silently skip.
-        // The plugin is a no-op on systems without Data Machine.
+      const wpAvailable = await $`command -v wp`.quiet().nothrow();
+      if (wpAvailable.exitCode !== 0) {
+        return;
       }
+
+      // Refresh composable files before the session reads them.
+      // DM SectionRegistry callbacks render live state (configured sources,
+      // skills, config). DM's own invalidation hooks cover state changes
+      // that happen inside a WordPress request, but cron jobs, direct DB
+      // edits, or other external processes would leave AGENTS.md stale.
+      // Running compose here guarantees the file matches live state at the
+      // moment OpenCode loads the session prompt.
+      const composeResult = await $`wp datamachine memory compose --allow-root`.quiet().nothrow();
+      if (composeResult.exitCode !== 0) {
+        console.warn(`[dm-agent-sync] memory compose failed (exit ${composeResult.exitCode}): ${await shellOutputText(composeResult)}`);
+      }
+
+      // Query all agents from Data Machine.
+      const agentsResult = await $`wp datamachine agents list --format=json --allow-root`.quiet().nothrow();
+      if (agentsResult.exitCode !== 0) {
+        console.warn(`[dm-agent-sync] agents list failed (exit ${agentsResult.exitCode}): ${await shellOutputText(agentsResult)}`);
+        return;
+      }
+
+      const agentsRaw = await shellOutputText(agentsResult);
+      const jsonMatch = agentsRaw.match(/\[[\s\S]*\]/);
+      if (!jsonMatch) {
+        console.warn("[dm-agent-sync] agents list did not contain a JSON array");
+        return;
+      }
+
+      let agents: DmAgent[];
+      try {
+        agents = JSON.parse(jsonMatch[0]);
+      } catch (error) {
+        console.warn(`[dm-agent-sync] agents list returned invalid JSON: ${String(error)}`);
+        return;
+      }
+
+      const entries = [];
+      for (const agent of agents) {
+        const status = agent.status || "active";
+        if (status !== "active") {
+          continue;
+        }
+
+        const pathsResult = await $`wp datamachine memory paths --agent=${agent.agent_slug} --format=json --allow-root`.quiet().nothrow();
+        if (pathsResult.exitCode !== 0) {
+          console.warn(`[dm-agent-sync] memory paths failed for ${agent.agent_slug} (exit ${pathsResult.exitCode}): ${await shellOutputText(pathsResult)}`);
+          continue;
+        }
+
+        let paths: DmPaths;
+        try {
+          paths = JSON.parse(await shellOutputText(pathsResult));
+        } catch (error) {
+          console.warn(`[dm-agent-sync] memory paths returned invalid JSON for ${agent.agent_slug}: ${String(error)}`);
+          continue;
+        }
+
+        if (!paths?.relative_files?.length) {
+          console.warn(`[dm-agent-sync] memory paths returned no files for ${agent.agent_slug}`);
+          continue;
+        }
+
+        const prompt = [
+          "{file:./AGENTS.md}",
+          ...paths.relative_files.map((f: string) => `{file:./${f}}`),
+        ].join("\n");
+
+        const agentModel =
+          agent.agent_config?.default_model ||
+          (agent.agent_config?.model?.default
+            ? `${agent.agent_config.model.default.provider}/${agent.agent_config.model.default.model}`
+            : undefined);
+        const tools = agent.agent_config?.tool_policy;
+        const entry: Record<string, unknown> = {
+          prompt,
+          mode: "primary" as const,
+        };
+        if (agentModel) {
+          entry.model = agentModel;
+        }
+        if (tools) {
+          entry.tools = tools;
+        }
+
+        entries.push({ agent, entry, prompt });
+      }
+
+      if (!entries.length) {
+        console.warn(`[dm-agent-sync] no active Data Machine agents with usable memory paths found (${agents.length} listed)`);
+        return;
+      }
+
+      if (!config.agent) {
+        config.agent = {};
+      }
+
+      const primary = entries[0];
+      syncDefaultSlot(config.agent, "build", primary.entry);
+      syncDefaultSlot(config.agent, "plan", primary.entry);
+
+      for (const { agent, entry } of entries) {
+        const agentSlug = agent.agent_slug;
+        if (!config.agent[agentSlug]) {
+          config.agent[agentSlug] = {
+            ...entry,
+            description: `Data Machine agent: ${agent.agent_name}`,
+          };
+        }
+      }
+
+      console.warn(`[dm-agent-sync] registered ${entries.length} Data Machine agent(s); build/plan prompt uses ${primary.agent.agent_slug}`);
     },
   };
 };
 
 /**
- * Check if an agent config entry looks like an intentional user override
- * (has a model set, which means the user chose something specific).
- *
- * @param {Record<string, unknown>} agent Agent configuration entry.
- * @return {boolean} Whether the entry looks user-configured.
+ * Populate build/plan defaults without clobbering user-authored fields.
  */
-function isUserOverride(agent: Record<string, unknown>): boolean {
-  return typeof agent.model === "string" && agent.model.length > 0;
+function syncDefaultSlot(
+  agentConfig: Record<string, unknown>,
+  slot: "build" | "plan",
+  managedEntry: Record<string, unknown>
+): void {
+  const existing = agentConfig[slot];
+  if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+    agentConfig[slot] = { ...managedEntry };
+    return;
+  }
+
+  const existingEntry = existing as Record<string, unknown>;
+  if (typeof existingEntry.prompt === "string" && existingEntry.prompt.length > 0) {
+    return;
+  }
+
+  agentConfig[slot] = {
+    ...managedEntry,
+    ...existingEntry,
+    prompt: managedEntry.prompt,
+  };
+}
+
+async function shellOutputText(output: any): Promise<string> {
+  if (typeof output.text === "function") {
+    return output.text();
+  }
+  return [output.stdout, output.stderr].filter(Boolean).join("\n");
 }
 
 export default dmAgentSync;

--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -75,6 +75,19 @@ fi
 KILL_LIST="$(dirname "$0")/skills-kill-list.txt"
 REQUIRED_PLUGINS=(dm-context-filter.ts dm-agent-sync.ts)
 
+is_killed_skill() {
+  local candidate="$1"
+
+  [[ -f "$KILL_LIST" ]] || return 1
+
+  while IFS= read -r skill || [[ -n "$skill" ]]; do
+    [[ -z "$skill" || "$skill" == \#* ]] && continue
+    [[ "$candidate" == "$skill" ]] && return 0
+  done < "$KILL_LIST"
+
+  return 1
+}
+
 # ----------------------------------------------------------------------------
 # Pass 1: KILL — remove blacklisted bundled kimaki skills.
 # ----------------------------------------------------------------------------
@@ -121,6 +134,10 @@ elif [[ -d "$SKILL_SOURCE_DIR" ]]; then
   for skill_dir in "$SKILL_SOURCE_DIR"/*/; do
     [[ -d "$skill_dir" ]] || continue
     skill_name="$(basename "$skill_dir")"
+    if is_killed_skill "$skill_name"; then
+      echo "kimaki-config: skipped killed skill $skill_name"
+      continue
+    fi
     if [[ -f "$skill_dir/SKILL.md" ]]; then
       target="$SKILLS_DIR/$skill_name"
       rm -rf "$target"

--- a/bridges/kimaki/skills-kill-list.txt
+++ b/bridges/kimaki/skills-kill-list.txt
@@ -1,6 +1,7 @@
 # Skills to remove from Kimaki after upgrades.
 # One skill directory name per line. Lines starting with # are ignored.
 
+batch
 egaki
 errore
 event-sourcing-state

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -140,6 +140,11 @@ sync_homeboy_project_components() {
     return 0
   fi
 
+  if [ -z "$project_id" ]; then
+    warn "Homeboy project config returned empty id — skipping DMC component attachment"
+    return 0
+  fi
+
   if [ -z "${DM_WORKSPACE_DIR:-}" ]; then
     warn "DMC workspace path not configured — skipping Homeboy component attachment"
     return 0

--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -187,6 +187,52 @@ def check_prompt_migration(data: dict) -> dict:
     }
 
 
+def is_default_only_agent_block(block: object, top_model: object) -> bool:
+    """Return whether an agent block is only OpenCode default-equivalent data."""
+    if not isinstance(block, dict):
+        return False
+
+    keys = set(block.keys())
+    if not keys <= {"mode", "model"}:
+        return False
+    if block.get("mode", "primary") != "primary":
+        return False
+    if "model" in block and block.get("model") != top_model:
+        return False
+    return True
+
+
+def check_agent_cleanup(data: dict) -> dict:
+    """Check for default-only persisted build/plan agent shells."""
+    agent = data.get("agent", {})
+    if not isinstance(agent, dict):
+        return {"status": "ok", "remove": []}
+
+    top_model = data.get("model")
+    remove = [
+        sub
+        for sub in ("build", "plan")
+        if is_default_only_agent_block(agent.get(sub), top_model)
+    ]
+    return {"status": "needed" if remove else "ok", "remove": remove}
+
+
+def apply_agent_cleanup(data: dict) -> List[str]:
+    """Remove default-only persisted build/plan agent shells from *data*."""
+    result = check_agent_cleanup(data)
+    agent = data.get("agent", {})
+    if not isinstance(agent, dict):
+        return []
+
+    for sub in result["remove"]:
+        agent.pop(sub, None)
+
+    if not agent:
+        data.pop("agent", None)
+
+    return result["remove"]
+
+
 def apply_prompt_migration(data: dict) -> dict:
     """Migrate ``agent.build.prompt`` → ``instructions`` in *data* (in-place).
 
@@ -205,11 +251,6 @@ def apply_prompt_migration(data: dict) -> dict:
     agent = data.get("agent", {})
     for sub in ("build", "plan"):
         agent.get(sub, {}).pop("prompt", None)
-    # Clean up empty dicts.
-    for sub in ("build", "plan"):
-        if sub in agent and isinstance(agent[sub], dict) and not agent[sub]:
-            pass  # keep mode/model keys
-
     # Merge with any existing instructions, preserving user-added entries.
     existing = set(data.get("instructions", []))
     merged = list(data.get("instructions", []))
@@ -217,6 +258,8 @@ def apply_prompt_migration(data: dict) -> dict:
         if p not in existing:
             merged.append(p)
     data["instructions"] = merged
+
+    apply_agent_cleanup(data)
 
     return result
 
@@ -287,6 +330,7 @@ def main() -> int:
 
     # --- Prompt migration check (runs for all runtimes with opencode.json) ---
     prompt_result = check_prompt_migration(data)
+    agent_cleanup_result = check_agent_cleanup(data)
 
     # --- Plugin array check ---
     expected = expected_plugins(
@@ -317,10 +361,16 @@ def main() -> int:
     diff = diff_plugins(current, expected)
     has_plugin_drift = bool(diff["missing"] or diff["unexpected"])
     has_prompt_drift = prompt_result["status"] == "needed"
-    has_any_drift = has_plugin_drift or has_prompt_drift
+    has_agent_cleanup_drift = agent_cleanup_result["status"] == "needed"
+    has_any_drift = has_plugin_drift or has_prompt_drift or has_agent_cleanup_drift
 
     if not has_any_drift:
-        result: dict = {"status": "ok", "plugins": current, "prompt_migration": "ok"}
+        result: dict = {
+            "status": "ok",
+            "plugins": current,
+            "prompt_migration": "ok",
+            "agent_cleanup": "ok",
+        }
         if plugin_skipped:
             result["plugins_skipped"] = (
                 f"runtime {args.runtime} does not use opencode.json plugin array"
@@ -335,6 +385,7 @@ def main() -> int:
             "current": current,
             "expected": expected,
             "prompt_migration": prompt_result["status"],
+            "agent_cleanup": agent_cleanup_result["status"],
         }
         if has_plugin_drift:
             result["missing"] = diff["missing"]
@@ -342,6 +393,8 @@ def main() -> int:
         if has_prompt_drift:
             result["prompt_details"] = prompt_result.get("details", "")
             result["prompt_instructions"] = prompt_result.get("instructions", [])
+        if has_agent_cleanup_drift:
+            result["agent_cleanup_remove"] = agent_cleanup_result.get("remove", [])
         if plugin_skipped:
             result["plugins_skipped"] = (
                 f"runtime {args.runtime} does not use opencode.json plugin array"
@@ -366,6 +419,8 @@ def main() -> int:
         apply_prompt_migration(data)
         prompt_migration_status = "migrated"
 
+    removed_agent_blocks = apply_agent_cleanup(data)
+
     with open(args.file, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
         fh.write("\n")
@@ -385,7 +440,10 @@ def main() -> int:
             "added": added,
             "backup": backup_path,
             "prompt_migration": prompt_migration_status,
+            "agent_cleanup": "removed" if removed_agent_blocks else "ok",
         }
+        if removed_agent_blocks:
+            result["agent_cleanup_removed"] = removed_agent_blocks
         if still_unexpected:
             result["unexpected"] = still_unexpected
         print(json.dumps(result))
@@ -399,7 +457,10 @@ def main() -> int:
         "after": after_plugins,
         "backup": backup_path,
         "prompt_migration": prompt_migration_status,
+        "agent_cleanup": "removed" if removed_agent_blocks else "ok",
     }
+    if removed_agent_blocks:
+        result["agent_cleanup_removed"] = removed_agent_blocks
     print(json.dumps(result))
     return 1
 

--- a/tests/dm-agent-sync.mjs
+++ b/tests/dm-agent-sync.mjs
@@ -1,0 +1,114 @@
+// tests/dm-agent-sync.mjs — unit smoke tests for the Kimaki DM agent sync plugin.
+
+import assert from "node:assert/strict"
+import dmAgentSync from "../bridges/kimaki/plugins/dm-agent-sync.ts"
+
+function output(stdout = "", exitCode = 0, stderr = "") {
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    async text() {
+      return [stdout, stderr].filter(Boolean).join("\n")
+    },
+  }
+}
+
+function fakeShell(responses) {
+  return (strings, ...values) => {
+    const command = strings.reduce((acc, part, index) => acc + part + (values[index] ?? ""), "")
+    return {
+      quiet() {
+        return this
+      },
+      nothrow() {
+        for (const [pattern, result] of responses) {
+          if (pattern.test(command)) {
+            return Promise.resolve(result)
+          }
+        }
+        return Promise.resolve(output("", 1, `unexpected command: ${command}`))
+      },
+    }
+  }
+}
+
+async function runConfig(config, responses) {
+  const warnings = []
+  const originalWarn = console.warn
+  console.warn = (message) => warnings.push(String(message))
+  try {
+    const plugin = await dmAgentSync({ $: fakeShell(responses) })
+    await plugin.config(config)
+  } finally {
+    console.warn = originalWarn
+  }
+  return warnings
+}
+
+const agentsJson = JSON.stringify([
+  { agent_id: 1, agent_slug: "franklin", agent_name: "Franklin", owner_id: 1, status: "active" },
+  { agent_id: 2, agent_slug: "julia", agent_name: "Julia", owner_id: 1, status: "active" },
+])
+
+const commonResponses = [
+  [/^command -v wp$/, output("/usr/local/bin/wp")],
+  [/^wp datamachine memory compose/, output("composed")],
+  [/^wp datamachine agents list/, output(`${agentsJson}\nTotal: 2 agent(s).`)],
+  [/--agent=franklin /, output(JSON.stringify({ agent_slug: "franklin", relative_files: ["SITE.md", "SOUL.md"] }))],
+  [/--agent=julia /, output(JSON.stringify({ agent_slug: "julia", relative_files: ["SITE.md", "MEMORY.md"] }))],
+]
+
+{
+  const config = {
+    model: "anthropic/claude-opus-4-7",
+    agent: {
+      build: { mode: "primary", model: "anthropic/claude-opus-4-7" },
+      plan: { mode: "primary", model: "anthropic/claude-opus-4-7" },
+    },
+  }
+  const warnings = await runConfig(config, commonResponses)
+  assert.match(config.agent.build.prompt, /\{file:\.\/AGENTS\.md\}/)
+  assert.match(config.agent.plan.prompt, /\{file:\.\/SOUL\.md\}/)
+  assert.equal(config.agent.build.model, "anthropic/claude-opus-4-7")
+  assert.match(config.agent.franklin.prompt, /\{file:\.\/SITE\.md\}/)
+  assert.match(config.agent.julia.description, /Data Machine agent: Julia/)
+  assert.ok(warnings.some((line) => line.includes("registered 2 Data Machine agent(s)")))
+}
+
+{
+  const config = {
+    agent: {
+      build: { mode: "primary", tools: { bash: true } },
+      plan: { mode: "primary" },
+    },
+  }
+  await runConfig(config, commonResponses)
+  assert.deepEqual(config.agent.build.tools, { bash: true })
+  assert.match(config.agent.build.prompt, /\{file:\.\/SOUL\.md\}/)
+  assert.match(config.agent.plan.prompt, /\{file:\.\/SOUL\.md\}/)
+}
+
+{
+  const config = {
+    agent: {
+      build: { prompt: "custom prompt" },
+    },
+  }
+  await runConfig(config, commonResponses)
+  assert.equal(config.agent.build.prompt, "custom prompt")
+  assert.match(config.agent.plan.prompt, /\{file:\.\/SOUL\.md\}/)
+}
+
+{
+  const config = {}
+  const warnings = await runConfig(config, [
+    [/^command -v wp$/, output("/usr/local/bin/wp")],
+    [/^wp datamachine memory compose/, output("composed")],
+    [/^wp datamachine agents list/, output("", 1, "db down")],
+  ])
+  assert.ok(warnings.some((line) => line.includes("agents list failed")))
+  assert.equal(config.agent, undefined)
+}
+
+console.log("OK: dm-agent-sync injects DM prompts and logs failures")

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -3,9 +3,9 @@
 // Each entry is a function (string -> string) the harness can apply to a
 // rendered system prompt. Two are first-class:
 //
-//   - "current": the actual filter logic from
-//     kimaki/plugins/dm-context-filter.ts. Loaded from disk so that
-//     editing the plugin source automatically updates the test.
+//   - "current": the actual dm-context-filter.ts OpenCode plugin hook.
+//     Loaded from disk so that editing the plugin source automatically
+//     updates the test.
 //
 //   - "broken-stripsection": the regex-only stripSection that misfires
 //     on fenced bash comments. Kept as a baseline so the harness can
@@ -15,22 +15,15 @@
 // Add new filters here when you need to A/B test alternative
 // implementations from a scenario file.
 
-import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PLUGIN_PATH = join(__dirname, "..", "..", "bridges", "kimaki", "plugins", "dm-context-filter.ts")
 
 // ---------------------------------------------------------------------------
-// "current" filter — extract the filter helpers from the live plugin
-// source by name. We can't `import` the .ts directly from node, so we
-// re-implement the helpers here BUT keep them in sync with the plugin
-// by way of the snapshot tests + reviewer eyeballs. If the plugin source
-// drifts from these, the snapshot diff will surface it.
-//
-// Keeping these as runtime-loaded eval would be brittle; the snapshots
-// are the trust boundary, not source-of-truth re-import.
+// Baseline helper copies — intentionally kept only for the broken baseline.
+// The "current" filter below imports and executes the real OpenCode plugin.
 // ---------------------------------------------------------------------------
 
 function stripSection(block, heading) {
@@ -116,32 +109,17 @@ Use \`kimaki tunnel\` only when the task specifically needs an inbound public UR
   return block.replace(/\s*$/, "") + instruction
 }
 
-function currentFilter(block) {
-  let r = block
-  r = stripSection(r, "## permissions")
-  r = stripSection(r, "## upgrading kimaki")
-  r = stripSection(r, "## scheduled sends and task management")
-  r = stripSection(r, "## running dev servers with tunnel access")
-  r = stripSection(r, "## starting new sessions from CLI")
-  r = stripSection(r, "## creating worktrees")
-  r = stripSection(r, "## worktree")
-  r = stripSection(r, "## cross-project commands")
-  r = stripSection(r, "## reading other sessions")
-  r = stripSection(r, "## waiting for a session to finish")
-  r = stripSection(r, "## running opencode commands via kimaki send")
-  r = stripSection(r, "## switching agents in the current session")
-  r = stripSection(r, "## showing diffs")
-  r = stripSection(r, "## about critique")
-  r = stripSection(r, "### always show diff at end of session")
-  r = stripSection(r, "### fetching user comments from critique diffs")
-  r = stripSection(r, "### reviewing diffs with AI")
-  r = stripWorktreeInlines(r)
-  r = stripProjectDiscoveryInlines(r)
-  r = stripAgentOverrideInlines(r)
-  r = r.replace(/\n{3,}/g, "\n\n")
-  r = appendWordPressSiteRuntimeInstruction(r)
-  r = appendDataMachineSessionHandoffInstruction(r)
-  return r
+async function currentFilter(block) {
+  const pluginModule = await import(pathToFileURL(PLUGIN_PATH).href)
+  const plugin = await pluginModule.default({})
+  const transform = plugin["experimental.chat.system.transform"]
+  if (typeof transform !== "function") {
+    throw new Error(`dm-context-filter plugin is missing experimental.chat.system.transform: ${PLUGIN_PATH}`)
+  }
+
+  const output = { system: [block] }
+  await transform({}, output)
+  return output.system.join("\n")
 }
 
 // ---------------------------------------------------------------------------
@@ -197,22 +175,10 @@ function brokenFilter(block) {
 function passthrough(block) { return block }
 
 // ---------------------------------------------------------------------------
-// Sanity check: confirm the plugin source on disk still uses the same
-// section list. If a future PR adds/removes a stripSection() call in
-// dm-context-filter.ts, this read surfaces it as a snapshot drift.
-// ---------------------------------------------------------------------------
-
-let pluginSourceSnapshot = ""
-try {
-  pluginSourceSnapshot = readFileSync(PLUGIN_PATH, "utf8")
-} catch (e) {
-  // Worktree-only file; harness still works without it.
-}
-
 export const filters = {
   current: currentFilter,
   "broken-stripsection": brokenFilter,
   passthrough,
 }
 
-export const meta = { pluginPath: PLUGIN_PATH, pluginSourceSnapshot }
+export const meta = { pluginPath: PLUGIN_PATH }

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -45,15 +45,16 @@
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "node:fs"
 import { execSync } from "node:child_process"
 import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
-import { getOpencodeSystemMessage } from "/Users/chubes/.nvm/versions/node/v24.13.1/lib/node_modules/kimaki/dist/system-message.js"
 import { filters } from "./filters.mjs"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const SNAPSHOT_DIR = join(__dirname, "__snapshots__")
 const SCENARIO_DIR = join(__dirname, "scenarios")
+const KIMAKI_DIST_DIR = process.env.KIMAKI_DIST_DIR || join(execSync("npm root -g", { encoding: "utf8" }).trim(), "kimaki", "dist")
+const { getOpencodeSystemMessage } = await import(pathToFileURL(join(KIMAKI_DIST_DIR, "system-message.js")).href)
 
 if (!existsSync(SNAPSHOT_DIR)) mkdirSync(SNAPSHOT_DIR, { recursive: true })
 
@@ -194,7 +195,7 @@ function gitDiff(beforePath, afterPath) {
 // Run one scenario.
 // ---------------------------------------------------------------------------
 
-function runScenario(name, scenario) {
+async function runScenario(name, scenario) {
   if (ONLY && name !== ONLY) return { name, skipped: true }
 
   const filterFn = filters[scenario.filter]
@@ -203,8 +204,8 @@ function runScenario(name, scenario) {
   if (!baselineFn) throw new Error(`scenario ${name}: unknown baseline "${scenario.baseline}"`)
 
   const raw = getOpencodeSystemMessage(scenario.args)
-  const baselineOut = baselineFn(raw)
-  const filteredOut = filterFn(raw)
+  const baselineOut = await baselineFn(raw)
+  const filteredOut = await filterFn(raw)
 
   const baselineLeaks = detectLeaks(baselineOut, scenario.triggers, scenario.allowLeakInSection)
   const filteredLeaks = detectLeaks(filteredOut, scenario.triggers, scenario.allowLeakInSection)
@@ -327,7 +328,10 @@ function printResult(r) {
 // ---------------------------------------------------------------------------
 
 const scenarios = loadScenarios()
-const results = scenarios.map(([name, scenario]) => runScenario(name, scenario))
+const results = []
+for (const [name, scenario] of scenarios) {
+  results.push(await runScenario(name, scenario))
+}
 
 let failed = 0
 for (const r of results) {

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -96,4 +96,19 @@ fi
 assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/alpha" "$TMP/dry-run-output.log"
 assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/beta" "$TMP/dry-run-output.log"
 
+cat > "$SITE_PATH/homeboy.json" <<'JSON'
+{}
+JSON
+DRY_RUN=false
+HOMEBOY_ATTACH_LOG="$TMP/empty-id-attached.log"
+export HOMEBOY_ATTACH_LOG
+sync_homeboy_project_components > "$TMP/empty-id-output.log"
+
+if [ -f "$HOMEBOY_ATTACH_LOG" ]; then
+  echo "FAIL: empty project id should not call homeboy attach-path"
+  cat "$HOMEBOY_ATTACH_LOG"
+  exit 1
+fi
+assert_contains "Homeboy project config returned empty id — skipping DMC component attachment" "$TMP/empty-id-output.log"
+
 echo "OK: Homeboy component attachment skips worktrees and metadata-less repos"

--- a/tests/post-upgrade-restore.sh
+++ b/tests/post-upgrade-restore.sh
@@ -50,6 +50,8 @@ mkdir -p "$LIVE_SKILLS" "$SRC_SKILLS" "$SRC_PLUGINS"
 # Seed a blacklisted skill that the kill pass should remove.
 mkdir -p "$LIVE_SKILLS/blacklisted-skill"
 echo "stub" > "$LIVE_SKILLS/blacklisted-skill/SKILL.md"
+mkdir -p "$LIVE_SKILLS/persisted-blacklisted-skill"
+echo "stub" > "$LIVE_SKILLS/persisted-blacklisted-skill/SKILL.md"
 
 # Seed a skill in the persistent source that should be restored.
 mkdir -p "$SRC_SKILLS/restored-skill"
@@ -57,6 +59,15 @@ cat > "$SRC_SKILLS/restored-skill/SKILL.md" <<'EOF'
 ---
 name: restored-skill
 description: test fixture
+---
+body
+EOF
+
+mkdir -p "$SRC_SKILLS/persisted-blacklisted-skill"
+cat > "$SRC_SKILLS/persisted-blacklisted-skill/SKILL.md" <<'EOF'
+---
+name: persisted-blacklisted-skill
+description: persisted but killed test fixture
 ---
 body
 EOF
@@ -80,6 +91,7 @@ chmod +x "$TEST_SCRIPT_DIR/post-upgrade.sh"
 cat > "$TEST_SCRIPT_DIR/skills-kill-list.txt" <<'EOF'
 # test kill list
 blacklisted-skill
+persisted-blacklisted-skill
 EOF
 
 # Run the script with explicit env overrides so it never touches the real
@@ -127,6 +139,9 @@ assert_log_contains_file() {
 # Pass 1: kill pass removed the blacklisted skill.
 assert_missing "$LIVE_SKILLS/blacklisted-skill"
 assert_log_contains "removed skill blacklisted-skill"
+assert_missing "$LIVE_SKILLS/persisted-blacklisted-skill"
+assert_log_contains "removed skill persisted-blacklisted-skill"
+assert_log_contains "skipped killed skill persisted-blacklisted-skill"
 
 # Pass 2: skill restore copied the SKILL.md tree.
 assert_present "$LIVE_SKILLS/restored-skill/SKILL.md"

--- a/tests/repair-opencode-json.sh
+++ b/tests/repair-opencode-json.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# tests/repair-opencode-json.sh — regression tests for opencode.json repair.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPAIR="$SCRIPT_DIR/lib/repair-opencode-json.py"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_json_missing_agent_slots() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+agent = data.get("agent", {})
+if "build" in agent or "plan" in agent:
+    raise SystemExit(f"managed build/plan slots should be removed: {agent}")
+PY
+}
+
+cat > "$TMP/default-only.json" <<'JSON'
+{
+  "model": "anthropic/claude-opus-4-7",
+  "agent": {
+    "build": { "mode": "primary", "model": "anthropic/claude-opus-4-7" },
+    "plan": { "mode": "primary", "model": "anthropic/claude-opus-4-7" }
+  }
+}
+JSON
+
+python3 "$REPAIR" \
+  --file "$TMP/default-only.json" \
+  --runtime opencode \
+  --chat-bridge kimaki \
+  --kimaki-plugins-dir /opt/kimaki-config/plugins \
+  --additive > "$TMP/default-only.out"
+
+assert_json_missing_agent_slots "$TMP/default-only.json"
+grep -q '"agent_cleanup": "removed"' "$TMP/default-only.out"
+
+cat > "$TMP/prompt-migration.json" <<'JSON'
+{
+  "model": "anthropic/claude-opus-4-7",
+  "agent": {
+    "build": {
+      "mode": "primary",
+      "model": "anthropic/claude-opus-4-7",
+      "prompt": "{file:./AGENTS.md}\n{file:./SOUL.md}\n{file:./MEMORY.md}"
+    },
+    "plan": {
+      "mode": "primary",
+      "model": "anthropic/claude-opus-4-7",
+      "prompt": "{file:./AGENTS.md}\n{file:./SOUL.md}"
+    }
+  }
+}
+JSON
+
+python3 "$REPAIR" \
+  --file "$TMP/prompt-migration.json" \
+  --runtime opencode \
+  --chat-bridge kimaki \
+  --kimaki-plugins-dir /opt/kimaki-config/plugins \
+  --additive > "$TMP/prompt-migration.out"
+
+assert_json_missing_agent_slots "$TMP/prompt-migration.json"
+python3 - "$TMP/prompt-migration.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+if data.get("instructions") != ["./SOUL.md", "./MEMORY.md"]:
+    raise SystemExit(f"unexpected instructions: {data.get('instructions')}")
+PY
+
+cat > "$TMP/custom-agent.json" <<'JSON'
+{
+  "model": "anthropic/claude-opus-4-7",
+  "agent": {
+    "build": { "mode": "primary", "tools": { "bash": true } },
+    "plan": { "mode": "primary", "model": "openai/gpt-5.5" }
+  }
+}
+JSON
+
+python3 "$REPAIR" \
+  --file "$TMP/custom-agent.json" \
+  --runtime opencode \
+  --chat-bridge kimaki \
+  --kimaki-plugins-dir /opt/kimaki-config/plugins \
+  --additive > "$TMP/custom-agent.out"
+
+python3 - "$TMP/custom-agent.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+agent = data.get("agent", {})
+if "build" not in agent or "plan" not in agent:
+    raise SystemExit(f"custom build/plan slots should be preserved: {agent}")
+PY
+
+echo "OK: repair-opencode-json removes managed agent shells"


### PR DESCRIPTION
## Summary
- Remove Kimaki's bundled `batch` skill and prevent killed skills from being restored from persisted `kimaki-config/skills`.
- Repair stale persisted `opencode.json` agent shells so default-only `agent.build` / `agent.plan` blocks do not block Data Machine-managed runtime context.
- Rework `dm-agent-sync` to populate build/plan prompts across multi-agent installs and log WP-CLI/JSON/path failures instead of silently dropping context.
- Update the effective-prompt harness to resolve Kimaki dynamically and execute the real `dm-context-filter.ts` OpenCode hook.

Fixes #110.
Fixes #111.
Fixes #112.
Fixes #113.
Fixes #114.
Fixes #115.

## Testing
- `bash tests/repair-opencode-json.sh`
- `node tests/dm-agent-sync.mjs`
- `node tests/effective-prompt/run.mjs`
- `bash tests/post-upgrade-restore.sh`
- `bash tests/homeboy-components.sh`
- `bash tests/opencode-wrapper.sh`
- `bash tests/kimaki-session-helper-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Kimaki/Data Machine context repair, adding regression coverage, and validating the issue fixes. Chris reviewed direction and clarified the `opencode.json` agent-block policy.