### PR TITLE
fix(runtime): remove stale attribution env signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,13 +425,13 @@ After this, the only outbound message path is `agents/dispatch-message` → DMC 
 
 When a coding-agent session asks Data Machine Code to create a worktree, DMC captures **origin-session metadata** so the worktree carries a breadcrumb back to the session that spawned it (Discord thread URL, opencode session ID, run ID, etc.). DMC reads that metadata from environment variables the runtime sets on the worktree-creating process.
 
-The env-var names are vendor-specific (`KIMAKI_SESSION_ID`, `OPENCODE_SESSION_ID`, `OPENCODE_RUN_ID`, …) so DMC cannot enumerate them without knowing about kimaki and opencode — a layer-purity violation per the platform's coding rules. The fix (Extra-Chill/data-machine-code#416) moves the env-var → field map out of DMC into a filter:
+The env-var names are vendor-specific (`OPENCODE_RUN_ID`, and future runtime-specific IDs) so DMC cannot enumerate them without knowing about kimaki and opencode — a layer-purity violation per the platform's coding rules. The fix (Extra-Chill/data-machine-code#416) moves the env-var → field map out of DMC into a filter:
 
 ```php
 apply_filters( 'datamachine_code_worktree_runtime_signatures', [] );
 ```
 
-wp-coding-agents is the integration layer that knows about kimaki and opencode — it installs both, writes the systemd units that pass those env vars into the spawned processes, and is the only honest place those brand names live. So **wp-coding-agents owns the registration.**
+wp-coding-agents is the integration layer that knows about kimaki and opencode — it installs both and is the only honest place those brand names live. So **wp-coding-agents owns the registration.**
 
 ### How it wires up
 
@@ -444,28 +444,19 @@ $WP_PATH/wp-content/mu-plugins/wp-coding-agents-runtimes.php
 The file is owned end-to-end by wp-coding-agents installers: created on first registration, each runtime contributes a marker-delimited block (`// BEGIN runtime:<id>` … `// END runtime:<id>`), and the same install path can rewrite or remove its block idempotently. The file registers entries via the filter:
 
 ```php
-$signatures['kimaki'] = [
-    'session_id' => 'KIMAKI_SESSION_ID',
-    'thread_id'  => 'KIMAKI_THREAD_ID',
-    'thread_url' => 'KIMAKI_THREAD_URL',
-];
-
 $signatures['opencode'] = [
-    'session_id' => 'OPENCODE_SESSION_ID',
     'run_id'     => 'OPENCODE_RUN_ID',
 ];
 ```
 
 DMC reads the map, walks each runtime's subkeys, and sniffs the named env vars at worktree-create time. The subkey set is open — DMC does not validate against a closed schema. Conventional subkeys are `session_id`, `thread_id`, `thread_url`, `run_id`; integrations may add more.
 
+Kimaki 0.13 does not currently export `KIMAKI_SESSION_ID`, `KIMAKI_THREAD_ID`, or `KIMAKI_THREAD_URL` to OpenCode/tool processes, and the observed OpenCode tool environment does not expose `OPENCODE_SESSION_ID`. Those stale registrations are intentionally absent. Upstream Kimaki support for Discord thread/session env vars is tracked in https://github.com/remorses/kimaki/issues/137.
+
 ### Registered signatures
 
 | Runtime ID  | Subkey       | Env var                | What it identifies                                  |
 |-------------|--------------|------------------------|-----------------------------------------------------|
