### PR TITLE
fix(kimaki): use native skill filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,12 +304,12 @@ Local installs run as your current user — no root, no service user, no chown.
 
 ### Kimaki (Discord)
 
-The default chat bridge for OpenCode. On VPS, wp-coding-agents installs post-upgrade hooks that:
+The default chat bridge for OpenCode. On VPS and macOS launchd installs, wp-coding-agents starts Kimaki with native 0.13 skill filters and installs post-upgrade hooks that:
 
-- **Remove unwanted bundled skills** — Kimaki ships with skills for frameworks and tools that aren't relevant to WordPress agent workflows. The kill list (`bridges/kimaki/skills-kill-list.txt`) controls which skills are removed after each upgrade.
+- **Disable unwanted bundled skills** — Kimaki ships with skills for frameworks and tools that aren't relevant to WordPress agent workflows. The disable list (`bridges/kimaki/skills-disable-list.txt`) is rendered as `--disable-skill` startup flags, so package-managed skill directories are left intact.
 - **Filter redundant context** — A plugin strips Kimaki's built-in memory injection and scheduling instructions from the agent context, since DM handles those concerns. Saves ~2,400 tokens per session.
 
-To customize the kill list, edit `bridges/kimaki/skills-kill-list.txt` before running setup, or edit `/opt/kimaki-config/skills-kill-list.txt` on the server after install.
+To customize the managed skill filters, edit `bridges/kimaki/skills-disable-list.txt` before running setup, or edit `/opt/kimaki-config/skills-disable-list.txt` on a VPS or `$KIMAKI_DATA_DIR/kimaki-config/skills-disable-list.txt` on a local install after setup.
 
 On local installs, Kimaki installs globally via npm but without a systemd service. Run it manually:
 

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -2,17 +2,17 @@
 # bridges/kimaki.sh — Kimaki Discord bridge.
 #
 # Owns install (local launchd / VPS systemd / Linux-local manual), upgrade-time
-# config sync (plugins, post-upgrade.sh, skills kill-list, regression test),
+# config sync (plugins, post-upgrade.sh, skill filters, regression test),
 # systemd + launchd template rendering, summary blocks, and the per-bridge
-# assets at bridges/kimaki/ (plugins/, post-upgrade.sh, skills-kill-list.txt).
+# assets at bridges/kimaki/ (plugins/, post-upgrade.sh, skills-disable-list.txt).
 #
 # Install layout:
-#   VPS:   /opt/kimaki-config/{plugins,post-upgrade.sh,skills-kill-list.txt}
+#   VPS:   /opt/kimaki-config/{plugins,post-upgrade.sh,skills-disable-list.txt}
 #          + /usr/local/bin/datamachine-kimaki-session
 #          + /usr/local/bin/datamachine-kimaki
 #          + /etc/systemd/system/kimaki.service (ExecStartPre runs post-upgrade.sh)
 #   Local: $KIMAKI_DATA_DIR/kimaki-config/ for plugins, post-upgrade.sh +
-#          kill list (executed inline at upgrade time — no launchd
+#          skill filters (executed inline at upgrade time — no launchd
 #          ExecStartPre hook). opencode.json loads plugins directly from this
 #          durable data-dir copy because `npm update -g kimaki` wipes package-
 #          local files.
