### PR TITLE
Fix dm-agent-sync OpenCode agent mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Runs on a dedicated VPS for always-on autonomous operation, or locally on your M
    └── Data Machine ── self-scheduling + AI tools
 ```
 
-On activation, Data Machine creates a default agent and scaffolds its memory files. Additional agents get their own files when created. Every registered file is injected into each session — the agent wakes up knowing who it is and what it's been working on. No memory management overhead in the context window.
+On activation, Data Machine creates a default agent and scaffolds its memory files. Additional agents get their own files when created. The runtime loads the selected agent's registered files for each session — the agent wakes up knowing who it is and what it's been working on. No memory management overhead in the context window.
 
 ## Runtime Auto-Discovery
 
@@ -34,9 +34,9 @@ Drop a file in `runtimes/`, it's available. The script scans `runtimes/*.sh` for
 
 ```
 hooks/
-└── dm-agent-sync.sh   # SessionStart hook: sync DM agents into CLAUDE.md
+└── dm-agent-sync.sh   # SessionStart hook: refresh CLAUDE.md memory includes
 runtimes/
-├── opencode.sh        # OpenCode: opencode.json + AGENTS.md + {file:} includes
+├── opencode.sh        # OpenCode: opencode.json instructions + AGENTS.md
 ├── claude-code.sh     # Claude Code: CLAUDE.md + @ includes + .mcp.json
 └── studio-code.sh     # Studio Code: CLAUDE.md + @ includes + Studio tools
 ```
@@ -222,9 +222,9 @@ Data Machine manages memory files across three layers, each scoped to a differen
 |------|---------|
 | **USER.md** | Information about the human the agent works with. Injected in chat and editor contexts only. |
 
-On activation, Data Machine creates a default agent for the first admin user and scaffolds all three layers. Each additional agent gets its own SOUL.md and MEMORY.md when created, sharing the same SITE.md and USER.md. All discovered files are injected into every session via the runtime's config — `opencode.json` (`{file:}` includes) for OpenCode, `CLAUDE.md` (`@` includes) for Claude Code and Studio Code. The agent doesn't manage memory infrastructure — it just reads and writes these files. DM handles the rest.
+On activation, Data Machine creates a default agent for the first admin user and scaffolds all three layers. Each additional agent gets its own SOUL.md and MEMORY.md when created, sharing the same SITE.md and USER.md. The selected agent's discovered files are injected into each session via the runtime's config — top-level `opencode.json` `instructions` for OpenCode, `CLAUDE.md` (`@` includes) for Claude Code and Studio Code. The agent doesn't manage memory infrastructure — it just reads and writes these files. DM handles the rest.
 
-**Runtime sync (Claude Code / Studio Code):** A SessionStart hook queries Data Machine on every session start and updates the `@` includes in CLAUDE.md. New agents created after setup are automatically discovered — no manual config regeneration needed. Claude Code's built-in auto-memory is disabled, since DM handles memory. Studio Code uses the same hook mechanism — it runs the Claude Agent SDK with the `claude_code` preset, which loads `.claude/settings.json` hooks by default.
+**Runtime sync:** Claude Code and Studio Code use a SessionStart hook that queries Data Machine on every session start and updates the `@` includes in CLAUDE.md. OpenCode uses top-level `instructions` plus a Kimaki plugin that only recomposes Data Machine memory files before OpenCode reads them; it does not write `agent.build.prompt`, `agent.plan.prompt`, or register every Data Machine agent into OpenCode config. Claude Code's built-in auto-memory is disabled, since DM handles memory. Studio Code uses the same hook mechanism — it runs the Claude Agent SDK with the `claude_code` preset, which loads `.claude/settings.json` hooks by default.
 
 ## Abilities
 

--- a/bridges/kimaki/plugins/dm-agent-sync.ts
+++ b/bridges/kimaki/plugins/dm-agent-sync.ts
@@ -1,12 +1,8 @@
-// dm-agent-sync.ts — OpenCode plugin that syncs Data Machine agents into
-// OpenCode's agent switcher.
+// dm-agent-sync.ts — OpenCode plugin that refreshes Data Machine memory.
 //
-// On session start, queries Data Machine for all registered agents and their
-// file paths, then registers each as an OpenCode agent with the correct
-// identity files (SOUL.md, MEMORY.md, USER.md, SITE.md) and AGENTS.md.
-//
-// This gives every Data Machine agent its own identity in the agent switcher
-// without manual opencode.json maintenance.
+// On session start, asks Data Machine to recompose memory files such as
+// AGENTS.md. Agent identity stays in Data Machine's channel/session binding and
+// OpenCode's top-level instructions instead of mutating config.agent.* prompts.
 //
 // How to use:
 //   Add to opencode.json:  "plugin": ["path/to/dm-agent-sync.ts"]
@@ -17,32 +13,9 @@
  */
 import type { Plugin } from "@opencode-ai/plugin";
 