-| `kimaki`    | `session_id` | `KIMAKI_SESSION_ID`    | Kimaki session (1:1 with a Discord thread)          |
-| `kimaki`    | `thread_id`  | `KIMAKI_THREAD_ID`     | Discord thread the session lives in                 |
-| `kimaki`    | `thread_url` | `KIMAKI_THREAD_URL`    | Deep link to that Discord thread                    |
-| `opencode`  | `session_id` | `OPENCODE_SESSION_ID`  | opencode session inside the kimaki/opencode runtime |
 | `opencode`  | `run_id`     | `OPENCODE_RUN_ID`      | Specific opencode run within that session           |
 
 Adding a new runtime is a one-liner: register a new block in the relevant `runtimes/<name>.sh` or `bridges/<name>.sh` via `runtime_signature_register <runtime_id> <signature_json>` (see `lib/runtime-signature.sh`).

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -91,22 +91,14 @@ _kimaki_register_cli_channel() {
 
 # _kimaki_register_runtime_signature
 #
-# Publish kimaki's worktree session-attribution env-var contract for the Data
-# Machine Code worktree-attribution code (Extra-Chill/data-machine-code#416).
-# kimaki sets KIMAKI_SESSION_ID, KIMAKI_THREAD_ID, and KIMAKI_THREAD_URL on
-# the opencode-serve children it spawns (see Kimaki source). DMC reads those
-# env vars at worktree-create time to record which kimaki session originated
-# the worktree, what Discord thread the session lives in, and the deep link
-# to that thread.
+# Remove kimaki's stale worktree session-attribution env-var contract.
 #
-# The registration is data, not config: the runtime ID 'kimaki' is what
-# wp-coding-agents *calls* the runtime here, and the env-var names are what
-# the kimaki binary actually sets. DMC stays naive — it doesn't know kimaki
-# exists; it just sniffs whatever env vars the filter map tells it to.
+# Kimaki 0.13 does not expose KIMAKI_SESSION_ID, KIMAKI_THREAD_ID, or
+# KIMAKI_THREAD_URL to OpenCode/tool processes. Keep the install/upgrade path
+# idempotently deleting the old block so DMC only sniffs env vars that actually
+# exist. Upstream support request: https://github.com/remorses/kimaki/issues/137
 _kimaki_register_runtime_signature() {
-  runtime_signature_register \
-    "kimaki" \
-    '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+  runtime_signature_unregister "kimaki"
 }
 
 _kimaki_sync_bin_helpers() {

--- a/lib/cli-channel.sh
+++ b/lib/cli-channel.sh
@@ -354,8 +354,9 @@ _cli_channel_block_matches() {
 # <new_block> removes the bridge's block entirely (used by unregister).
 _cli_channel_rewrite() {
   local file="$1" name="$2" new_block="$3"
-  awk -v name="$name" -v new_block="$new_block" '
+  CLI_CHANNEL_NEW_BLOCK="$new_block" awk -v name="$name" '
     BEGIN {
+      new_block = ENVIRON["CLI_CHANNEL_NEW_BLOCK"]
       begin_marker = "    // BEGIN bridge:" name
       end_marker   = "    // END bridge:" name
       inserted = 0

--- a/lib/runtime-signature.sh
+++ b/lib/runtime-signature.sh
@@ -5,8 +5,8 @@
 # Data Machine Code's worktree-attribution code captures "origin session"
 # metadata when an agent spawns a worktree. Historically DMC hardcoded the
 # env-var → field map for each coding-agent runtime it knew about
-# (KIMAKI_SESSION_ID → kimaki_session_id, OPENCODE_RUN_ID → opencode_run_id,
-# etc.). Per the platform's layer-purity rule, those vendor names do not
+# (OPENCODE_RUN_ID → opencode_run_id, etc.). Per the platform's layer-purity rule,
+# those vendor names do not
 # belong in DMC — DMC is runtime-agnostic substrate.
 #
 # Extra-Chill/data-machine-code#416 generalises the DMC surface to read the
@@ -15,14 +15,13 @@
 #   apply_filters( 'datamachine_code_worktree_runtime_signatures', [] )
 #
 # Each entry is keyed by an opaque runtime ID (a string the integration layer
-# chooses, e.g. 'kimaki', 'opencode') and maps subkeys (session_id, thread_id,
+# chooses, e.g. 'opencode') and maps subkeys (session_id, thread_id,
 # thread_url, run_id, …) to the env var DMC should sniff for that subkey.
 #
 # wp-coding-agents is the integration layer that knows about kimaki and
-# opencode — it installs both, writes systemd units that pass KIMAKI_* /
-# OPENCODE_* into the spawned processes, and is the only honest place those
-# brand names live. This module owns publishing that knowledge into the
-# DMC filter via a mu-plugin file.
+# opencode — it installs both and is the only honest place those brand names
+# live. This module owns publishing the env-var contracts those runtimes
+# actually expose into the DMC filter via a mu-plugin file.
 #
 # Resolved file: $SITE_PATH/wp-content/mu-plugins/wp-coding-agents-runtimes.php
 #
@@ -49,7 +48,9 @@
 # The file uses the same marker-delimited block pattern as
 # lib/cli-channel.sh so each runtime's block can be inserted, replaced, or
 # removed idempotently without re-parsing PHP, and so two runtimes (kimaki
-# and opencode) can each manage their own block independently.
+# and opencode) can each manage their own block independently. Runtimes may
+# also unregister stale blocks when an upstream env-var contract disappears or
+# turns out not to exist.
 #
 # Public surface:
 #   runtime_signature_mu_plugin_path                       — echo file path
@@ -58,7 +59,7 @@
 #   runtime_signature_unregister <runtime_id>
 #
 # `signature_json` is a JSON object mapping subkey → env-var name, e.g.:
-#   '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+#   '{"run_id":"OPENCODE_RUN_ID"}'
 #
 # Honors DRY_RUN (logs intent, makes no changes).
 
@@ -200,8 +201,8 @@ _runtime_signature_php_escape() {
 
 # _runtime_signature_json_to_php_map <json_object_literal>
 #
-# Convert a JSON object like {"session_id":"KIMAKI_SESSION_ID",...} into a
-# PHP associative array literal [ 'session_id' => 'KIMAKI_SESSION_ID', ... ].
+# Convert a JSON object like {"run_id":"OPENCODE_RUN_ID",...} into a PHP
+# associative array literal [ 'run_id' => 'OPENCODE_RUN_ID', ... ].
 # Uses python3 (every host that runs wp-coding-agents already depends on
 # python3 — see lib/repair-opencode-json.py and runtimes/opencode.sh).
 # Keys are emitted in the order they appear in the JSON for stable diffs.
@@ -348,8 +349,9 @@ _runtime_signature_block_matches() {
 # <new_block> removes the runtime's block entirely (used by unregister).
 _runtime_signature_rewrite() {
   local file="$1" runtime_id="$2" new_block="$3"
-  awk -v rid="$runtime_id" -v new_block="$new_block" '
+  RUNTIME_SIGNATURE_NEW_BLOCK="$new_block" awk -v rid="$runtime_id" '
     BEGIN {
+      new_block = ENVIRON["RUNTIME_SIGNATURE_NEW_BLOCK"]
       begin_marker = "    // BEGIN runtime:" rid
       end_marker   = "    // END runtime:" rid
       inserted = 0

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -18,9 +18,9 @@ runtime_install() {
 #
 # Publish opencode's worktree session-attribution env-var contract for the
 # Data Machine Code worktree-attribution code (Extra-Chill/data-machine-code#416).
-# opencode sets OPENCODE_SESSION_ID and OPENCODE_RUN_ID on processes it
-# spawns; DMC reads those at worktree-create time to record which opencode
-# session/run originated the worktree.
+# OpenCode exposes OPENCODE_RUN_ID to tool processes. Kimaki/OpenCode 0.13
+# does not expose OPENCODE_SESSION_ID there; DMC should only sniff env vars
+# that actually exist at worktree-create time.
 #
 # Registered from runtime_install (setup-time) and from the legacy-wrapper-
 # removal phase in upgrade.sh, which is the upgrade-time entry point that
@@ -37,7 +37,7 @@ _opencode_register_runtime_signature() {
   fi
   runtime_signature_register \
     "opencode" \
-    '{"session_id":"OPENCODE_SESSION_ID","run_id":"OPENCODE_RUN_ID"}'
+    '{"run_id":"OPENCODE_RUN_ID"}'
 }
 
 # Remove any legacy wp-coding-agents-opencode-wrapper-v2 bash shim that prior

--- a/tests/cli-channel-perms.sh
+++ b/tests/cli-channel-perms.sh
@@ -48,10 +48,19 @@ fi
 MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-channels.php"
 FAILED=0
 
+file_mode() {
+  local file="$1"
+  if stat -c %a "$file" >/dev/null 2>&1; then
+    stat -c %a "$file"
+  else
+    stat -f %Lp "$file"
+  fi
+}
+
 assert_mode_0644() {
   local file="$1" name="$2"
   local got
-  got=$(stat -c %a "$file")
+  got=$(file_mode "$file")
   if [ "$got" = "644" ]; then
     echo "  ok   $name"
   else

--- a/tests/runtime-signature.sh
+++ b/tests/runtime-signature.sh
@@ -83,10 +83,28 @@ assert_php_lint() {
   fi
 }
 
+file_hash() {
+  local file="$1"
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$file" | cut -d' ' -f1
+  else
+    md5 -q "$file"
+  fi
+}
+
+file_mode() {
+  local file="$1"
+  if stat -c %a "$file" >/dev/null 2>&1; then
+    stat -c %a "$file"
+  else
+    stat -f %Lp "$file"
+  fi
+}
+
 assert_mode_0644() {
   local file="$1" name="$2"
   local got
-  got=$(stat -c %a "$file")
+  got=$(file_mode "$file")
   if [ "$got" = "644" ]; then
     echo "  ok   $name"
   else
@@ -97,81 +115,98 @@ assert_mode_0644() {
   fi
 }
 
-# --- 1. Fresh scaffold + register kimaki -----------------------------------
+# --- 1. Fresh scaffold + register opencode ---------------------------------
 # Use a hostile umask (matches root cron/systemd default 0077) to prove the
 # helper forces 0644 regardless of caller umask — see issue #133.
-echo "==> register kimaki (fresh scaffold, umask 077)"
+echo "==> register opencode (fresh scaffold, umask 077)"
 (
   umask 077
-  runtime_signature_register "kimaki" \
-    '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+  runtime_signature_register "opencode" \
+    '{"run_id":"OPENCODE_RUN_ID"}'
 )
 assert_file_exists "$MU_FILE" "mu-plugin created"
 assert_php_lint "$MU_FILE" "scaffold parses with php -l"
 assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after fresh write under umask 077"
 
-if grep -q "BEGIN runtime:kimaki" "$MU_FILE"; then
-  echo "  ok   kimaki block present"
+if grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
+  echo "  ok   opencode block present"
 else
-  echo "  FAIL kimaki block missing"
+  echo "  FAIL opencode block missing"
   FAILED=$((FAILED + 1))
 fi
 
+if grep -q "OPENCODE_SESSION_ID\|KIMAKI_SESSION_ID\|KIMAKI_THREAD_ID\|KIMAKI_THREAD_URL" "$MU_FILE"; then
+  echo "  FAIL stale unsupported env vars registered"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   stale unsupported env vars absent"
+fi
+
 # --- 2. Idempotency --------------------------------------------------------
-echo "==> re-register kimaki with same signature (idempotent)"
-HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)
-runtime_signature_register "kimaki" \
-  '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
-HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
+echo "==> re-register opencode with same signature (idempotent)"
+HASH_BEFORE=$(file_hash "$MU_FILE")
+runtime_signature_register "opencode" \
+  '{"run_id":"OPENCODE_RUN_ID"}'
+HASH_AFTER=$(file_hash "$MU_FILE")
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-register"
 
-# --- 3. Add opencode without disturbing kimaki -----------------------------
+# --- 3. Add a sibling runtime without disturbing opencode -------------------
 # Simulate a legacy 0600 file from a pre-#133 install. The next register call
 # must self-heal it back to 0644 via the mktemp+mv path.
 echo "==> simulate legacy 0600 file and verify self-heal on next register"
 chmod 0600 "$MU_FILE"
-runtime_signature_register "opencode" \
-  '{"session_id":"OPENCODE_SESSION_ID","run_id":"OPENCODE_RUN_ID"}'
+runtime_signature_register "example" \
+  '{"session_id":"EXAMPLE_SESSION_ID"}'
 assert_php_lint "$MU_FILE" "two-runtime file parses with php -l"
 assert_mode_0644 "$MU_FILE" "mu-plugin mode self-healed to 0644 after sibling register"
 
-if grep -q "BEGIN runtime:kimaki" "$MU_FILE" && grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
+if grep -q "BEGIN runtime:opencode" "$MU_FILE" && grep -q "BEGIN runtime:example" "$MU_FILE"; then
   echo "  ok   both runtime blocks present"
 else
-  echo "  FAIL kimaki and/or opencode block missing after sibling register"
+  echo "  FAIL opencode and/or example block missing after sibling register"
   FAILED=$((FAILED + 1))
 fi
 
-# --- 4. Mutation: replace kimaki block, opencode untouched -----------------
-echo "==> re-register kimaki with mutated signature"
+# --- 4. Mutation: replace opencode block, sibling untouched ----------------
+echo "==> re-register opencode with mutated signature"
+runtime_signature_register "opencode" \
+  '{"run_id":"OPENCODE_RUN_ID","trace_id":"OPENCODE_TRACE_ID"}'
+if grep -q "OPENCODE_TRACE_ID" "$MU_FILE"; then
+  echo "  ok   opencode block updated"
+else
+  echo "  FAIL opencode block did not pick up new subkey"
+  FAILED=$((FAILED + 1))
+fi
+if grep -q "EXAMPLE_SESSION_ID" "$MU_FILE"; then
+  echo "  ok   sibling block preserved across opencode mutation"
+else
+  echo "  FAIL sibling block clobbered by opencode re-register"
+  FAILED=$((FAILED + 1))
+fi
+
+# --- 5. Unregister stale kimaki block and sibling --------------------------
+echo "==> simulate legacy kimaki block and unregister it"
 runtime_signature_register "kimaki" \
-  '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL","run_id":"KIMAKI_RUN_ID"}'
-if grep -q "KIMAKI_RUN_ID" "$MU_FILE"; then
-  echo "  ok   kimaki block updated"
-else
-  echo "  FAIL kimaki block did not pick up new subkey"
+  '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+runtime_signature_unregister "kimaki"
+if grep -q "KIMAKI_SESSION_ID\|KIMAKI_THREAD_ID\|KIMAKI_THREAD_URL" "$MU_FILE"; then
+  echo "  FAIL stale kimaki vars present after unregister"
   FAILED=$((FAILED + 1))
-fi
-if grep -q "OPENCODE_SESSION_ID" "$MU_FILE"; then
-  echo "  ok   opencode block preserved across kimaki mutation"
 else
-  echo "  FAIL opencode block clobbered by kimaki re-register"
-  FAILED=$((FAILED + 1))
+  echo "  ok   stale kimaki vars absent after unregister"
 fi
-
-# --- 5. Unregister opencode ------------------------------------------------
-echo "==> unregister opencode"
-runtime_signature_unregister "opencode"
+echo "==> unregister sibling"
+runtime_signature_unregister "example"
+if grep -q "BEGIN runtime:example" "$MU_FILE"; then
+  echo "  FAIL sibling block still present after unregister"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   sibling block removed"
+fi
 if grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
-  echo "  FAIL opencode block still present after unregister"
-  FAILED=$((FAILED + 1))
+  echo "  ok   opencode block preserved across unregisters"
 else
-  echo "  ok   opencode block removed"
-fi
-if grep -q "BEGIN runtime:kimaki" "$MU_FILE"; then
-  echo "  ok   kimaki block preserved across opencode unregister"
-else
-  echo "  FAIL kimaki block clobbered by opencode unregister"
+  echo "  FAIL opencode block clobbered by unregisters"
   FAILED=$((FAILED + 1))
 fi
 assert_php_lint "$MU_FILE" "post-unregister file parses with php -l"
@@ -198,8 +233,8 @@ require '$MU_FILE';
 echo json_encode( \$result );
 PHP
 RESULT=$(php "$SHIM")
-EXPECTED='{"kimaki":{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL","run_id":"KIMAKI_RUN_ID"}}'
-assert_eq "$RESULT" "$EXPECTED" "filter returns surviving kimaki signature"
+EXPECTED='{"opencode":{"run_id":"OPENCODE_RUN_ID","trace_id":"OPENCODE_TRACE_ID"}}'
+assert_eq "$RESULT" "$EXPECTED" "filter returns surviving opencode signature"
 
 # --- Done ------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Summary\n- remove unsupported Kimaki session/thread runtime-signature registration and unregister stale Kimaki blocks during install/upgrade\n- narrow OpenCode runtime signature registration to the observed `OPENCODE_RUN_ID` env var\n- update runtime-signature docs/tests to reject stale `KIMAKI_*` and `OPENCODE_SESSION_ID` contracts\n- make the mu-plugin rewrite tests portable on macOS by avoiding multi-line awk -v values and Linux-only stat/md5 helpers\n\nCloses https://github.com/Extra-Chill/wp-coding-agents/issues/149\n\nUpstream Kimaki support request: https://github.com/remorses/kimaki/issues/137\n\n## Verification\n- inspected Kimaki 0.13.0 source: OpenCode server env includes Kimaki process/config plumbing but not `KIMAKI_SESSION_ID`, `KIMAKI_THREAD_ID`, or `KIMAKI_THREAD_URL`\n- inspected live OpenCode tool env: per-run attribution env present as `OPENCODE_RUN_ID`; no Kimaki session/thread vars or `OPENCODE_SESSION_ID` observed\n- `bash tests/runtime-signature.sh`\n- `bash tests/opencode-wrapper-removal.sh`\n- `bash tests/bridge-render.sh`\n- `bash tests/post-upgrade-restore.sh`\n- `bash tests/cli-channel-perms.sh`\n- `bash tests/datamachine-kimaki-adapter.sh`\n- `for test in tests/*.sh; do echo "==> "; bash ""; done`\n- `node tests/dm-agent-sync.mjs`\n- `git diff --check`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode (GPT-5.5)\n- **Used for:** Inspected the issue and Kimaki/OpenCode env contracts, drafted the code/docs/tests changes, ran verification, and prepared this PR for Chris to review.