### PR TITLE
Refresh dm-context-filter for Kimaki 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Local installs run as your current user — no root, no service user, no chown.
 The default chat bridge for OpenCode. On VPS, wp-coding-agents installs post-upgrade hooks that:
 
 - **Remove unwanted bundled skills** — Kimaki ships with skills for frameworks and tools that aren't relevant to WordPress agent workflows. The kill list (`bridges/kimaki/skills-kill-list.txt`) controls which skills are removed after each upgrade.
-- **Filter redundant context** — A plugin strips Kimaki's built-in memory injection and scheduling instructions from the agent context, since DM handles those concerns. Saves ~2,400 tokens per session.
+- **Filter conflicting context** — A plugin strips Kimaki memory injection, scheduling guidance, site-runtime guidance, cross-project session discovery, and generic agent override examples where they conflict with Data Machine policy. Managed Kimaki services also start with `--no-critique`, so Kimaki omits critique instructions upstream.
 
 To customize the kill list, edit `bridges/kimaki/skills-kill-list.txt` before running setup, or edit `/opt/kimaki-config/skills-kill-list.txt` on the server after install.
 

--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -1,30 +1,32 @@
 // dm-context-filter.ts — OpenCode plugin for WordPress agent VPSes with Data Machine.
 //
-// Strips Kimaki built-in features from the agent context when Data Machine
-// manages memory, scheduling, and other concerns.
+// Strips Kimaki built-in features from the agent context only where they
+// conflict with Data Machine-owned policy.
 //
 // What it removes from the system prompt:
-// 1. Scheduling — ~500 tokens of --send-at, cron, task management instructions.
-// 2. Tunnel / dev server — ~500 tokens about kimaki tunnel and tmux. DM-managed
+// 1. Scheduling — Kimaki task scheduling competes with Data Machine flows,
+//    jobs, and pending-action approvals.
+// 2. Tunnel / dev server — Kimaki defaults every dev server through a public
+//    tunnel. Data Machine-managed
 //    WordPress installs already have a site runtime (Studio locally, a live
 //    site on VPS). Tunnels are task-specific for inbound public URLs like
 //    webhooks/OAuth callbacks, not the default way to interact with the site.
-// 3. Critique — ~900 tokens of diff-sharing instructions. We use GitHub PRs.
-// 4. Waiting for sessions — ~150 tokens. Rarely used, discoverable via --help.
-// 5. Session/workspace conflicts — generic Kimaki agent override examples can
+// 3. Session/workspace conflicts — generic Kimaki agent override examples can
 //    bypass the Data Machine-bound default agent slot.
-// 8. Permissions — ~80 tokens describing which Discord roles can message the
-//    bot. The agent has no capability to act on this; pure metadata leakage.
-// 9. Upgrading kimaki — ~80 tokens of /upgrade-and-restart playbook. The user
-//    runs the slash command themselves when they want to upgrade.
-// 10. Reading other sessions — ~250 tokens documenting `kimaki session list
+// 4. Reading other sessions — documents `kimaki session list
 //    --project` / `session search --channel <id>`. These are cross-project
 //    discovery vectors; on a single-project fleet server the agent only ever
 //    needs to list sessions in the current project (no flags required).
-// 11. Agent override inlines — `--agent <current_agent>` examples from the
+// 5. Agent override inlines — `--agent <current_agent>` examples from the
 //    generic Kimaki prompt. On DM-managed sites the Discord channel owns the
 //    personal-agent binding; passing the runtime agent (for example `opencode`)
 //    bypasses that binding and starts the wrong kind of minion session.
+//
+// What it intentionally does not strip anymore:
+// - Critique instructions. Managed Kimaki services start with `--no-critique`,
+//   so Kimaki omits those instructions upstream.
+// - Generic permissions / upgrade / wait-session help. They no longer conflict
+//   with Data Machine memory or site policy.
 //
 // This plugin is strip-only. Positive guidance about how to use Kimaki's
 // session bridge or the WordPress site runtime belongs in Data Machine's
@@ -37,10 +39,9 @@
 // throws errors, the agent needs the kimaki.log path to investigate.
 //
 // What it removes from chat message injection:
-// 8. MEMORY.md injection — Kimaki reads MEMORY.md from the project directory and
+// 1. MEMORY.md injection — Kimaki reads MEMORY.md from the project directory and
 //    injects a condensed TOC. Conflicts with Data Machine's own memory files.
-// 9. "Update MEMORY.md" time-gap reminder — Redundant with external memory system.
-// Total savings: ~2,400+ tokens per session.
+// 2. "Update MEMORY.md" time-gap reminder — Redundant with external memory system.
 //
 // How to use:
 //   Add to opencode.json:  "plugin": ["/opt/kimaki-config/plugins/dm-context-filter.ts"]
