### PR TITLE
fix(lib,tests): mu-plugin perms self-heal + effective-prompt .actual cleanup

### DIFF
--- a/lib/cli-channel.sh
+++ b/lib/cli-channel.sh
@@ -98,6 +98,9 @@ cli_channel_ensure_mu_plugin_file() {
 
   mkdir -p "$dir"
 
+  # Write the scaffold, then force mode 0644 regardless of the caller's
+  # umask (root cron/systemd contexts default to 0077 which strips the
+  # world-read bit PHP-FPM needs — see issue #133).
   cat > "$file" <<'PHP'
 <?php
 /**
@@ -142,6 +145,8 @@ add_filter( 'datamachine_code_cli_channels', function ( $channels ) {
     return $channels;
 } );
 PHP
+
+  chmod 0644 "$file"
 
   log "  Wrote CLI-channel mu-plugin scaffold: $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
@@ -280,6 +285,9 @@ cli_channel_register() {
   fi
 
   mv "$tmp" "$file"
+  # Self-heal legacy 0600 files written before the umask fix in #133.
+  # mktemp creates with mode 0600 so mv preserves that — force 0644.
+  chmod 0644 "$file"
   log "  Registered CLI channel '$name' in $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("CLI channel: $name")
@@ -316,6 +324,7 @@ cli_channel_unregister() {
   tmp=$(mktemp "${file}.XXXXXX")
   _cli_channel_rewrite "$file" "$name" "" > "$tmp"
   mv "$tmp" "$file"
+  chmod 0644 "$file"
   log "  Unregistered CLI channel '$name' from $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("CLI channel removed: $name")

--- a/lib/runtime-signature.sh
+++ b/lib/runtime-signature.sh
@@ -107,6 +107,9 @@ runtime_signature_ensure_mu_plugin_file() {
 
   mkdir -p "$dir"
 
+  # Write the scaffold, then force mode 0644 regardless of the caller's
+  # umask (root cron/systemd contexts default to 0077 which strips the
+  # world-read bit PHP-FPM needs — see issue #133).
   cat > "$file" <<'PHP'
 <?php
 /**
@@ -153,6 +156,8 @@ add_filter( 'datamachine_code_worktree_runtime_signatures', function ( $signatur
     return $signatures;
 } );
 PHP
+
+  chmod 0644 "$file"
 
   log "  Wrote runtime-signature mu-plugin scaffold: $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
@@ -273,6 +278,9 @@ runtime_signature_register() {
   fi
 
   mv "$tmp" "$file"
+  # Self-heal legacy 0600 files written before the umask fix in #133.
+  # mktemp creates with mode 0600 so mv preserves that — force 0644.
+  chmod 0644 "$file"
   log "  Registered runtime signature '$runtime_id' in $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("runtime signature: $runtime_id")
@@ -310,6 +318,7 @@ runtime_signature_unregister() {
   tmp=$(mktemp "${file}.XXXXXX")
   _runtime_signature_rewrite "$file" "$runtime_id" "" > "$tmp"
   mv "$tmp" "$file"
+  chmod 0644 "$file"
   log "  Unregistered runtime signature '$runtime_id' from $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("runtime signature removed: $runtime_id")

--- a/tests/cli-channel-perms.sh
+++ b/tests/cli-channel-perms.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# tests/cli-channel-perms.sh — Regression coverage for issue #133 in
+# lib/cli-channel.sh.
+#
+# The mu-plugin file written by cli_channel_ensure_mu_plugin_file /
+# cli_channel_register must land at mode 0644 regardless of the caller's
+# umask, because PHP-FPM (running as www-data) needs world-read to load it.
+# Root cron/systemd contexts default to umask 0077 → 0600, which broke
+# every install that ran setup.sh / upgrade.sh from a daemon context.
+#
+# Asserts the three write paths each produce mode 0644:
+#   1. Fresh scaffold (cli_channel_ensure_mu_plugin_file)
+#   2. Subsequent register replacing/inserting a block (mktemp + mv)
+#   3. Unregister removing a block (mktemp + mv)
+#
+# Also asserts the self-heal behavior: if a legacy file is mode 0600
+# (left by a pre-#133 install), the next register call must restore 0644.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/wp-content/mu-plugins"
+export SITE_PATH="$TMP"
+export DRY_RUN=false
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/cli-channel.sh"
+UPDATED_ITEMS=()
+
+# Silence helper logs unless --verbose.
+VERBOSE=false
+for arg in "$@"; do
+  case "$arg" in
+    --verbose|-v) VERBOSE=true ;;
+  esac
+done
+if [ "$VERBOSE" = false ]; then
+  log() { :; }
+  warn() { echo "WARN: $1" >&2; }
+fi
+
+MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-channels.php"
+FAILED=0
+
+assert_mode_0644() {
+  local file="$1" name="$2"
+  local got
+  got=$(stat -c %a "$file")
+  if [ "$got" = "644" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "    got:  $got"
+    echo "    want: 644"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# --- 1. Fresh scaffold under hostile umask ---------------------------------
+echo "==> register kimaki (fresh scaffold, umask 077)"
+(
+  umask 077
+  cli_channel_register "kimaki" \
+    "/usr/local/bin/kimaki" \
+    '["send","--channel","{recipient}","--prompt","{message}"]'
+)
+assert_mode_0644 "$MU_FILE" "fresh scaffold lands as 0644 under umask 077"
+
+# --- 2. Sibling register exercises mktemp + mv path; self-heal from 0600 ---
+echo "==> simulate legacy 0600 file and verify self-heal on next register"
+chmod 0600 "$MU_FILE"
+(
+  umask 077
+  cli_channel_register "opencode-telegram" \
+    "/usr/local/bin/opencode-telegram" \
+    '["dispatch","--chat","{recipient}","--text","{message}"]'
+)
+assert_mode_0644 "$MU_FILE" "mu-plugin self-healed to 0644 after sibling register"
+
+# --- 3. Unregister also lands as 0644 --------------------------------------
+echo "==> unregister opencode-telegram"
+chmod 0600 "$MU_FILE"
+(
+  umask 077
+  cli_channel_unregister "opencode-telegram"
+)
+assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
+
+# --- Done ------------------------------------------------------------------
+echo
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAILED: $FAILED assertion(s)"
+  exit 1
+fi
+echo "OK: all cli-channel perms assertions passed"

--- a/tests/effective-prompt/__snapshots__/.gitignore
+++ b/tests/effective-prompt/__snapshots__/.gitignore
@@ -1,0 +1,8 @@
+# Diff-intermediate files written by tests/effective-prompt/run.mjs when
+# a snapshot mismatch occurs. They mirror the canonical .baseline.txt /
+# .filtered.txt / .raw.txt and are only useful for local inspection.
+#
+# The harness already cleans these up on a successful run; this file
+# keeps them out of git when a run fails and they are left in place
+# for debugging. See issue #134.
+*.actual

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -42,7 +42,7 @@
 //
 // Exit code: 0 on success, 1 on any assertion failure.
 
-import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "node:fs"
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, unlinkSync } from "node:fs"
 import { execSync } from "node:child_process"
 import { dirname, join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
@@ -323,6 +323,17 @@ let failed = 0
 for (const r of results) {
   printResult(r)
   if (!r.skipped && r.failures.length > 0) failed++
+}
+
+// Clean up .actual diff intermediates on a fully successful run so they do
+// not litter the working tree (issue #134). On any failure, leave them in
+// place so the reviewer can diff against the canonical snapshot.
+if (failed === 0) {
+  for (const f of readdirSync(SNAPSHOT_DIR)) {
+    if (f.endsWith(".actual")) {
+      try { unlinkSync(join(SNAPSHOT_DIR, f)) } catch {}
+    }
+  }
 }
 
 console.log(`\n${"=".repeat(72)}`)

--- a/tests/runtime-signature.sh
+++ b/tests/runtime-signature.sh
@@ -83,12 +83,32 @@ assert_php_lint() {
   fi
 }
 
+assert_mode_0644() {
+  local file="$1" name="$2"
+  local got
+  got=$(stat -c %a "$file")
+  if [ "$got" = "644" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "    got:  $got"
+    echo "    want: 644"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
 # --- 1. Fresh scaffold + register kimaki -----------------------------------
-echo "==> register kimaki (fresh scaffold)"
-runtime_signature_register "kimaki" \
-  '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+# Use a hostile umask (matches root cron/systemd default 0077) to prove the
+# helper forces 0644 regardless of caller umask — see issue #133.
+echo "==> register kimaki (fresh scaffold, umask 077)"
+(
+  umask 077
+  runtime_signature_register "kimaki" \
+    '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+)
 assert_file_exists "$MU_FILE" "mu-plugin created"
 assert_php_lint "$MU_FILE" "scaffold parses with php -l"
+assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after fresh write under umask 077"
 
 if grep -q "BEGIN runtime:kimaki" "$MU_FILE"; then
   echo "  ok   kimaki block present"
@@ -106,10 +126,14 @@ HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-register"
 
 # --- 3. Add opencode without disturbing kimaki -----------------------------
-echo "==> register opencode (sibling block)"
+# Simulate a legacy 0600 file from a pre-#133 install. The next register call
+# must self-heal it back to 0644 via the mktemp+mv path.
+echo "==> simulate legacy 0600 file and verify self-heal on next register"
+chmod 0600 "$MU_FILE"
 runtime_signature_register "opencode" \
   '{"session_id":"OPENCODE_SESSION_ID","run_id":"OPENCODE_RUN_ID"}'
 assert_php_lint "$MU_FILE" "two-runtime file parses with php -l"
+assert_mode_0644 "$MU_FILE" "mu-plugin mode self-healed to 0644 after sibling register"
 
 if grep -q "BEGIN runtime:kimaki" "$MU_FILE" && grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
   echo "  ok   both runtime blocks present"
@@ -151,6 +175,7 @@ else
   FAILED=$((FAILED + 1))
 fi
 assert_php_lint "$MU_FILE" "post-unregister file parses with php -l"
+assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
 
 # --- 6. Filter-shape end-to-end (php execution) ----------------------------
 echo "==> apply_filters returns the expected shape"


### PR DESCRIPTION
## Summary

Two paper-cut bugs blocking real workflows on the extrachill.com VPS.

### #133 — mu-plugin perms (`lib/cli-channel.sh`, `lib/runtime-signature.sh`)

`cli_channel_ensure_mu_plugin_file` / `cli_channel_register` / `cli_channel_unregister` and the runtime-signature equivalents wrote their mu-plugin files using the caller's umask. Root cron/systemd contexts default to umask `0077`, producing mode `0600` files that PHP-FPM (www-data) cannot read — every WordPress request then logs "Permission denied" from `wp-settings.php` and the `datamachine_code_cli_channels` / `datamachine_code_worktree_runtime_signatures` filters return empty arrays, breaking dispatch-message and worktree origin attribution respectively.

**Implementation chosen: `chmod 0644` after every write path.** This integrates most cleanly with the existing `cat > "$file"` and `mktemp + mv` patterns the helpers already use, requires no restructuring around `install -m 0644`, and keeps the umask of the calling context untouched (no risk of leaking `umask 022` into other helpers that share the bash process).

Three write paths covered in both helpers:

1. Initial scaffold (`cat > $file` → `chmod 0644`)
2. Register replacing/inserting a block (`mktemp` creates at `0600`, `mv` preserves, then `chmod 0644`)
3. Unregister removing a block (same `mktemp + mv` path)

The chmod after `mktemp + mv` is what gives us **self-heal**: a legacy `0600` file from a pre-#133 install gets upgraded the next time the helper touches it.

### #134 — `.actual` snapshot files (`tests/effective-prompt/run.mjs`)

The effective-prompt harness writes `.actual` diff-intermediate files alongside the canonical snapshots when a scenario fails, but never cleans them up. They accumulated in `tests/effective-prompt/__snapshots__/` and dirtied the working tree, which blocks `homeboy release wp-coding-agents` on `preflight.working_tree`.

Two-part fix matching the issue's recommendation:

1. **`tests/effective-prompt/__snapshots__/.gitignore`** ignoring `*.actual`. Canonical `.baseline.txt` / `.filtered.txt` / `.raw.txt` snapshots stay tracked; only the diff intermediates become invisible to git.
2. **Cleanup in `run.mjs`**: after the main loop with zero failures, unlink every `*.actual` in `__snapshots__/`. On any failure, leave them in place for reviewer inspection.

**Snapshot mismatches still surface as visible test failures.** The harness already prints `<label> snapshot drift — run with --update to refresh` in the FAIL block and exits non-zero. The `.gitignore` only hides the intermediate copies of the new content, not the failure signal itself. Confirmed end-to-end on this branch: drifted snapshots produced loud FAIL output with `.actual` files left on disk for inspection but absent from `git status`.

## Verification

### `bash -n` on modified scripts

```
$ bash -n lib/cli-channel.sh && bash -n lib/runtime-signature.sh \
    && bash -n tests/cli-channel-perms.sh && bash -n tests/runtime-signature.sh
(clean)
```

### Perms test (umask 077 + self-heal scenarios)

```
$ bash tests/cli-channel-perms.sh
==> register kimaki (fresh scaffold, umask 077)
  ok   fresh scaffold lands as 0644 under umask 077
==> simulate legacy 0600 file and verify self-heal on next register
  ok   mu-plugin self-healed to 0644 after sibling register
==> unregister opencode-telegram
  ok   mu-plugin mode 0644 after unregister

OK: all cli-channel perms assertions passed

$ bash tests/runtime-signature.sh
==> register kimaki (fresh scaffold, umask 077)
  ok   mu-plugin created
  ok   scaffold parses with php -l
  ok   mu-plugin mode 0644 after fresh write under umask 077
  ok   kimaki block present
==> re-register kimaki with same signature (idempotent)
  ok   file unchanged on re-register
==> simulate legacy 0600 file and verify self-heal on next register
  ok   two-runtime file parses with php -l
  ok   mu-plugin mode self-healed to 0644 after sibling register
  ok   both runtime blocks present
==> re-register kimaki with mutated signature
  ok   kimaki block updated
  ok   opencode block preserved across kimaki mutation
==> unregister opencode
  ok   opencode block removed
  ok   kimaki block preserved across opencode unregister
  ok   post-unregister file parses with php -l
  ok   mu-plugin mode 0644 after unregister
==> apply_filters returns the expected shape
  ok   filter returns surviving kimaki signature

OK: all runtime-signature assertions passed
```

### Regression-validity check (test fails without the fix)

Stashed the fix and re-ran `tests/cli-channel-perms.sh` against unpatched `lib/cli-channel.sh`:

```
==> register kimaki (fresh scaffold, umask 077)
  FAIL fresh scaffold lands as 0644 under umask 077
    got:  600
    want: 644
==> simulate legacy 0600 file and verify self-heal on next register
  FAIL mu-plugin self-healed to 0644 after sibling register
    got:  600
    want: 644
==> unregister opencode-telegram
  FAIL mu-plugin mode 0644 after unregister
    got:  600
    want: 644

FAILED: 3 assertion(s)
```

Test catches the exact bug from the bug report.

### Effective-prompt cleanup

Ran the harness against drifted snapshots (kimaki on host has moved ahead of committed snapshots — unrelated to this PR). `.actual` files were written to disk on failure but were absent from `git status` thanks to the new `.gitignore`. After `--update` to refresh snapshots, the next clean run unlinked every `.actual` file and left `tests/effective-prompt/__snapshots__/` containing only the six canonical `.txt` files. Working tree clean.

### No release/version churn

- No `CHANGELOG.md` edits
- No `VERSION` edits
- No `homeboy release` / `homeboy deploy` run

Closes #133, closes #134