@@ -247,7 +247,7 @@ bridge_sync_config() {
   # Resolve paths per environment.
   #   VPS:   plugins live at /opt/kimaki-config/plugins (referenced by opencode.json,
   #          and by ExecStartPre in kimaki.service). Config dir holds plugins +
-  #          post-upgrade.sh + skills-kill-list.txt.
+  #          post-upgrade.sh + skills-disable-list.txt.
   #   Local: opencode.json points at $KIMAKI_DATA_DIR/kimaki-config/plugins, the
   #          durable source that survives `npm update -g kimaki`. Existing configs
   #          that still reference package-local plugin paths are migrated by the
@@ -278,7 +278,7 @@ bridge_sync_config() {
   # kimaki IS the detected bridge and kimaki.service IS running — the
   # config dir just never got bootstrapped. Create it now from the repo.
   # All contents are wp-coding-agents-owned (plugins, post-upgrade.sh,
-  # kill list); there is no user state to preserve.
+  # skill filters); there is no user state to preserve.
   if [ "$LOCAL_MODE" = false ] && [ ! -d "$KIMAKI_CONFIG_DIR" ]; then
     if [ "$DRY_RUN" = true ]; then
       echo -e "${BLUE}[dry-run]${NC} Would bootstrap $KIMAKI_CONFIG_DIR from $SCRIPT_DIR/bridges/kimaki/"
@@ -286,7 +286,7 @@ bridge_sync_config() {
       log "  $KIMAKI_CONFIG_DIR missing — bootstrapping from repo (install predates v0.4.0)"
       mkdir -p "$KIMAKI_CONFIG_DIR/plugins"
       UPDATED_ITEMS+=("bootstrapped $KIMAKI_CONFIG_DIR (install predates v0.4.0)")
-      # Fall through — the plugin/post-upgrade/kill-list copy logic below
+      # Fall through — the plugin/post-upgrade/skill-filter copy logic below
       # handles the actual file placement idempotently.
     fi
   fi
@@ -327,7 +327,7 @@ bridge_sync_config() {
     done
   fi
 
-  # Stage post-upgrade.sh and skills-kill-list.txt in KIMAKI_CONFIG_DIR.
+  # Stage post-upgrade.sh and skills-disable-list.txt in KIMAKI_CONFIG_DIR.
   # On VPS this is read by ExecStartPre. On local we execute it inline below.
   if [ "$DRY_RUN" = false ]; then
     mkdir -p "$KIMAKI_CONFIG_DIR" 2>/dev/null || true
@@ -348,16 +348,16 @@ bridge_sync_config() {
     fi
   fi
 
-  if [ -f "$SCRIPT_DIR/bridges/kimaki/skills-kill-list.txt" ]; then
+  if [ -f "$SCRIPT_DIR/bridges/kimaki/skills-disable-list.txt" ]; then
     if [ "$DRY_RUN" = true ]; then
-      if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/skills-kill-list.txt" "$KIMAKI_CONFIG_DIR/skills-kill-list.txt" 2>/dev/null; then
-        echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_CONFIG_DIR/skills-kill-list.txt"
+      if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/skills-disable-list.txt" "$KIMAKI_CONFIG_DIR/skills-disable-list.txt" 2>/dev/null; then
+        echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_CONFIG_DIR/skills-disable-list.txt"
       fi
     else
-      if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/skills-kill-list.txt" "$KIMAKI_CONFIG_DIR/skills-kill-list.txt" 2>/dev/null; then
-        cp "$SCRIPT_DIR/bridges/kimaki/skills-kill-list.txt" "$KIMAKI_CONFIG_DIR/skills-kill-list.txt"
-        log "  Updated $KIMAKI_CONFIG_DIR/skills-kill-list.txt"
-        UPDATED_ITEMS+=("kimaki-config/skills-kill-list.txt")
+      if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/skills-disable-list.txt" "$KIMAKI_CONFIG_DIR/skills-disable-list.txt" 2>/dev/null; then
+        cp "$SCRIPT_DIR/bridges/kimaki/skills-disable-list.txt" "$KIMAKI_CONFIG_DIR/skills-disable-list.txt"
+        log "  Updated $KIMAKI_CONFIG_DIR/skills-disable-list.txt"
+        UPDATED_ITEMS+=("kimaki-config/skills-disable-list.txt")
       fi
     fi
   fi
@@ -366,15 +366,15 @@ bridge_sync_config() {
   # outside Kimaki's npm package so `npm update -g kimaki` cannot wipe them.
   _kimaki_sync_bin_helpers
 
-  # On local, execute post-upgrade.sh inline to enforce the kill list.
+  # On local, execute post-upgrade.sh inline to restore wp-coding-agents skills.
   # On VPS, kimaki.service ExecStartPre runs it on next service restart.
   if [ "$LOCAL_MODE" = true ] && [ -x "$KIMAKI_CONFIG_DIR/post-upgrade.sh" ]; then
     if [ "$DRY_RUN" = true ]; then
       echo -e "${BLUE}[dry-run]${NC} Would run: $KIMAKI_CONFIG_DIR/post-upgrade.sh"
     else
-      log "  Running post-upgrade.sh to enforce skills kill list..."
+      log "  Running post-upgrade.sh to restore wp-coding-agents skills..."
       if "$KIMAKI_CONFIG_DIR/post-upgrade.sh" 2>&1 | sed 's/^/    /'; then
-        UPDATED_ITEMS+=("ran post-upgrade.sh (enforced skills kill list)")
+        UPDATED_ITEMS+=("ran post-upgrade.sh (restored wp-coding-agents skills)")
       else
         warn "  post-upgrade.sh exited non-zero — review output above"
       fi
@@ -525,6 +525,8 @@ bridge_update_launchd() {
 bridge_render_systemd() {
   local unit="$1" env_block="$2"
   [ "$unit" = "kimaki.service" ] || { echo "kimaki has no unit '$unit'" >&2; return 1; }
+  local skill_filter_args
+  skill_filter_args="$(_kimaki_skill_filter_args_shell)"
   cat <<EOF
 [Unit]
 Description=Kimaki Discord Bot (wp-coding-agents)
@@ -547,7 +549,7 @@ $env_block
 # tolerate exit code 1 (no matches found, the happy path on a clean box).
 ExecStartPre=-/usr/bin/pkill -TERM -u $SERVICE_USER -f "opencode-ai/bin/.*serve"
 ExecStartPre=$KIMAKI_CONFIG_DIR/post-upgrade.sh
-ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique
+ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique$skill_filter_args
 Restart=always
 RestartSec=10
 
@@ -563,6 +565,8 @@ bridge_render_launchd() {
   kimaki_bin_dir="$(dirname "$KIMAKI_BIN")"
   node_bin_dir="$(_resolve_node_bin_dir "$KIMAKI_BIN")"
   path_value="$(_compose_path_value "$HOME/.local/bin" "$kimaki_bin_dir" "$node_bin_dir" "$HOME/.opencode/bin" "$HOME/.bun/bin" /opt/homebrew/bin /usr/local/bin /usr/bin /bin /usr/sbin /sbin)"
+  local skill_filter_plist_args
+  skill_filter_plist_args="$(_kimaki_skill_filter_args_plist)"
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -577,6 +581,7 @@ bridge_render_launchd() {
         <string>$KIMAKI_DATA_DIR</string>
         <string>--auto-restart</string>
         <string>--no-critique</string>
+$skill_filter_plist_args
     </array>
     <key>WorkingDirectory</key>
     <string>$SITE_PATH</string>
@@ -600,6 +605,48 @@ bridge_render_launchd() {
 </dict>
 </plist>
 EOF
+}
+
+_kimaki_skill_filter_source() {
+  if [ -n "${KIMAKI_SKILL_FILTERS_FILE:-}" ]; then
+    printf '%s\n' "$KIMAKI_SKILL_FILTERS_FILE"
+  elif [ -n "${KIMAKI_CONFIG_DIR:-}" ] && [ -f "$KIMAKI_CONFIG_DIR/skills-disable-list.txt" ]; then
+    printf '%s\n' "$KIMAKI_CONFIG_DIR/skills-disable-list.txt"
+  elif [ -n "${KIMAKI_DATA_DIR:-}" ] && [ -f "$KIMAKI_DATA_DIR/kimaki-config/skills-disable-list.txt" ]; then
+    printf '%s\n' "$KIMAKI_DATA_DIR/kimaki-config/skills-disable-list.txt"
+  else
+    printf '%s\n' "$SCRIPT_DIR/bridges/kimaki/skills-disable-list.txt"
+  fi
+}
+
+_kimaki_each_disabled_skill() {
+  local filters_file skill
+  filters_file="$(_kimaki_skill_filter_source)"
+  [ -f "$filters_file" ] || return 0
+
+  while IFS= read -r skill || [ -n "$skill" ]; do
+    [ -n "$skill" ] || continue
+    case "$skill" in \#*) continue ;; esac
+    printf '%s\n' "$skill"
+  done < "$filters_file"
+}
+
+_kimaki_skill_filter_args_shell() {
+  local out="" skill
+  while IFS= read -r skill; do
+    out="$out --disable-skill $skill"
+  done < <(_kimaki_each_disabled_skill)
+  printf '%s' "$out"
+}
+
+_kimaki_skill_filter_args_plist() {
+  local out="" skill
+  while IFS= read -r skill; do
+    out="$out        <string>--disable-skill</string>
+        <string>$skill</string>
+"
+  done < <(_kimaki_each_disabled_skill)
+  printf '%s' "$out"
 }
 
 # ============================================================================

--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
-# post-upgrade.sh — Enforce kimaki skill state and validate plugin state.
+# post-upgrade.sh — Restore wp-coding-agents skills and validate plugin state.
 #
-# Three passes run against the npm-installed kimaki package and persistent
+# Two passes run against the npm-installed kimaki package and persistent
 # kimaki-config directory:
-#   1. KILL    — remove unwanted bundled kimaki skills listed in
-#                skills-kill-list.txt (target: $(npm root -g)/kimaki/skills/).
-#   2. RESTORE skills  — re-copy wp-coding-agents skills from the persistent
+#   1. RESTORE skills  — re-copy wp-coding-agents skills from the persistent
 #                source dir (kimaki-config/skills/) into kimaki/skills/.
-#   3. VERIFY plugins  — confirm required wp-coding-agents opencode plugins
+#   2. VERIFY plugins  — confirm required wp-coding-agents opencode plugins
 #                exist at the persistent kimaki-config/plugins path loaded by
 #                opencode.json. Local installs no longer restore plugins into
 #                $(npm root -g)/kimaki/plugins because package-local files are
@@ -61,7 +59,6 @@ else
   SKILLS_DIR="/usr/lib/node_modules/kimaki/skills"
 fi
 
-KILL_LIST="$(dirname "$0")/skills-kill-list.txt"
 REQUIRED_PLUGINS=(dm-context-filter.ts dm-agent-sync.ts)
 WP_CODING_AGENTS_SKILLS=(upgrade-wp-coding-agents wp-coding-agents-setup)
 
@@ -76,43 +73,8 @@ is_wp_coding_agents_skill() {
   return 1
 }
 
-is_killed_skill() {
-  local candidate="$1"
-
-  [[ -f "$KILL_LIST" ]] || return 1
-
-  while IFS= read -r skill || [[ -n "$skill" ]]; do
-    [[ -z "$skill" || "$skill" == \#* ]] && continue
-    [[ "$candidate" == "$skill" ]] && return 0
-  done < "$KILL_LIST"
-
-  return 1
-}
-
 # ----------------------------------------------------------------------------
-# Pass 1: KILL — remove blacklisted bundled kimaki skills.
-# ----------------------------------------------------------------------------
-
-removed=0
-if [[ ! -d "$SKILLS_DIR" ]]; then
-  echo "kimaki-config: skills dir not found at $SKILLS_DIR, skipping kill pass"
-elif [[ ! -f "$KILL_LIST" ]]; then
-  echo "kimaki-config: kill list not found at $KILL_LIST, skipping kill pass"
-else
-  while IFS= read -r skill || [[ -n "$skill" ]]; do
-    # Skip comments and blank lines
-    [[ -z "$skill" || "$skill" == \#* ]] && continue
-    target="$SKILLS_DIR/$skill"
-    if [[ -d "$target" ]]; then
-      rm -rf "$target"
-      echo "kimaki-config: removed skill $skill"
-      removed=$((removed + 1))
-    fi
-  done < "$KILL_LIST"
-fi
-
-# ----------------------------------------------------------------------------
-# Pass 2: RESTORE skills — re-copy wp-coding-agents skills from the
+# Pass 1: RESTORE skills — re-copy wp-coding-agents skills from the
 # persistent source dir into the npm-managed skills dir. Idempotent: `rm -rf`
 # before each `cp -r` so a stale copy always gets replaced by the current
 # source.
@@ -135,10 +97,6 @@ elif [[ -d "$SKILL_SOURCE_DIR" ]]; then
   for skill_dir in "$SKILL_SOURCE_DIR"/*/; do
     [[ -d "$skill_dir" ]] || continue
     skill_name="$(basename "$skill_dir")"
-    if is_killed_skill "$skill_name"; then
-      echo "kimaki-config: skipped killed skill $skill_name"
-      continue
-    fi
     if ! is_wp_coding_agents_skill "$skill_name"; then
       echo "kimaki-config: skipped unmanaged skill $skill_name"
       continue
@@ -156,7 +114,7 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-# Pass 3: VERIFY plugins — opencode.json now loads wp-coding-agents plugins
+# Pass 2: VERIFY plugins — opencode.json now loads wp-coding-agents plugins
 # directly from persistent kimaki-config/plugins. When the target and source are
 # the same directory (the default), there is nothing to restore. An explicit
 # KIMAKI_PLUGINS_DIR override still receives a best-effort copy for operator
@@ -219,4 +177,4 @@ else
   done
 fi
 
-echo "kimaki-config: done ($removed skills removed, $skills_restored skills restored, $plugins_restored plugins restored, $missing_required_plugins required plugins missing)"
+echo "kimaki-config: done ($skills_restored skills restored, $plugins_restored plugins restored, $missing_required_plugins required plugins missing)"

--- a/bridges/kimaki/skills-disable-list.txt
+++ b/bridges/kimaki/skills-disable-list.txt
@@ -1,5 +1,5 @@
-# Skills to remove from Kimaki after upgrades.
-# One skill directory name per line. Lines starting with # are ignored.
+# Skills to disable in managed Kimaki services.
+# One skill name per line. Lines starting with # are ignored.
 
 batch
 egaki

--- a/tests/__snapshots__/bridges/kimaki-launchd
+++ b/tests/__snapshots__/bridges/kimaki-launchd
@@ -11,6 +11,42 @@
         <string>/home/chubes/.kimaki</string>
         <string>--auto-restart</string>
         <string>--no-critique</string>
+        <string>--disable-skill</string>
+        <string>batch</string>
+        <string>--disable-skill</string>
+        <string>egaki</string>
+        <string>--disable-skill</string>
+        <string>errore</string>
+        <string>--disable-skill</string>
+        <string>event-sourcing-state</string>
+        <string>--disable-skill</string>
+        <string>gitchamber</string>
+        <string>--disable-skill</string>
+        <string>goke</string>
+        <string>--disable-skill</string>
+        <string>jitter</string>
+        <string>--disable-skill</string>
+        <string>lintcn</string>
+        <string>--disable-skill</string>
+        <string>npm-package</string>
+        <string>--disable-skill</string>
+        <string>playwriter</string>
+        <string>--disable-skill</string>
+        <string>proxyman</string>
+        <string>--disable-skill</string>
+        <string>spiceflow</string>
+        <string>--disable-skill</string>
+        <string>termcast</string>
+        <string>--disable-skill</string>
+        <string>tuistory</string>
+        <string>--disable-skill</string>
+        <string>usecomputer</string>
+        <string>--disable-skill</string>
+        <string>x-articles</string>
+        <string>--disable-skill</string>
+        <string>zele</string>
+        <string>--disable-skill</string>
+        <string>zustand-centralized-state</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/__snapshots__/bridges/kimaki-systemd
+++ b/tests/__snapshots__/bridges/kimaki-systemd
@@ -22,7 +22,7 @@ Environment=DATAMACHINE_SITE_PATH=/var/www/site
 # tolerate exit code 1 (no matches found, the happy path on a clean box).
 ExecStartPre=-/usr/bin/pkill -TERM -u chubes -f "opencode-ai/bin/.*serve"
 ExecStartPre=/opt/kimaki-config/post-upgrade.sh
-ExecStart=/usr/bin/kimaki --data-dir /home/chubes/.kimaki --auto-restart --no-critique
+ExecStart=/usr/bin/kimaki --data-dir /home/chubes/.kimaki --auto-restart --no-critique --disable-skill batch --disable-skill egaki --disable-skill errore --disable-skill event-sourcing-state --disable-skill gitchamber --disable-skill goke --disable-skill jitter --disable-skill lintcn --disable-skill npm-package --disable-skill playwriter --disable-skill proxyman --disable-skill spiceflow --disable-skill termcast --disable-skill tuistory --disable-skill usecomputer --disable-skill x-articles --disable-skill zele --disable-skill zustand-centralized-state
 Restart=always
 RestartSec=10
 

--- a/tests/post-upgrade-restore.sh
+++ b/tests/post-upgrade-restore.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # tests/post-upgrade-restore.sh — smoke test for bridges/kimaki/post-upgrade.sh
 #
-# Verifies the three passes (kill, restore skills, verify plugins) using
+# Verifies the restore and verify passes using
 # temp-dir env overrides so the test never touches the real npm install or
 # user config.
 #
 # What we cover:
-#   1. Kill pass removes a blacklisted skill from the simulated skills dir.
+#   1. Bundled Kimaki skills are left untouched; filtering happens at startup.
 #   2. Skill restore pass copies wp-coding-agents SKILL.md trees from the
 #      persistent source back into the (wiped) skills dir.
 #   3. Default plugin pass is a no-op because opencode loads the persistent
@@ -49,11 +49,11 @@ mkdir -p "$LIVE_SKILLS" "$SRC_SKILLS" "$SRC_PLUGINS"
 # Note: deliberately NOT creating LIVE_PLUGINS — explicit override mode must
 # still mkdir it.
 
-# Seed a blacklisted skill that the kill pass should remove.
+# Seed bundled skills that post-upgrade must not remove. Managed Kimaki service
+# startup now filters these with --disable-skill instead of mutating package
+# directories.
 mkdir -p "$LIVE_SKILLS/blacklisted-skill"
 echo "stub" > "$LIVE_SKILLS/blacklisted-skill/SKILL.md"
-mkdir -p "$LIVE_SKILLS/persisted-blacklisted-skill"
-echo "stub" > "$LIVE_SKILLS/persisted-blacklisted-skill/SKILL.md"
 
 # Seed a wp-coding-agents skill in the persistent source that should be restored.
 mkdir -p "$SRC_SKILLS/upgrade-wp-coding-agents"
@@ -74,15 +74,6 @@ description: unmanaged fixture
 body
 EOF
 
-mkdir -p "$SRC_SKILLS/persisted-blacklisted-skill"
-cat > "$SRC_SKILLS/persisted-blacklisted-skill/SKILL.md" <<'EOF'
----
-name: persisted-blacklisted-skill
-description: persisted but killed test fixture
----
-body
-EOF
-
 # Seed two required plugins in the persistent source. Default mode verifies them
 # in place; explicit override mode restores them into the requested target.
 cat > "$SRC_PLUGINS/dm-context-filter.ts" <<'EOF'
@@ -94,17 +85,10 @@ cat > "$SRC_PLUGINS/dm-agent-sync.ts" <<'EOF'
 export default async () => ({})
 EOF
 
-# Build a temp skills-kill-list.txt next to a copied post-upgrade.sh so the
-# script's `dirname "$0"` lookup finds it.
 TEST_SCRIPT_DIR="$TMP/kimaki-config-dir"
 mkdir -p "$TEST_SCRIPT_DIR"
 cp "$POST_UPGRADE" "$TEST_SCRIPT_DIR/post-upgrade.sh"
 chmod +x "$TEST_SCRIPT_DIR/post-upgrade.sh"
-cat > "$TEST_SCRIPT_DIR/skills-kill-list.txt" <<'EOF'
-# test kill list
-blacklisted-skill
-persisted-blacklisted-skill
-EOF
 
 # Run the script with explicit env overrides so it never touches the real
 # npm install or user config.
@@ -147,12 +131,8 @@ assert_log_contains_file() {
   fi
 }
 
-# Pass 1: kill pass removed the blacklisted skill.
-assert_missing "$LIVE_SKILLS/blacklisted-skill"
-assert_log_contains "removed skill blacklisted-skill"
-assert_missing "$LIVE_SKILLS/persisted-blacklisted-skill"
-assert_log_contains "removed skill persisted-blacklisted-skill"
-assert_log_contains "skipped killed skill persisted-blacklisted-skill"
+# Pass 1: bundled Kimaki skills are not removed by post-upgrade.
+assert_present "$LIVE_SKILLS/blacklisted-skill/SKILL.md"
 
 # Pass 2: skill restore copied the allowed SKILL.md tree and skipped unmanaged skills.
 assert_present "$LIVE_SKILLS/upgrade-wp-coding-agents/SKILL.md"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -9,10 +9,9 @@
 #   2. Update setup-installed Data Machine plugins to latest tagged releases.
 #   3. Sync chat-bridge config (dispatches per bridge)
 #        kimaki:
-#          VPS:   /opt/kimaki-config (plugins + post-upgrade.sh + kill list)
+#          VPS:   /opt/kimaki-config (plugins + post-upgrade.sh + skill filters)
 #          Local: $KIMAKI_DATA_DIR/kimaki-config/ for plugins,
-#                 post-upgrade.sh + kill
-#                 list, and runs post-upgrade.sh inline (no launchd
+#                 post-upgrade.sh + skill filters, and runs post-upgrade.sh inline (no launchd
 #                 ExecStartPre hook).
 #        cc-connect: no per-install artifacts; reports binary version and
 #          reminds user to `npm update -g cc-connect`.
@@ -328,7 +327,7 @@ update_data_machine_plugins() {
 
 # ============================================================================
 # Phase 3: Sync chat-bridge config
-#   kimaki    → plugins + post-upgrade.sh + skills-kill-list (see below).
+#   kimaki    → plugins + post-upgrade.sh + skills-disable-list (see below).
 #   cc-connect → no per-install artifacts beyond the npm package; config.toml
 #                is user-owned. Report version and remind user to
 #                `npm update -g cc-connect` for upstream updates.


### PR DESCRIPTION
## Summary
- replace Kimaki bundled-skill deletion with native `--disable-skill` startup filters
- keep post-upgrade focused on restoring wp-coding-agents skills and validating persistent plugins
- update Kimaki service snapshots, docs, and post-upgrade regression coverage

Closes #146.

## Verification
- `tests/post-upgrade-restore.sh`
- `tests/bridge-render.sh`
- `tests/path-helpers.sh`
- `for f in **/*.sh(.); do bash -n "$f" || exit 1; done`
- `tests/datamachine-kimaki-adapter.sh`
- `tests/opencode-wrapper-removal.sh`
- `tests/kimaki-session-helper-smoke.sh`
- `bash tests/repair-opencode-json.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shell/docs/test changes and ran local verification; Chris remains responsible for review and merge.