@@ -57,20 +58,11 @@ const fleetContextFilter: Plugin = async () => {
     "experimental.chat.system.transform": async (_input, output) => {
       output.system = output.system.map((block) => {
         let result = block;
-        result = stripSection(result, "## permissions");
-        result = stripSection(result, "## upgrading kimaki");
         result = stripSection(result, "## scheduled sends and task management");
         result = stripSection(result, "## running dev servers with tunnel access");
-        result = stripSection(result, "## worktree");
         result = stripSection(result, "## reading other sessions");
-        result = stripSection(result, "## waiting for a session to finish");
         result = stripSection(result, "## running opencode commands via kimaki send");
         result = stripSection(result, "## switching agents in the current session");
-        result = stripSection(result, "## showing diffs");
-        result = stripSection(result, "## about critique");
-        result = stripSection(result, "### always show diff at end of session");
-        result = stripSection(result, "### fetching user comments from critique diffs");
-        result = stripSection(result, "### reviewing diffs with AI");
         result = stripAgentOverrideInlines(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");

--- a/tests/effective-prompt/README.md
+++ b/tests/effective-prompt/README.md
@@ -3,15 +3,20 @@
 Pluggable harness that renders the kimaki opencode system prompt, runs the
 `dm-context-filter` plugin over it, snapshots the result, and asserts that
 no banned `--agent` override examples leak into the filtered prompt that an
-opencode session actually sees.
+opencode session actually sees. The harness also exercises the plugin's
+`chat.message` filter so Kimaki `MEMORY.md` injection stays suppressed.
 
 ## Why
 
-`dm-context-filter.ts` is a security-and-context plugin. It strips ~5,000
-tokens of kimaki-shipped instructions that conflict with Data Machine's
-memory and channel-bound agent model. When the filter has a bug,
-the leaked content is invisible until you go reading the system prompt by
+`dm-context-filter.ts` is a security-and-context plugin. It strips only the
+kimaki-shipped instructions that conflict with Data Machine's memory,
+scheduling, site-runtime, and channel-bound agent model. When the filter has a
+bug, the leaked content is invisible until you go reading the system prompt by
 hand. This harness catches those leaks at test time.
+
+wp-coding-agents starts managed Kimaki services with `--no-critique`, so the
+harness disables critique in Kimaki's store before rendering snapshots. Set
+`KIMAKI_EFFECTIVE_PROMPT_CRITIQUE=1` to inspect the upstream critique prompt.
 
 ## Run it
 
@@ -69,6 +74,9 @@ baseline filter:
 3. **Snapshot match**: the rendered raw / baseline / filtered prompts
    match the committed snapshots. Run with `--update` after an
    intentional change.
+4. **Memory injection filter**: synthetic Kimaki `MEMORY.md` context and
+   stale-memory reminders are removed while unrelated synthetic/user text is
+   preserved.
 
 ## Files
 

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -15,6 +15,25 @@ Your current Discord guild ID is: 1493321868415996064
 
 Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
 
+## permissions
+
+Only users with these Discord permissions can send messages to the bot:
+- Server Owner
+- Administrator permission
+- Manage Server permission
+- "Kimaki" role (case-insensitive)
+
+Other Discord bots are ignored by default. To allow another bot to trigger sessions (for multi-agent orchestration), assign it the "Kimaki" role.
+
+## upgrading kimaki
+
+Use built-in upgrade commands when the user explicitly asks to update kimaki:
+- Discord slash command: "/upgrade-and-restart" upgrades to the latest version and restarts the bot
+- CLI command: `kimaki upgrade` upgrades and restarts the bot (or starts a fresh process if needed)
+- CLI command: `kimaki upgrade --skip-restart` upgrades without restarting
+
+Do not restart the bot unless the user explicitly asks for it.
+
 ## debugging kimaki issues
 
 If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
@@ -24,6 +43,22 @@ If there are internal kimaki issues (sessions not responding, bot errors, unexpe
 To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
 
 ## requesting files from the user
 
@@ -48,28 +83,161 @@ kimaki user list --guild 1493321868415996064 --query "username"
 
 This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
 
+## starting new sessions from CLI
+
+To start a new thread/session in this channel pro-grammatically, run:
+
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --user '<discord-user-id>'
+
+You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
+
+Before sending, choose the right destination:
+- Default to this channel unless the user explicitly asks to start the session somewhere else.
+- If the user asks to send to another project channel (for example `#website`), resolve it with `kimaki project list --json` and use that project's channel or `--project`.
+- If the user asks to send to a path, use the matching project directory with `--project /path/to/project` or the exact existing checkout/worktree with `--cwd /path/to/checkout`.
+- NEVER use `--worktree` unless the user explicitly asks for a worktree. Default to creating normal threads without worktrees.
+
+To send a prompt to an existing thread instead of creating a new one:
+
+kimaki send --thread <thread_id> --prompt 'follow-up prompt'
+
+Use this when you already have the Discord thread ID.
+
+To send to the thread associated with a known session:
+
+kimaki send --session <session_id> --prompt 'follow-up prompt'
+
+Use this when you have the OpenCode session ID.
+
+Use --notify-only to create a notification thread without starting an AI session:
+
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --user '<discord-user-id>'
+
+Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
+
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --user '<discord-user-id>'
+
+Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
+
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --user '<discord-user-id>'
+
+Use --cwd to start a session in an existing project subfolder or git worktree directory:
+
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+
+Important:
+- NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
+- Use `--cwd` to reuse an existing project subfolder or worktree directory. Use `--worktree` to create a new worktree.
+- The prompt passed to `--worktree` is the task for the new thread running inside that worktree.
+- Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
+- Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
+
+Available agents:
+- `build`: default coding agent
+- `plan`: planning agent
+
+## creating worktrees
+
+ONLY create worktrees when the user explicitly asks for one. Never proactively use `--worktree` for normal tasks.
+
+When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --user '<discord-user-id>'
+```
+
+This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
+
+By default, worktrees are created from `HEAD`, which means whatever commit or branch the current checkout is on. If you want a different base, pass `--base-branch` or use the slash command option explicitly.
+
+Critical recursion guard:
+- If you already are in a worktree thread, do not create another worktree unless the user explicitly asks for a nested worktree.
+- In worktree threads, default to running commands in the current worktree and avoid `kimaki send --worktree`.
+
+### Sending sessions to existing directories
+
+Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+```
+
+The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
+
+**Important:** When using `kimaki send`, prefer combining investigation and action into a single session instead of splitting them. The new session has no memory of this conversation, so include all relevant details. Use **bold**, `code`, lists, and > quotes for readability.
+
+This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
+
+### Session handoff
+
+When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --user '<discord-user-id>'
+```
+
+The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
+
+Use this for handoff when:
+- User asks to "handoff", "continue in new thread", or "start fresh session"
+- You detect you're running low on context window space
+- A complex task would benefit from a clean slate with summarized context
+
+## cross-project commands
+
+When the user references another project by name, run `kimaki project list` to find its directory path and channel ID. Then read files, search code, or run commands directly in that directory. If the project is not listed, use `kimaki project add /path/to/repo` to register it and create a Discord channel for it. Do not add subfolders of an existing project — only add root project directories.
+
+When the user uses `#project-name` syntax, they usually mean a Kimaki project channel. Use `kimaki project list --json` to resolve the `channel_name` to its repo working directory. Try the lookup yourself before acting, for example filter by `channel_name` with jq: `kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'`.
+
+```bash
 # List all registered projects with their channel IDs
+kimaki project list
 kimaki project list --json  # machine-readable output
+kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'
 
 # Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
+kimaki project create my-new-app
 
 # Add an existing directory as a project
+kimaki project add /path/to/repo
 ```
+
+To send a task to another project:
 
 ```bash
 # Send to a specific channel
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2'
 
 # Or use --project to resolve from directory
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0'
 
 # Or use --cwd for an existing checkout/worktree path
 kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
 ```
 
+When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
+
 Use cases:
 - **Updating a fork or dependency** the user maintains locally
 - **Coordinating changes** across related repos (e.g., SDK + docs)
+- **Delegating subtasks** to isolated sessions in other projects
 
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
 # Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait
 
 # Send to an existing thread and wait
 kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
@@ -81,63 +249,13 @@ kimaki session wait <session_id>
 The command exits with the session markdown on stdout once the model finishes responding.
 
 Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
 - **Run a task in a separate worktree** and use the result in your current session
 - **Chain sessions sequentially** where the next depends on the previous output
 
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 # Start the dev server in a named background session
 bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
@@ -306,21 +424,3 @@ Examples:
 <channel-topic>
 intelligence-chubes4 personal agent
 </channel-topic>
-
-## WordPress Site Runtime
-
-This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
-
-On local WordPress Studio installs, use Studio and `studio wp` against the existing site. On VPS installs, use the live WordPress site and `wp` in the configured site path.
-
-Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
-
-## Data Machine Session Handoff
-
-For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
-
-Typical flow:
-
-1. Create the checkout with `studio wp datamachine-code workspace worktree add <repo> <branch>`.
-2. Start the helper session with `datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'`.
-3. Use the helper thread for the isolated task and bring the result back here.

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -15,6 +15,25 @@ Your current Discord guild ID is: 1493321868415996064
 
 Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
 
+## permissions
+
+Only users with these Discord permissions can send messages to the bot:
+- Server Owner
+- Administrator permission
+- Manage Server permission
+- "Kimaki" role (case-insensitive)
+
+Other Discord bots are ignored by default. To allow another bot to trigger sessions (for multi-agent orchestration), assign it the "Kimaki" role.
+
+## upgrading kimaki
+
+Use built-in upgrade commands when the user explicitly asks to update kimaki:
+- Discord slash command: "/upgrade-and-restart" upgrades to the latest version and restarts the bot
+- CLI command: `kimaki upgrade` upgrades and restarts the bot (or starts a fresh process if needed)
+- CLI command: `kimaki upgrade --skip-restart` upgrades without restarting
+
+Do not restart the bot unless the user explicitly asks for it.
+
 ## debugging kimaki issues
 
 If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
@@ -24,6 +43,22 @@ If there are internal kimaki issues (sessions not responding, bot errors, unexpe
 To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
 
 ## requesting files from the user
 
@@ -188,48 +223,39 @@ Use cases:
 - **Coordinating changes** across related repos (e.g., SDK + docs)
 - **Delegating subtasks** to isolated sessions in other projects
 
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
+# Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
 
 ## markdown formatting
 

--- a/tests/effective-prompt/__snapshots__/default.raw.txt
+++ b/tests/effective-prompt/__snapshots__/default.raw.txt
@@ -44,6 +44,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -348,117 +364,6 @@ Use `--wait` when you need to:
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
 
-
-## showing diffs
-
-IMPORTANT: After editing any files, you MUST execute the critique command using the Bash tool to get a diff URL, then share that URL with the user.
-IMPORTANT: The user cannot see tool results directly. If critique prints a URL in the Bash tool output, you MUST copy that URL into your final message yourself.
-IMPORTANT: When the user asks to see a diff, show a diff, or review changes, ALWAYS use critique to generate a web URL instead of showing raw git diff output.
-
-Typical usage examples:
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### always show diff at end of session
-
-If you edited any files during the current session, you MUST run `bunx critique --web` at the end of your final message to generate a diff URL and share it with the user. This applies even if the user did not ask to see a diff — always show what changed. Pass the file paths you edited as `--filter` arguments so the diff only includes your changes. Skip this only if the session was purely read-only (no file edits, no writes).
-The final user-facing message must include the actual critique URL as plain text or markdown link, because the user cannot see the Bash tool output.
-
-Example — if you edited `src/config.ts` and `src/utils.ts`:
-
-```bash
-bunx critique --web "Short title describing the changes" --filter "src/config.ts" --filter "src/utils.ts"
-```
-
-The string after `--web` becomes the diff page title — make it reflect what the changes do (e.g. "Add retry logic to API client", "Fix auth timeout bug").
-
-### fetching user comments from critique diffs
-
-Users can add line-level comments (annotations) on any critique diff page via the Agentation widget (bottom-right corner of the diff page). To read those comments:
-
-```bash
-curl https://critique.work/v/<id>/annotations
-```
-
-Returns `text/markdown` with each annotation showing the file, line, and comment text.
-Use this when the user says they left comments on a critique diff and you need to read them.
-You can also use WebFetch on `https://critique.work/v/<id>/annotations` to get the markdown directly.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
-
-### reviewing diffs with AI
-
-`bunx critique review --web` generates an AI-powered review of a diff and uploads it as a shareable URL.
-It spawns a separate opencode session that analyzes the diff, groups related changes, and produces
-a structured review with explanations, diagrams, and suggestions. This is useful when the user
-asks you to explain or review a diff — the output is much richer than a plain diff URL.
-
-**WARNING: This command is very slow (up to 20 minutes for large diffs).** Only run it when the
-user explicitly asks for a code review or diff explanation. Always warn the user it will take
-a while before running it. Set Bash tool timeout to at least 25 minutes (`timeout: 1_500_000`).
-
-Always pass `--agent opencode` and `--session ses_EFFECTIVE_PROMPT_TEST` so the reviewer has context about
-why the changes were made. If you know other session IDs that produced the diff (e.g. from
-`kimaki session list` or from the thread history), pass them too with additional `--session` flags.
-
-Examples:
-
-```bash
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 
 ## running dev servers with tunnel access

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -13,6 +13,25 @@ Your current Discord channel ID is: 1493345787894038649
 
 Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
 
+## permissions
+
+Only users with these Discord permissions can send messages to the bot:
+- Server Owner
+- Administrator permission
+- Manage Server permission
+- "Kimaki" role (case-insensitive)
+
+Other Discord bots are ignored by default. To allow another bot to trigger sessions (for multi-agent orchestration), assign it the "Kimaki" role.
+
+## upgrading kimaki
+
+Use built-in upgrade commands when the user explicitly asks to update kimaki:
+- Discord slash command: "/upgrade-and-restart" upgrades to the latest version and restarts the bot
+- CLI command: `kimaki upgrade` upgrades and restarts the bot (or starts a fresh process if needed)
+- CLI command: `kimaki upgrade --skip-restart` upgrades without restarting
+
+Do not restart the bot unless the user explicitly asks for it.
+
 ## debugging kimaki issues
 
 If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
@@ -22,6 +41,22 @@ If there are internal kimaki issues (sessions not responding, bot errors, unexpe
 To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
 
 ## requesting files from the user
 
@@ -46,28 +81,157 @@ kimaki user list --guild <guildId> --query "username"
 
 This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
 
+## starting new sessions from CLI
+
+To start a new thread/session in this channel pro-grammatically, run:
+
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --user '<discord-user-id>'
+
+You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
+
+Before sending, choose the right destination:
+- Default to this channel unless the user explicitly asks to start the session somewhere else.
+- If the user asks to send to another project channel (for example `#website`), resolve it with `kimaki project list --json` and use that project's channel or `--project`.
+- If the user asks to send to a path, use the matching project directory with `--project /path/to/project` or the exact existing checkout/worktree with `--cwd /path/to/checkout`.
+- NEVER use `--worktree` unless the user explicitly asks for a worktree. Default to creating normal threads without worktrees.
+
+To send a prompt to an existing thread instead of creating a new one:
+
+kimaki send --thread <thread_id> --prompt 'follow-up prompt'
+
+Use this when you already have the Discord thread ID.
+
+To send to the thread associated with a known session:
+
+kimaki send --session <session_id> --prompt 'follow-up prompt'
+
+Use this when you have the OpenCode session ID.
+
+Use --notify-only to create a notification thread without starting an AI session:
+
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --user '<discord-user-id>'
+
+Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
+
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --user '<discord-user-id>'
+
+Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
+
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --user '<discord-user-id>'
+
+Use --cwd to start a session in an existing project subfolder or git worktree directory:
+
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+
+Important:
+- NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
+- Use `--cwd` to reuse an existing project subfolder or worktree directory. Use `--worktree` to create a new worktree.
+- The prompt passed to `--worktree` is the task for the new thread running inside that worktree.
+- Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
+- Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
+
+## creating worktrees
+
+ONLY create worktrees when the user explicitly asks for one. Never proactively use `--worktree` for normal tasks.
+
+When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --user '<discord-user-id>'
+```
+
+This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
+
+By default, worktrees are created from `HEAD`, which means whatever commit or branch the current checkout is on. If you want a different base, pass `--base-branch` or use the slash command option explicitly.
+
+Critical recursion guard:
+- If you already are in a worktree thread, do not create another worktree unless the user explicitly asks for a nested worktree.
+- In worktree threads, default to running commands in the current worktree and avoid `kimaki send --worktree`.
+
+### Sending sessions to existing directories
+
+Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+```
+
+The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
+
+**Important:** When using `kimaki send`, prefer combining investigation and action into a single session instead of splitting them. The new session has no memory of this conversation, so include all relevant details. Use **bold**, `code`, lists, and > quotes for readability.
+
+This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
+
+### Session handoff
+
+When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --user '<discord-user-id>'
+```
+
+The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
+
+Use this for handoff when:
+- User asks to "handoff", "continue in new thread", or "start fresh session"
+- You detect you're running low on context window space
+- A complex task would benefit from a clean slate with summarized context
+
+## cross-project commands
+
+When the user references another project by name, run `kimaki project list` to find its directory path and channel ID. Then read files, search code, or run commands directly in that directory. If the project is not listed, use `kimaki project add /path/to/repo` to register it and create a Discord channel for it. Do not add subfolders of an existing project — only add root project directories.
+
+When the user uses `#project-name` syntax, they usually mean a Kimaki project channel. Use `kimaki project list --json` to resolve the `channel_name` to its repo working directory. Try the lookup yourself before acting, for example filter by `channel_name` with jq: `kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'`.
+
+```bash
 # List all registered projects with their channel IDs
+kimaki project list
 kimaki project list --json  # machine-readable output
+kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .directory'
 
 # Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
+kimaki project create my-new-app
 
 # Add an existing directory as a project
+kimaki project add /path/to/repo
 ```
+
+To send a task to another project:
 
 ```bash
 # Send to a specific channel
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2'
 
 # Or use --project to resolve from directory
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0'
 
 # Or use --cwd for an existing checkout/worktree path
 kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
 ```
 
+When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
+
 Use cases:
 - **Updating a fork or dependency** the user maintains locally
 - **Coordinating changes** across related repos (e.g., SDK + docs)
+- **Delegating subtasks** to isolated sessions in other projects
 
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
 # Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait
 
 # Send to an existing thread and wait
 kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
@@ -79,63 +243,13 @@ kimaki session wait <session_id>
 The command exits with the session markdown on stdout once the model finishes responding.
 
 Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
 - **Run a task in a separate worktree** and use the result in your current session
 - **Chain sessions sequentially** where the next depends on the previous output
 
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_MINIMAL
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_MINIMAL
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_MINIMAL --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_MINIMAL --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 # Start the dev server in a named background session
 bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
@@ -301,20 +415,3 @@ Examples:
 - If a plan has multiple strategy of implementation show these as options
 - After a genuinely ambiguous request where you cannot infer intent: offer the different approaches
 
-## WordPress Site Runtime
-
-This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
-
-On local WordPress Studio installs, use Studio and `studio wp` against the existing site. On VPS installs, use the live WordPress site and `wp` in the configured site path.
-
-Use `kimaki tunnel` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
-
-## Data Machine Session Handoff
-
-For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
-
-Typical flow:
-
-1. Create the checkout with `studio wp datamachine-code workspace worktree add <repo> <branch>`.
-2. Start the helper session with `datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'`.
-3. Use the helper thread for the isolated task and bring the result back here.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -13,6 +13,25 @@ Your current Discord channel ID is: 1493345787894038649
 
 Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
 
+## permissions
+
+Only users with these Discord permissions can send messages to the bot:
+- Server Owner
+- Administrator permission
+- Manage Server permission
+- "Kimaki" role (case-insensitive)
+
+Other Discord bots are ignored by default. To allow another bot to trigger sessions (for multi-agent orchestration), assign it the "Kimaki" role.
+
+## upgrading kimaki
+
+Use built-in upgrade commands when the user explicitly asks to update kimaki:
+- Discord slash command: "/upgrade-and-restart" upgrades to the latest version and restarts the bot
+- CLI command: `kimaki upgrade` upgrades and restarts the bot (or starts a fresh process if needed)
+- CLI command: `kimaki upgrade --skip-restart` upgrades without restarting
+
+Do not restart the bot unless the user explicitly asks for it.
+
 ## debugging kimaki issues
 
 If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
@@ -22,6 +41,22 @@ If there are internal kimaki issues (sessions not responding, bot errors, unexpe
 To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
 
 ## requesting files from the user
 
@@ -182,48 +217,39 @@ Use cases:
 - **Coordinating changes** across related repos (e.g., SDK + docs)
 - **Delegating subtasks** to isolated sessions in other projects
 
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
+# Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
 
 ## markdown formatting
 

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
@@ -42,6 +42,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -342,117 +358,6 @@ Use `--wait` when you need to:
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
 
-
-## showing diffs
-
-IMPORTANT: After editing any files, you MUST execute the critique command using the Bash tool to get a diff URL, then share that URL with the user.
-IMPORTANT: The user cannot see tool results directly. If critique prints a URL in the Bash tool output, you MUST copy that URL into your final message yourself.
-IMPORTANT: When the user asks to see a diff, show a diff, or review changes, ALWAYS use critique to generate a web URL instead of showing raw git diff output.
-
-Typical usage examples:
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### always show diff at end of session
-
-If you edited any files during the current session, you MUST run `bunx critique --web` at the end of your final message to generate a diff URL and share it with the user. This applies even if the user did not ask to see a diff — always show what changed. Pass the file paths you edited as `--filter` arguments so the diff only includes your changes. Skip this only if the session was purely read-only (no file edits, no writes).
-The final user-facing message must include the actual critique URL as plain text or markdown link, because the user cannot see the Bash tool output.
-
-Example — if you edited `src/config.ts` and `src/utils.ts`:
-
-```bash
-bunx critique --web "Short title describing the changes" --filter "src/config.ts" --filter "src/utils.ts"
-```
-
-The string after `--web` becomes the diff page title — make it reflect what the changes do (e.g. "Add retry logic to API client", "Fix auth timeout bug").
-
-### fetching user comments from critique diffs
-
-Users can add line-level comments (annotations) on any critique diff page via the Agentation widget (bottom-right corner of the diff page). To read those comments:
-
-```bash
-curl https://critique.work/v/<id>/annotations
-```
-
-Returns `text/markdown` with each annotation showing the file, line, and comment text.
-Use this when the user says they left comments on a critique diff and you need to read them.
-You can also use WebFetch on `https://critique.work/v/<id>/annotations` to get the markdown directly.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
-
-### reviewing diffs with AI
-
-`bunx critique review --web` generates an AI-powered review of a diff and uploads it as a shareable URL.
-It spawns a separate opencode session that analyzes the diff, groups related changes, and produces
-a structured review with explanations, diagrams, and suggestions. This is useful when the user
-asks you to explain or review a diff — the output is much richer than a plain diff URL.
-
-**WARNING: This command is very slow (up to 20 minutes for large diffs).** Only run it when the
-user explicitly asks for a code review or diff explanation. Always warn the user it will take
-a while before running it. Set Bash tool timeout to at least 25 minutes (`timeout: 1_500_000`).
-
-Always pass `--agent opencode` and `--session ses_MINIMAL` so the reviewer has context about
-why the changes were made. If you know other session IDs that produced the diff (e.g. from
-`kimaki session list` or from the thread history), pass them too with additional `--session` flags.
-
-Examples:
-
-```bash
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_MINIMAL
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_MINIMAL
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_MINIMAL --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_MINIMAL --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 
 ## running dev servers with tunnel access

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -46,67 +46,12 @@ function stripSection(block, heading) {
   return [...lines.slice(0, start), ...lines.slice(end)].join("\n")
 }
 
-function stripWorktreeInlines(block) {
-  let result = block
-  result = result.replace(/\n+Worktrees are useful for handing off parallel tasks[^\n]*\n/g, "\n")
-  result = result.replace(/\n+IMPORTANT: NEVER use `--worktree`[^\n]*\n/g, "\n")
-  result = result.replace(/\n+Use --worktree to create a git worktree[\s\S]*?--worktree [^\n]*\n/g, "\n")
-  result = result.replace(/\n+Use --cwd to start a session in an existing git worktree[\s\S]*?--cwd [^\n]*\n/g, "\n")
-  result = result.replace(/\n+Important:\n(?:- [^\n]*\n)*?- NEVER use `--worktree`[^\n]*\n(?:- [^\n]*\n)*/g, "\n")
-  return result
-}
-
-function stripProjectDiscoveryInlines(block) {
-  let result = block
-  result = result.replace(/\n+When the user references another project by name,[\s\S]*?root project directories\.\n/g, "\n")
-  result = result.replace(/\n+When the user uses `#project-name` syntax,[\s\S]*?before acting,[^\n]*\n/g, "\n")
-  result = result.replace(/\n+To send a task to another project:[\s\S]*?(?=\n\S|$)/g, "\n")
-  result = result.replace(/\n+When sending prompts to other projects,[^\n]*\n/g, "\n")
-  result = result.replace(/\n+kimaki project (?:list|add|create)[^\n]*\n/g, "\n")
-  result = result.replace(/\n+kimaki send --project [^\n]*\n/g, "\n")
-  result = result.replace(/\n+kimaki send --channel <channel_id>[^\n]*\n/g, "\n")
-  result = result.replace(/\n+kimaki session search [^\n]*--channel <channel_id>[^\n]*\n/g, "\n")
-  result = result.replace(/\n+kimaki (?:session|task) [^\n]*--project [^\n]*\n/g, "\n")
-  result = result.replace(/\n+[^\n]*(?:project channel|cross-project|#project-name|other project|another project)[^\n]*\n/gi, "\n")
-  return result
-}
-
 function stripAgentOverrideInlines(block) {
   let result = block
   result = result.replace(/\n+Prefer passing the current agent with `--agent <current_agent>`[^\n]*\n/g, "\n")
   result = result.replace(/\n+Use --agent to specify which agent to use for the session:[\s\S]*?\nkimaki send --channel [^\n]* --agent [^\n]*\n/g, "\n")
   result = result.replace(/ --agent <current_agent>/g, "")
   return result
-}
-
-function appendDataMachineSessionHandoffInstruction(block) {
-  const instruction = `
-
-## Data Machine Session Handoff
-
-For parallel repo work, create or reuse a Data Machine Code workspace checkout, then launch the helper session through the Kimaki bridge helper. Data Machine Code owns repo/workspace setup; Kimaki carries the Discord session.
-
-Typical flow:
-
-1. Create the checkout with \`studio wp datamachine-code workspace worktree add <repo> <branch>\`.
-2. Start the helper session with \`datamachine-kimaki-session --channel <current_channel> --cwd <workspace_path> --prompt '<task>'\`.
-3. Use the helper thread for the isolated task and bring the result back here.
-`
-  return block.replace(/\s*$/, "") + instruction
-}
-
-function appendWordPressSiteRuntimeInstruction(block) {
-  const instruction = `
-
-## WordPress Site Runtime
-
-This is a Data Machine-managed WordPress agent install. Use the existing WordPress site runtime by default — do not start a separate dev server just to work on the site.
-
-On local WordPress Studio installs, use Studio and \`studio wp\` against the existing site. On VPS installs, use the live WordPress site and \`wp\` in the configured site path.
-
-Use \`kimaki tunnel\` only when the task specifically needs an inbound public URL, such as GitHub webhooks, OAuth callbacks, or an explicit browser preview for someone who cannot access the local/VPS site directly.
-`
-  return block.replace(/\s*$/, "") + instruction
 }
 
 async function currentFilter(block) {
@@ -139,29 +84,13 @@ function stripSectionBroken(block, heading) {
 
 function brokenFilter(block) {
   let r = block
-  r = stripSectionBroken(r, "## permissions")
-  r = stripSectionBroken(r, "## upgrading kimaki")
   r = stripSectionBroken(r, "## scheduled sends and task management")
   r = stripSectionBroken(r, "## running dev servers with tunnel access")
-  r = stripSectionBroken(r, "## starting new sessions from CLI")
-  r = stripSectionBroken(r, "## creating worktrees")
-  r = stripSectionBroken(r, "## worktree")
-  r = stripSectionBroken(r, "## cross-project commands")
   r = stripSectionBroken(r, "## reading other sessions")
-  r = stripSectionBroken(r, "## waiting for a session to finish")
   r = stripSectionBroken(r, "## running opencode commands via kimaki send")
   r = stripSectionBroken(r, "## switching agents in the current session")
-  r = stripSectionBroken(r, "## showing diffs")
-  r = stripSectionBroken(r, "## about critique")
-  r = stripSectionBroken(r, "### always show diff at end of session")
-  r = stripSectionBroken(r, "### fetching user comments from critique diffs")
-  r = stripSectionBroken(r, "### reviewing diffs with AI")
-  r = stripWorktreeInlines(r)
-  r = stripProjectDiscoveryInlines(r)
   r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
-  r = appendWordPressSiteRuntimeInstruction(r)
-  r = appendDataMachineSessionHandoffInstruction(r)
   return r
 }
 

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -13,7 +13,9 @@
 //      language fails the next test run.
 //   2. It loads the LIVE plugin source from kimaki/plugins/, so a filter
 //      change in this repo immediately reflows the snapshots.
-//   3. It writes named .txt snapshots to __snapshots__/, so reviewers
+//   3. It renders Kimaki as wp-coding-agents starts it: critique disabled via
+//      `--no-critique`, unless KIMAKI_EFFECTIVE_PROMPT_CRITIQUE=1 is set.
+//   4. It writes named .txt snapshots to __snapshots__/, so reviewers
 //      can `git diff` to see exactly what changed in the rendered prompt
 //      between commits — same workflow as jest snapshots, no jest dep.
 //
@@ -54,6 +56,10 @@ const __dirname = dirname(__filename)
 const SNAPSHOT_DIR = join(__dirname, "__snapshots__")
 const SCENARIO_DIR = join(__dirname, "scenarios")
 const KIMAKI_DIST_DIR = process.env.KIMAKI_DIST_DIR || join(execSync("npm root -g", { encoding: "utf8" }).trim(), "kimaki", "dist")
+const { store } = await import(pathToFileURL(join(KIMAKI_DIST_DIR, "store.js")).href)
+if (process.env.KIMAKI_EFFECTIVE_PROMPT_CRITIQUE !== "1") {
+  store.setState({ critiqueEnabled: false })
+}
 const { getOpencodeSystemMessage } = await import(pathToFileURL(join(KIMAKI_DIST_DIR, "system-message.js")).href)
 
 if (!existsSync(SNAPSHOT_DIR)) mkdirSync(SNAPSHOT_DIR, { recursive: true })
@@ -257,6 +263,42 @@ async function runScenario(name, scenario) {
   }
 }
 
+async function runMessageFilterChecks() {
+  const pluginModule = await import(pathToFileURL(join(__dirname, "..", "..", "bridges", "kimaki", "plugins", "dm-context-filter.ts")).href)
+  const plugin = await pluginModule.default({})
+  const filter = plugin["chat.message"]
+  if (typeof filter !== "function") {
+    throw new Error("dm-context-filter plugin is missing chat.message")
+  }
+
+  const output = {
+    parts: [
+      { type: "text", synthetic: true, text: "Project memory from MEMORY.md\n- old kimaki memory" },
+      { type: "text", synthetic: true, text: "Please update MEMORY.md before starting the new task." },
+      { type: "text", synthetic: true, text: "Current agent: build" },
+      { type: "text", text: "User-visible text" },
+    ],
+  }
+  await filter({}, output)
+
+  const texts = output.parts.map((part) => part.text || "")
+  const failures = []
+  if (texts.some((text) => text.includes("Project memory from MEMORY.md"))) {
+    failures.push("MEMORY.md synthetic injection leaked")
+  }
+  if (texts.some((text) => text.includes("update MEMORY.md before starting the new task"))) {
+    failures.push("MEMORY.md reminder leaked")
+  }
+  if (!texts.includes("Current agent: build")) {
+    failures.push("unrelated synthetic text was removed")
+  }
+  if (!texts.includes("User-visible text")) {
+    failures.push("non-synthetic user text was removed")
+  }
+
+  return { name: "chat.message memory filter", failures }
+}
+
 // ---------------------------------------------------------------------------
 // Reporting.
 // ---------------------------------------------------------------------------
@@ -318,11 +360,23 @@ const results = []
 for (const [name, scenario] of scenarios) {
   results.push(await runScenario(name, scenario))
 }
+const messageFilterResult = await runMessageFilterChecks()
 
 let failed = 0
 for (const r of results) {
   printResult(r)
   if (!r.skipped && r.failures.length > 0) failed++
+}
+
+console.log(`\n${"=".repeat(72)}`)
+console.log(`check: ${messageFilterResult.name}`)
+console.log(`${"=".repeat(72)}`)
+if (messageFilterResult.failures.length > 0) {
+  console.log(`\n  FAIL:`)
+  for (const f of messageFilterResult.failures) console.log(`    - ${f}`)
+  failed++
+} else {
+  console.log(`\n  PASS`)
 }
 
 // Clean up .actual diff intermediates on a fully successful run so they do
@@ -338,7 +392,7 @@ if (failed === 0) {
 
 console.log(`\n${"=".repeat(72)}`)
 if (failed === 0) {
-  console.log(`OK — ${results.filter((r) => !r.skipped).length} scenario(s) passed`)
+  console.log(`OK — ${results.filter((r) => !r.skipped).length} scenario(s) and 1 message-filter check passed`)
   console.log(`Snapshots: ${SNAPSHOT_DIR}`)
   console.log(`To see the side-by-side baseline-vs-filtered diff for any scenario:`)
   console.log(`  git --no-pager diff --no-index tests/effective-prompt/__snapshots__/<scenario>.baseline.txt tests/effective-prompt/__snapshots__/<scenario>.filtered.txt`)


### PR DESCRIPTION
## Summary

- Rebaseline `dm-context-filter` around managed Kimaki startup behavior, especially `--no-critique`.
- Keep Data Machine conflict filters for scheduling, site runtime/tunnel defaults, cross-project session discovery, and generic agent override examples.
- Add effective-prompt coverage for the `chat.message` filter so Kimaki `MEMORY.md` injection/reminders stay suppressed.
- Refresh effective-prompt snapshots and docs to describe the remaining policy.

Fixes #143.

## Verification

- `node tests/effective-prompt/run.mjs`
- `KIMAKI_DIST_DIR="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/kimaki-0.13.0/dist" node tests/effective-prompt/run.mjs`
- `bash tests/bridge-render.sh`
- `bash tests/datamachine-kimaki-adapter.sh`

Note: the Kimaki 0.13 package tarball needed temporary dependency install outside the repo. The published package includes private/missing dev dependencies (`db`, `opencode-cached-provider`, `opencode-deterministic-provider`), so those dev dependency entries were removed only from the temp extraction before `npm install --omit=dev --ignore-scripts --package-lock=false`. No repo files were modified for that.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refreshed the Kimaki context filter, prompt harness, snapshots, docs, and ran verification; Chris remains responsible for review and merge.
