### PR TITLE
test(kimaki): refresh prompt snapshots for 0.9.1

### DIFF
--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -132,7 +132,7 @@ bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST 
 The command prints a preview URL when done — share that URL with the user.
 
 # Start the dev server in a named background session
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s myapp-dev
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
 
 # Wait until the dev server prints something useful, then inspect it
 bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
@@ -141,7 +141,7 @@ bunx tuistory read -s myapp-dev
 
 ### passing the public URL to your app
 
-If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups, so `--port` is often unnecessary.
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
 
 ```bash
 # Your app can read process.env.TRAFORO_URL directly
@@ -168,13 +168,13 @@ bunx tuistory read -s myapp-dev
 
 ```bash
 # Next.js project
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s projectname-nextjs-dev-3000
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
 
-# Vite project on port 5173
-bunx tuistory launch "kimaki tunnel -p 5173 -- pnpm dev" -s vite-dev-5173
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
 
 # Custom tunnel ID (only for intentionally public-safe services)
-bunx tuistory launch "kimaki tunnel -p 3000 -t holocron -- pnpm dev" -s holocron-dev
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
 ```
 
 ### stopping the dev server

--- a/tests/effective-prompt/__snapshots__/default.raw.txt
+++ b/tests/effective-prompt/__snapshots__/default.raw.txt
@@ -466,11 +466,11 @@ Use a tuistory session with a descriptive name like `projectname-dev` so you can
 
 Use random tunnel IDs by default. Only pass `-t` when exposing a service that is safe to be publicly discoverable.
 
-`kimaki tunnel` injects `TRAFORO_URL` into the child process. Prefer wiring your app to that URL so OAuth callbacks, webhook URLs, and absolute links use the public tunnel instead of localhost.
+`kimaki tunnel` injects `TRAFORO_URL` into the child process. Prefer wiring your app to that URL so OAuth callbacks, webhook URLs, and absolute links use the public tunnel instead of localhost. The local port is detected from the child process output, so do not pass `-p` when launching a dev server command unless detection fails.
 
 ```bash
 # Start the dev server in a named background session
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s myapp-dev
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
 
 # Wait until the dev server prints something useful, then inspect it
 bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
@@ -479,7 +479,7 @@ bunx tuistory read -s myapp-dev
 
 ### passing the public URL to your app
 
-If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups, so `--port` is often unnecessary.
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
 
 ```bash
 # Your app can read process.env.TRAFORO_URL directly
@@ -506,13 +506,13 @@ bunx tuistory read -s myapp-dev
 
 ```bash
 # Next.js project
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s projectname-nextjs-dev-3000
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
 
-# Vite project on port 5173
-bunx tuistory launch "kimaki tunnel -p 5173 -- pnpm dev" -s vite-dev-5173
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
 
 # Custom tunnel ID (only for intentionally public-safe services)
-bunx tuistory launch "kimaki tunnel -p 3000 -t holocron -- pnpm dev" -s holocron-dev
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
 ```
 
 ### stopping the dev server

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -130,7 +130,7 @@ bunx critique review --web --agent opencode --session ses_MINIMAL --filter "src/
 The command prints a preview URL when done — share that URL with the user.
 
 # Start the dev server in a named background session
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s myapp-dev
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
 
 # Wait until the dev server prints something useful, then inspect it
 bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
@@ -139,7 +139,7 @@ bunx tuistory read -s myapp-dev
 
 ### passing the public URL to your app
 
-If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups, so `--port` is often unnecessary.
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
 
 ```bash
 # Your app can read process.env.TRAFORO_URL directly
@@ -166,13 +166,13 @@ bunx tuistory read -s myapp-dev
 
 ```bash
 # Next.js project
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s projectname-nextjs-dev-3000
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
 
-# Vite project on port 5173
-bunx tuistory launch "kimaki tunnel -p 5173 -- pnpm dev" -s vite-dev-5173
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
 
 # Custom tunnel ID (only for intentionally public-safe services)
-bunx tuistory launch "kimaki tunnel -p 3000 -t holocron -- pnpm dev" -s holocron-dev
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
 ```
 
 ### stopping the dev server

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
@@ -460,11 +460,11 @@ Use a tuistory session with a descriptive name like `projectname-dev` so you can
 
 Use random tunnel IDs by default. Only pass `-t` when exposing a service that is safe to be publicly discoverable.
 
-`kimaki tunnel` injects `TRAFORO_URL` into the child process. Prefer wiring your app to that URL so OAuth callbacks, webhook URLs, and absolute links use the public tunnel instead of localhost.
+`kimaki tunnel` injects `TRAFORO_URL` into the child process. Prefer wiring your app to that URL so OAuth callbacks, webhook URLs, and absolute links use the public tunnel instead of localhost. The local port is detected from the child process output, so do not pass `-p` when launching a dev server command unless detection fails.
 
 ```bash
 # Start the dev server in a named background session
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s myapp-dev
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
 
 # Wait until the dev server prints something useful, then inspect it
 bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
@@ -473,7 +473,7 @@ bunx tuistory read -s myapp-dev
 
 ### passing the public URL to your app
 
-If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups, so `--port` is often unnecessary.
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
 
 ```bash
 # Your app can read process.env.TRAFORO_URL directly
@@ -500,13 +500,13 @@ bunx tuistory read -s myapp-dev
 
 ```bash
 # Next.js project
-bunx tuistory launch "kimaki tunnel -p 3000 -- pnpm dev" -s projectname-nextjs-dev-3000
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
 
-# Vite project on port 5173
-bunx tuistory launch "kimaki tunnel -p 5173 -- pnpm dev" -s vite-dev-5173
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
 
 # Custom tunnel ID (only for intentionally public-safe services)
-bunx tuistory launch "kimaki tunnel -p 3000 -t holocron -- pnpm dev" -s holocron-dev
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
 ```
 
 ### stopping the dev server


### PR DESCRIPTION
## Summary
- Refresh Kimaki effective-prompt raw and baseline snapshots for `kimaki@0.9.1`.
- Captures the new `kimaki tunnel` guidance now that ports can be auto-detected.

## Testing
- `node tests/effective-prompt/run.mjs`
- `bash tests/datamachine-kimaki-adapter.sh`
- `bash tests/kimaki-session-helper-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refreshed snapshots, ran targeted verification, and drafted this PR description; Chris remains responsible for review and merge.