### PR TITLE
Prefer Kimaki command shim in launchd sessions

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -533,7 +533,7 @@ bridge_render_launchd() {
   local kimaki_bin_dir node_bin_dir path_value
   kimaki_bin_dir="$(dirname "$KIMAKI_BIN")"
   node_bin_dir="$(_resolve_node_bin_dir "$KIMAKI_BIN")"
-  path_value="$(_compose_path_value "$kimaki_bin_dir" "$node_bin_dir" "$HOME/.local/bin" "$HOME/.opencode/bin" "$HOME/.bun/bin" /opt/homebrew/bin /usr/local/bin /usr/bin /bin /usr/sbin /sbin)"
+  path_value="$(_compose_path_value "$HOME/.local/bin" "$kimaki_bin_dir" "$node_bin_dir" "$HOME/.opencode/bin" "$HOME/.bun/bin" /opt/homebrew/bin /usr/local/bin /usr/bin /bin /usr/sbin /sbin)"
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/tests/__snapshots__/bridges/kimaki-launchd
+++ b/tests/__snapshots__/bridges/kimaki-launchd
@@ -23,7 +23,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/home/chubes/.local/bin:/home/chubes/.opencode/bin:/home/chubes/.bun/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/home/chubes/.local/bin:/opt/homebrew/bin:/home/chubes/.opencode/bin:/home/chubes/.bun/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>KIMAKI_DATA_DIR</key>
         <string>/home/chubes/.kimaki</string>
     </dict>


### PR DESCRIPTION
## Summary
- Put `$HOME/.local/bin` before the npm Kimaki bin directory in the generated launchd PATH.
- Ensure agent shell commands resolve the Data Machine `kimaki` shim before the real npm-installed Kimaki binary.
- Refresh the Kimaki launchd snapshot for the new PATH order.

## Testing
- `tests/bridge-render.sh --update`
- `tests/bridge-render.sh`
- `tests/datamachine-kimaki-adapter.sh`
- `homeboy lint --path /Users/chubes/Developer/wp-coding-agents@fix-kimaki-shim-path-order --changed-only`
- `homeboy test --path /Users/chubes/Developer/wp-coding-agents@fix-kimaki-shim-path-order`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed local PATH ordering after deploying the Kimaki adapter, drafted the launchd PATH fix, and ran regression checks.