-interface DmAgent {
-  agent_id: number;
-  agent_slug: string;
-  agent_name: string;
-  owner_id: number;
-  status?: string;
-  agent_config?: {
-    default_model?: string;
-    tool_policy?: Record<string, boolean>;
-    model?: {
-      default?: {
-        provider?: string;
-        model?: string;
-      };
-    };
-  };
-}
-
-interface DmPaths {
-  agent_slug: string;
-  relative_files: string[];
-}
-
 const dmAgentSync: Plugin = async ({ $ }) => {
   return {
-    config: async (config) => {
+    config: async () => {
       const sitePath = getSitePath();
       const wpAvailable = await $`command -v wp`.quiet().nothrow();
       if (wpAvailable.exitCode !== 0) {
@@ -61,146 +34,15 @@ const dmAgentSync: Plugin = async ({ $ }) => {
         : await $`wp datamachine memory compose --allow-root`.quiet().nothrow();
       if (composeResult.exitCode !== 0) {
         console.warn(`[dm-agent-sync] memory compose failed (exit ${composeResult.exitCode}): ${await shellOutputText(composeResult)}`);
-      }
-
-      // Query all agents from Data Machine.
-      const agentsResult = sitePath
-        ? await $`wp --path=${sitePath} datamachine agents list --format=json --allow-root`.quiet().nothrow()
-        : await $`wp datamachine agents list --format=json --allow-root`.quiet().nothrow();
-      if (agentsResult.exitCode !== 0) {
-        console.warn(`[dm-agent-sync] agents list failed (exit ${agentsResult.exitCode}): ${await shellOutputText(agentsResult)}`);
         return;
       }
-
-      const agentsRaw = await shellOutputText(agentsResult);
-      const jsonMatch = agentsRaw.match(/\[[\s\S]*\]/);
-      if (!jsonMatch) {
-        console.warn("[dm-agent-sync] agents list did not contain a JSON array");
-        return;
-      }
-
-      let agents: DmAgent[];
-      try {
-        agents = JSON.parse(jsonMatch[0]);
-      } catch (error) {
-        console.warn(`[dm-agent-sync] agents list returned invalid JSON: ${String(error)}`);
-        return;
-      }
-
-      const entries = [];
-      for (const agent of agents) {
-        const status = agent.status || "active";
-        if (status !== "active") {
-          continue;
-        }
-
-        const pathsResult = sitePath
-          ? await $`wp --path=${sitePath} datamachine memory paths --agent=${agent.agent_slug} --format=json --allow-root`.quiet().nothrow()
-          : await $`wp datamachine memory paths --agent=${agent.agent_slug} --format=json --allow-root`.quiet().nothrow();
-        if (pathsResult.exitCode !== 0) {
-          console.warn(`[dm-agent-sync] memory paths failed for ${agent.agent_slug} (exit ${pathsResult.exitCode}): ${await shellOutputText(pathsResult)}`);
-          continue;
-        }
-
-        let paths: DmPaths;
-        try {
-          paths = JSON.parse(await shellOutputText(pathsResult));
-        } catch (error) {
-          console.warn(`[dm-agent-sync] memory paths returned invalid JSON for ${agent.agent_slug}: ${String(error)}`);
-          continue;
-        }
-
-        if (!paths?.relative_files?.length) {
-          console.warn(`[dm-agent-sync] memory paths returned no files for ${agent.agent_slug}`);
-          continue;
-        }
-
-        const promptRoot = sitePath || ".";
-        const prompt = [
-          `{file:${promptRoot}/AGENTS.md}`,
-          ...paths.relative_files.map((f: string) => `{file:${promptRoot}/${f}}`),
-        ].join("\n");
-
-        const agentModel =
-          agent.agent_config?.default_model ||
-          (agent.agent_config?.model?.default
-            ? `${agent.agent_config.model.default.provider}/${agent.agent_config.model.default.model}`
-            : undefined);
-        const tools = agent.agent_config?.tool_policy;
-        const entry: Record<string, unknown> = {
-          prompt,
-          mode: "primary" as const,
-        };
-        if (agentModel) {
-          entry.model = agentModel;
-        }
-        if (tools) {
-          entry.tools = tools;
-        }
-
-        entries.push({ agent, entry, prompt });
-      }
-
-      if (!entries.length) {
-        console.warn(`[dm-agent-sync] no active Data Machine agents with usable memory paths found (${agents.length} listed)`);
-        return;
-      }
-
-      if (!config.agent) {
-        config.agent = {};
-      }
-
-      const primary = entries[0];
-      syncDefaultSlot(config.agent, "build", primary.entry);
-      syncDefaultSlot(config.agent, "plan", primary.entry);
-
-      for (const { agent, entry } of entries) {
-        const agentSlug = agent.agent_slug;
-        if (!config.agent[agentSlug]) {
-          config.agent[agentSlug] = {
-            ...entry,
-            description: `Data Machine agent: ${agent.agent_name}`,
-          };
-        }
-      }
-
-      console.warn(`[dm-agent-sync] registered ${entries.length} Data Machine agent(s); build/plan prompt uses ${primary.agent.agent_slug}`);
+      console.warn("[dm-agent-sync] recomposed Data Machine memory");
     },
   };
 };
 
 function getSitePath(): string {
   return process.env.DATAMACHINE_SITE_PATH || process.env.SITE_PATH || process.env.PWD || "";
-}
-
-/**
- * Populate build/plan defaults without clobbering user-authored fields.
- *
- * @param {Record<string, unknown>} agentConfig  - OpenCode agent config object.
- * @param {"build"|"plan"}          slot         - Default slot to synchronize.
- * @param {Record<string, unknown>} managedEntry - Data Machine-managed entry.
- */
-function syncDefaultSlot(
-  agentConfig: Record<string, unknown>,
-  slot: "build" | "plan",
-  managedEntry: Record<string, unknown>
-): void {
-  const existing = agentConfig[slot];
-  if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
-    agentConfig[slot] = { ...managedEntry };
-    return;
-  }
-
-  const existingEntry = existing as Record<string, unknown>;
-  if (typeof existingEntry.prompt === "string" && existingEntry.prompt.length > 0) {
-    return;
-  }
-
-  agentConfig[slot] = {
-    ...managedEntry,
-    ...existingEntry,
-    prompt: managedEntry.prompt,
-  };
 }
 
 async function shellOutputText(output: any): Promise<string> {

--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -87,8 +87,9 @@ def expected_plugins(
         # "drift" comparisons on those runtimes are no-ops.
         return plugins
 
-    # DM context filter + agent sync: only when the bridge is Kimaki, since
-    # these plugins rewrite Kimaki-specific prompts. wp-coding-agents does
+    # DM context filter + memory sync: only when the bridge is Kimaki. These
+    # plugins filter Kimaki-specific prompt sections and refresh composed Data
+    # Machine memory; they do not write OpenCode agent prompts. wp-coding-agents does
     # not manage opencode-claude-auth on any bridge — Kimaki ships its own
     # AnthropicAuthPlugin, and non-kimaki bridges use opencode's native auth
     # flow. See wp-coding-agents#117.

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -134,10 +134,12 @@ runtime_generate_config() {
   # Resolve Kimaki plugin dir + copy plugin files FIRST, unconditionally.
   # Setup.sh must be idempotent: whether this site has a fresh install or an
   # existing opencode.json, the kimaki plugins dir on disk must end up with
-  # the current dm-context-filter.ts + dm-agent-sync.ts. Previously this only
-  # ran on fresh installs because the whole function early-returned on an
-  # existing file, which left upgraded installs missing the security policy
-  # filter they're meant to run with. See wp-coding-agents#67.
+  # the current dm-context-filter.ts + dm-agent-sync.ts. dm-agent-sync only
+  # recomposes Data Machine memory; it must not write config.agent.* prompts.
+  # Previously this only ran on fresh installs because the whole function
+  # early-returned on an existing file, which left upgraded installs missing
+  # the security policy filter they're meant to run with. See
+  # wp-coding-agents#67.
   KIMAKI_PLUGINS_DIR=""
   if [ "$CHAT_BRIDGE" = "kimaki" ]; then
     if [ "$LOCAL_MODE" = true ]; then
@@ -175,7 +177,8 @@ runtime_generate_config() {
   fi
 
   # OpenCode plugins. wp-coding-agents only manages plugins it owns end to
-  # end: dm-context-filter.ts and dm-agent-sync.ts on Kimaki bridges. The
+  # end: dm-context-filter.ts and dm-agent-sync.ts on Kimaki bridges. The sync
+  # plugin refreshes composed memory files without mutating config.agent slots.
   # opencode-claude-auth plugin is intentionally NOT installed on any bridge:
   # Kimaki ships a built-in AnthropicAuthPlugin and non-kimaki bridges use
   # opencode's native auth flow (`opencode auth login anthropic`). See

--- a/tests/dm-agent-sync.mjs
+++ b/tests/dm-agent-sync.mjs
@@ -1,4 +1,4 @@
-// tests/dm-agent-sync.mjs — unit smoke tests for the Kimaki DM agent sync plugin.
+// tests/dm-agent-sync.mjs — unit smoke tests for the Kimaki DM memory sync plugin.
 
 import assert from "node:assert/strict"
 import dmAgentSync from "../bridges/kimaki/plugins/dm-agent-sync.ts"
@@ -49,17 +49,9 @@ async function runConfig(config, responses) {
   return warnings
 }
 
-const agentsJson = JSON.stringify([
-  { agent_id: 1, agent_slug: "franklin", agent_name: "Franklin", owner_id: 1, status: "active" },
-  { agent_id: 2, agent_slug: "julia", agent_name: "Julia", owner_id: 1, status: "active" },
-])
-
 const commonResponses = [
   [/^command -v wp$/, output("/usr/local/bin/wp")],
   [/^wp --path=\/tmp\/datamachine-site datamachine memory compose/, output("composed")],
-  [/^wp --path=\/tmp\/datamachine-site datamachine agents list/, output(`${agentsJson}\nTotal: 2 agent(s).`)],
-  [/--agent=franklin /, output(JSON.stringify({ agent_slug: "franklin", relative_files: ["SITE.md", "SOUL.md"] }))],
-  [/--agent=julia /, output(JSON.stringify({ agent_slug: "julia", relative_files: ["SITE.md", "MEMORY.md"] }))],
 ]
 
 {
@@ -71,12 +63,12 @@ const commonResponses = [
     },
   }
   const warnings = await runConfig(config, commonResponses)
-  assert.match(config.agent.build.prompt, /\{file:\/tmp\/datamachine-site\/AGENTS\.md\}/)
-  assert.match(config.agent.plan.prompt, /\{file:\/tmp\/datamachine-site\/SOUL\.md\}/)
+  assert.equal(config.agent.build.prompt, undefined)
+  assert.equal(config.agent.plan.prompt, undefined)
   assert.equal(config.agent.build.model, "anthropic/claude-opus-4-7")
-  assert.match(config.agent.franklin.prompt, /\{file:\/tmp\/datamachine-site\/SITE\.md\}/)
-  assert.match(config.agent.julia.description, /Data Machine agent: Julia/)
-  assert.ok(warnings.some((line) => line.includes("registered 2 Data Machine agent(s)")))
+  assert.equal(config.agent.franklin, undefined)
+  assert.equal(config.agent.julia, undefined)
+  assert.ok(warnings.some((line) => line.includes("recomposed Data Machine memory")))
 }
 
 {
@@ -88,8 +80,8 @@ const commonResponses = [
   }
   await runConfig(config, commonResponses)
   assert.deepEqual(config.agent.build.tools, { bash: true })
-  assert.match(config.agent.build.prompt, /\{file:\/tmp\/datamachine-site\/SOUL\.md\}/)
-  assert.match(config.agent.plan.prompt, /\{file:\/tmp\/datamachine-site\/SOUL\.md\}/)
+  assert.equal(config.agent.build.prompt, undefined)
+  assert.equal(config.agent.plan.prompt, undefined)
 }
 
 {
@@ -100,18 +92,17 @@ const commonResponses = [
   }
   await runConfig(config, commonResponses)
   assert.equal(config.agent.build.prompt, "custom prompt")
-  assert.match(config.agent.plan.prompt, /\{file:\/tmp\/datamachine-site\/SOUL\.md\}/)
+  assert.equal(config.agent.plan, undefined)
 }
 
 {
   const config = {}
   const warnings = await runConfig(config, [
     [/^command -v wp$/, output("/usr/local/bin/wp")],
-    [/^wp --path=\/tmp\/datamachine-site datamachine memory compose/, output("composed")],
-    [/^wp --path=\/tmp\/datamachine-site datamachine agents list/, output("", 1, "db down")],
+    [/^wp --path=\/tmp\/datamachine-site datamachine memory compose/, output("", 1, "db down")],
   ])
-  assert.ok(warnings.some((line) => line.includes("agents list failed")))
+  assert.ok(warnings.some((line) => line.includes("memory compose failed")))
   assert.equal(config.agent, undefined)
 }
 
-console.log("OK: dm-agent-sync injects DM prompts and logs failures")
+console.log("OK: dm-agent-sync recomposes DM memory without mutating OpenCode agents")


### PR DESCRIPTION
## Summary
- Narrow `dm-agent-sync.ts` to only recompose Data Machine memory at OpenCode session config time.
- Stop querying all Data Machine agents, registering them into OpenCode config, or writing `agent.build.prompt` / `agent.plan.prompt`.
- Update tests and docs to describe selected-agent instructions plus memory recomposition.

Closes #147.

## Verification
- `node tests/dm-agent-sync.mjs`
- `bash tests/repair-opencode-json.sh`
- `./tests/opencode-local-plugin-path.sh`
- `./tests/bridge-render.sh`
- `./tests/datamachine-kimaki-adapter.sh`
- `./tests/opencode-wrapper-removal.sh`
- `bash -c 'set -e; fail=0; while IFS= read -r -d "" f; do if ! bash -n "$f"; then echo "FAIL: $f"; fail=1; fi; done < <(find . -type f -name "*.sh" -not -path "./.git/*" -print0); exit "$fail"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code, test, and documentation updates for Chris to review and verify.
