### PR TITLE
fix(kimaki): stop normalizing agent overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ The file is owned end-to-end by bridge installers: it is created on first regist
 
 ```php
 $channels['kimaki'] = [
-    'command' => '/usr/local/bin/datamachine-kimaki',
+    'command' => '/usr/bin/kimaki',
     'args'    => [ 'send', '--channel', '{recipient}', '--prompt', '{message}' ],
     'detach'  => true,
     'timeout' => 600,
@@ -389,7 +389,7 @@ agents/dispatch-message
 
 ### Bridge-specific notes
 
-- **kimaki** registers the local `datamachine-kimaki` adapter shim wp-coding-agents installs alongside the kimaki binary. The shim normalises Kimaki send flags across versions. If it isn't on disk yet (very early installs), the bridge falls back to the resolved global `kimaki` binary.
+- **kimaki** registers the resolved real `kimaki` binary. The `datamachine-kimaki` helper remains as a thin compatibility delegate for installs that call it directly, but CLI-channel dispatch no longer rewrites `--agent` flags.
 - **cc-connect** assumes `cc-connect send` accepts `--project <name> <message>`. cc-connect routes outgoing messages through its currently-bound platform per project (Feishu/DingTalk/Slack/Telegram/Discord/etc.), so `recipient` is the cc-connect project, not a raw chat ID. **Assumption to validate against upstream:** if `--project` is unsupported, the argv collapses to `["send","{message}"]` and `recipient` becomes informational only. Tracked alongside Extra-Chill/wp-coding-agents#129.
 - **telegram** is the odd one out. `opencode-telegram-bot` is inbound-only (polls Telegram, forwards to a local opencode server); it has no outbound `send` subcommand. To preserve the channel/recipient model, the bridge registers `curl` against Telegram's `sendMessage` Bot API with `TELEGRAM_BOT_TOKEN` baked in. `recipient` is a Telegram chat ID. The token is captured at install/upgrade time from the existing bot `.env` if not in the current shell — rotating the token requires re-running `upgrade.sh` so the channel config picks up the new value.
 

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -54,6 +54,10 @@ bridge_install() {
     _kimaki_install_systemd
   fi
 
+  if [ -z "${KIMAKI_BIN:-}" ]; then
+    KIMAKI_BIN=$(command -v kimaki 2>/dev/null || echo kimaki)
+  fi
+
   _kimaki_sync_bin_helpers
   _kimaki_register_cli_channel
   _kimaki_register_runtime_signature
@@ -67,15 +71,12 @@ bridge_install() {
 # channel ID (numeric string) the message is delivered to. `message` is the
 # message body.
 #
-# We register the local-mode adapter shim (`datamachine-kimaki`) installed by
-# _kimaki_sync_bin_helpers; it normalises Kimaki send flags across versions.
-# Falls back to the resolved global `kimaki` binary if the adapter isn't on
-# disk yet (early VPS installs predating the adapter shim).
+# Register the real Kimaki binary. Kimaki 0.13+ handles missing agent
+# preferences by falling back to its default agent, so the CLI channel does not
+# need Data Machine-specific agent flag normalization.
 _kimaki_register_cli_channel() {
   local cmd
-  if [ -n "${RESOLVED_DATAMACHINE_KIMAKI:-}" ] && [ -x "$RESOLVED_DATAMACHINE_KIMAKI" ]; then
-    cmd="$RESOLVED_DATAMACHINE_KIMAKI"
-  elif [ -n "${KIMAKI_BIN:-}" ]; then
+  if [ -n "${KIMAKI_BIN:-}" ]; then
     cmd="$KIMAKI_BIN"
   else
     cmd="$(command -v kimaki 2>/dev/null || echo kimaki)"
@@ -155,7 +156,7 @@ _kimaki_sync_command_shim() {
 
   if [ -e "$shim_target" ] && ! grep -q 'wp-coding-agents datamachine-kimaki adapter' "$shim_target" 2>/dev/null; then
     warn "  $shim_target exists and is not the Data Machine Kimaki adapter — leaving it untouched"
-    warn "  Install $helper_dir earlier on PATH or call datamachine-kimaki directly to normalize Kimaki send flags"
+    warn "  Install $helper_dir earlier on PATH or call datamachine-kimaki directly"
     return 0
   fi
 

--- a/bridges/kimaki/bin/datamachine-kimaki
+++ b/bridges/kimaki/bin/datamachine-kimaki
@@ -6,15 +6,8 @@ usage() {
   cat <<'EOF'
 Usage: datamachine-kimaki <kimaki-args...>
 
-Data Machine compatibility adapter for Kimaki.
-
-In Data Machine mode, Kimaki is the Discord transport while Data Machine owns
-agent identity and site-root memory. This adapter normalizes the Kimaki `send`
-agent slot before delegating to the real Kimaki binary:
-
-  send --agent <anything>  -> send --agent build
-
-Kimaki project, --cwd, and --worktree routing are passed through unchanged.
+Data Machine compatibility adapter for Kimaki. It resolves the real Kimaki
+binary and delegates arguments unchanged.
 
 Set DATAMACHINE_REAL_KIMAKI to the real Kimaki binary path. If unset, the
 adapter resolves the next non-adapter `kimaki` from PATH.
@@ -55,45 +48,10 @@ resolve_real_kimaki() {
   exit 2
 }
 
-normalize_send_args() {
-  normalized_args=()
-
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --agent)
-        normalized_args+=(--agent build)
-        shift
-        if [[ $# -gt 0 && "$1" != --* ]]; then
-          shift
-        fi
-        ;;
-      --agent=*)
-        normalized_args+=(--agent build)
-        shift
-        ;;
-      *)
-        normalized_args+=("$1")
-        shift
-        ;;
-    esac
-  done
-
-  return 0
-}
-
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   usage
   exit 0
 fi
 
 real_kimaki="$(resolve_real_kimaki)"
-
-if [[ "${1:-}" != "send" ]]; then
-  exec "$real_kimaki" "$@"
-fi
-
-shift
-normalized_args=()
-normalize_send_args "$@"
-
-exec "$real_kimaki" send "${normalized_args[@]}"
+exec "$real_kimaki" "$@"

--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -11,20 +11,14 @@
 //    webhooks/OAuth callbacks, not the default way to interact with the site.
 // 3. Critique — ~900 tokens of diff-sharing instructions. We use GitHub PRs.
 // 4. Waiting for sessions — ~150 tokens. Rarely used, discoverable via --help.
-// 5. Session/workspace conflicts — generic Kimaki agent override examples can
-//    bypass the Data Machine-bound default agent slot.
-// 8. Permissions — ~80 tokens describing which Discord roles can message the
+// 5. Permissions — ~80 tokens describing which Discord roles can message the
 //    bot. The agent has no capability to act on this; pure metadata leakage.
-// 9. Upgrading kimaki — ~80 tokens of /upgrade-and-restart playbook. The user
+// 6. Upgrading kimaki — ~80 tokens of /upgrade-and-restart playbook. The user
 //    runs the slash command themselves when they want to upgrade.
-// 10. Reading other sessions — ~250 tokens documenting `kimaki session list
+// 7. Reading other sessions — ~250 tokens documenting `kimaki session list
 //    --project` / `session search --channel <id>`. These are cross-project
 //    discovery vectors; on a single-project fleet server the agent only ever
 //    needs to list sessions in the current project (no flags required).
-// 11. Agent override inlines — `--agent <current_agent>` examples from the
-//    generic Kimaki prompt. On DM-managed sites the Discord channel owns the
-//    personal-agent binding; passing the runtime agent (for example `opencode`)
-//    bypasses that binding and starts the wrong kind of minion session.
 //
 // This plugin is strip-only. Positive guidance about how to use Kimaki's
 // session bridge or the WordPress site runtime belongs in Data Machine's
@@ -64,14 +58,11 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "## worktree");
         result = stripSection(result, "## reading other sessions");
         result = stripSection(result, "## waiting for a session to finish");
-        result = stripSection(result, "## running opencode commands via kimaki send");
-        result = stripSection(result, "## switching agents in the current session");
         result = stripSection(result, "## showing diffs");
         result = stripSection(result, "## about critique");
         result = stripSection(result, "### always show diff at end of session");
         result = stripSection(result, "### fetching user comments from critique diffs");
         result = stripSection(result, "### reviewing diffs with AI");
-        result = stripAgentOverrideInlines(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");
         return result;
@@ -159,41 +150,6 @@ function stripSection(block: string, heading: string): string {
   const before = lines.slice(0, start);
   const after = lines.slice(end);
   return [...before, ...after].join("\n");
-}
-
-/**
- * Remove generic Kimaki agent override examples from surviving sections.
- *
- * On Data Machine-managed sites the Discord channel selects the personal
- * agent. Passing `--agent <current_agent>` teaches the runtime agent to turn
- * the synthetic reminder value (often `opencode`) into a real session routing
- * override, bypassing the channel-bound Franklin agent.
- *
- * @param {string} block System prompt block.
- * @return {string} System prompt block without agent override examples.
- */
-function stripAgentOverrideInlines(block: string): string {
-  let result = block;
-
-  // Delete the generic instruction that recommends passing the current runtime
-  // agent to spawned sessions.
-  result = result.replace(
-    /\n+Prefer passing the current agent with `--agent <current_agent>`[^\n]*\n/g,
-    "\n"
-  );
-
-  // Remove the generic "pick an agent" example from the surviving start-new-
-  // sessions section; normal minions should rely on the channel binding.
-  result = result.replace(
-    /\n+Use --agent to specify which agent to use for the session:[\s\S]*?\nkimaki send --channel [^\n]* --agent [^\n]*\n/g,
-    "\n"
-  );
-
-  // Surviving `kimaki send` examples should rely on channel routing and the
-  // Data Machine-bound default agent slot.
-  result = result.replace(/ --agent <current_agent>/g, "");
-
-  return result;
 }
 
 export default fleetContextFilter;

--- a/tests/datamachine-kimaki-adapter.sh
+++ b/tests/datamachine-kimaki-adapter.sh
@@ -33,22 +33,22 @@ PY
 }
 
 "$ADAPTER" send --prompt hi --agent opencode
-assert_args send --prompt hi --agent build
+assert_args send --prompt hi --agent opencode
 
 "$ADAPTER" send --prompt hi --agent plan
-assert_args send --prompt hi --agent build
+assert_args send --prompt hi --agent plan
 
 "$ADAPTER" send --prompt hi --agent=general
-assert_args send --prompt hi --agent build
+assert_args send --prompt hi --agent=general
 
 "$ADAPTER" send --prompt hi --cwd /tmp/elsewhere
 assert_args send --prompt hi --cwd /tmp/elsewhere
 
 "$ADAPTER" send --prompt hi --cwd=/tmp/elsewhere --agent opencode
-assert_args send --prompt hi --cwd=/tmp/elsewhere --agent build
+assert_args send --prompt hi --cwd=/tmp/elsewhere --agent opencode
 
 "$ADAPTER" send --prompt hi --agent --model anthropic/test
-assert_args send --prompt hi --agent build --model anthropic/test
+assert_args send --prompt hi --agent --model anthropic/test
 
 "$ADAPTER" send --prompt hi --cwd --model anthropic/test
 assert_args send --prompt hi --cwd --model anthropic/test
@@ -66,6 +66,6 @@ mkdir -p "$shim_dir" "$real_dir"
 cp "$ADAPTER" "$shim_dir/kimaki"
 cp "$REAL_KIMAKI" "$real_dir/kimaki"
 PATH="$shim_dir:$real_dir:$PATH" "$shim_dir/kimaki" send --prompt hi --agent opencode --cwd /tmp/site
-assert_args send --prompt hi --agent build --cwd /tmp/site
+assert_args send --prompt hi --agent opencode --cwd /tmp/site
 
-echo "OK: datamachine-kimaki adapter normalizes agent send flags"
+echo "OK: datamachine-kimaki adapter delegates arguments unchanged"

--- a/tests/effective-prompt/README.md
+++ b/tests/effective-prompt/README.md
@@ -1,9 +1,9 @@
 # effective-prompt
 
 Pluggable harness that renders the kimaki opencode system prompt, runs the
-`dm-context-filter` plugin over it, snapshots the result, and asserts that
-no banned `--agent` override examples leak into the filtered prompt that an
-opencode session actually sees.
+`dm-context-filter` plugin over it, snapshots the result, and asserts any
+scenario-specific banned trigger phrases do not leak into the filtered prompt
+that an opencode session actually sees.
 
 ## Why
 
@@ -49,8 +49,7 @@ Each scenario is a JSON file in `scenarios/`. Override any of:
 - **`baseline`** — name from `filters.mjs`. Default
   `"broken-stripsection"` (kept as diff evidence for reviewers).
 - **`triggers`** — array of `{ name, pattern }`. Pattern is a JS regex
-  string; prefix with `(?i)` for case-insensitive. Default: `--agent`, which
-  catches generic Kimaki agent override examples.
+  string; prefix with `(?i)` for case-insensitive. Default: empty.
 - **`allowLeakInSection`** — array of section headings (e.g. `"## Minion
   Session Routing"`) where trigger matches are intentional and must not
   count as leaks.

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -25,6 +25,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -48,6 +64,23 @@ kimaki user list --guild 1493321868415996064 --query "username"
 
 This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
 
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
+
 # List all registered projects with their channel IDs
 kimaki project list --json  # machine-readable output
 
@@ -62,7 +95,7 @@ kimaki project list --json  # machine-readable output
 # Or use --project to resolve from directory
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 Use cases:
@@ -72,7 +105,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
 
 # Wait for a session that was already started elsewhere
 kimaki session wait <session_id>

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -25,6 +25,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -52,9 +68,10 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:
@@ -65,31 +82,31 @@ Before sending, choose the right destination:
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt 'follow-up prompt'
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt 'follow-up prompt'
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user '<discord-user-id>'
 
 Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --user '<discord-user-id>'
 
 Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
 
-kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --user '<discord-user-id>'
 
 Use --cwd to start a session in an existing project subfolder or git worktree directory:
 
-kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 
 Important:
 - NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
@@ -98,9 +115,30 @@ Important:
 - Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
 - Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
 
+Use --agent to specify which agent to use for the session:
+
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --user '<discord-user-id>'
+
 Available agents:
 - `build`: default coding agent
 - `plan`: planning agent
+
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
 
 ## creating worktrees
 
@@ -109,7 +147,7 @@ ONLY create worktrees when the user explicitly asks for one. Never proactively u
 When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --user '<discord-user-id>'
 ```
 
 This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
@@ -125,7 +163,7 @@ Critical recursion guard:
 Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
@@ -139,7 +177,7 @@ This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
 When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
@@ -172,13 +210,13 @@ To send a task to another project:
 
 ```bash
 # Send to a specific channel
-kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2'
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
 
 # Or use --project to resolve from directory
-kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0'
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.

--- a/tests/effective-prompt/__snapshots__/default.raw.txt
+++ b/tests/effective-prompt/__snapshots__/default.raw.txt
@@ -44,6 +44,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -23,6 +23,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -46,6 +62,23 @@ kimaki user list --guild <guildId> --query "username"
 
 This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
 
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
+
 # List all registered projects with their channel IDs
 kimaki project list --json  # machine-readable output
 
@@ -60,7 +93,7 @@ kimaki project list --json  # machine-readable output
 # Or use --project to resolve from directory
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 Use cases:
@@ -70,7 +103,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
 
 # Wait for a session that was already started elsewhere
 kimaki session wait <session_id>

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -23,6 +23,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -50,9 +66,10 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:
@@ -63,31 +80,31 @@ Before sending, choose the right destination:
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt 'follow-up prompt'
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt 'follow-up prompt'
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user '<discord-user-id>'
 
 Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --user '<discord-user-id>'
 
 Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
 
-kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --user '<discord-user-id>'
 
 Use --cwd to start a session in an existing project subfolder or git worktree directory:
 
-kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 
 Important:
 - NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
@@ -96,6 +113,27 @@ Important:
 - Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
 - Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
 
+Use --agent to specify which agent to use for the session:
+
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --user '<discord-user-id>'
+
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
+
 ## creating worktrees
 
 ONLY create worktrees when the user explicitly asks for one. Never proactively use `--worktree` for normal tasks.
@@ -103,7 +141,7 @@ ONLY create worktrees when the user explicitly asks for one. Never proactively u
 When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --user '<discord-user-id>'
 ```
 
 This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
@@ -119,7 +157,7 @@ Critical recursion guard:
 Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
@@ -133,7 +171,7 @@ This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
 When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
@@ -166,13 +204,13 @@ To send a task to another project:
 
 ```bash
 # Send to a specific channel
-kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2'
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
 
 # Or use --project to resolve from directory
-kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0'
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
@@ -42,6 +42,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -71,14 +71,6 @@ function stripProjectDiscoveryInlines(block) {
   return result
 }
 
-function stripAgentOverrideInlines(block) {
-  let result = block
-  result = result.replace(/\n+Prefer passing the current agent with `--agent <current_agent>`[^\n]*\n/g, "\n")
-  result = result.replace(/\n+Use --agent to specify which agent to use for the session:[\s\S]*?\nkimaki send --channel [^\n]* --agent [^\n]*\n/g, "\n")
-  result = result.replace(/ --agent <current_agent>/g, "")
-  return result
-}
-
 function appendDataMachineSessionHandoffInstruction(block) {
   const instruction = `
 
@@ -149,8 +141,6 @@ function brokenFilter(block) {
   r = stripSectionBroken(r, "## cross-project commands")
   r = stripSectionBroken(r, "## reading other sessions")
   r = stripSectionBroken(r, "## waiting for a session to finish")
-  r = stripSectionBroken(r, "## running opencode commands via kimaki send")
-  r = stripSectionBroken(r, "## switching agents in the current session")
   r = stripSectionBroken(r, "## showing diffs")
   r = stripSectionBroken(r, "## about critique")
   r = stripSectionBroken(r, "### always show diff at end of session")
@@ -158,7 +148,6 @@ function brokenFilter(block) {
   r = stripSectionBroken(r, "### reviewing diffs with AI")
   r = stripWorktreeInlines(r)
   r = stripProjectDiscoveryInlines(r)
-  r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
   r = appendWordPressSiteRuntimeInstruction(r)
   r = appendDataMachineSessionHandoffInstruction(r)

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -27,9 +27,8 @@
 //     "broken-stripsection" (the regex-only stripSection that misfires
 //     on fenced bash comments). The harness keeps baseline output available
 //     as diff evidence, but leak detection is the correctness gate.
-//   - triggers: array of { name, pattern }. Default: --agent override
-//     examples that bypass the Data Machine-bound agent slot.
-//     Lines matching any trigger in the filtered output count as leaks.
+//   - triggers: array of { name, pattern }. Default: empty. Lines matching
+//     any trigger in the filtered output count as leaks.
 //   - allowLeakInSection: array of section headings where trigger
 //     matches are intentional (e.g. the appended Minion Routing note
 //     intentionally references --cwd to point agents at it).
@@ -73,9 +72,7 @@ const VERBOSE = args.includes("--verbose")
 // scenarios/ once the suite is seeded.
 // ---------------------------------------------------------------------------
 
-const DEFAULT_TRIGGERS = [
-  { name: "--agent",         pattern: "--agent"                  },
-]
+const DEFAULT_TRIGGERS = []
 
 // The filter is strip-only — it never appends sections. Any trigger word
 // appearing in the filtered output is a real leak that needs investigation,


### PR DESCRIPTION
## Summary
- rely on Kimaki 0.13 missing-agent fallback instead of rewriting `--agent` flags to `build`
- keep generic Kimaki agent guidance in the filtered prompt and refresh effective-prompt snapshots
- register the real `kimaki` binary for CLI-channel dispatch while leaving `datamachine-kimaki` as a thin compatibility delegate

Closes #144.

## Verification
- Verified upstream Kimaki `main` / `0.13.0` source: `resolveValidatedAgentPreference()` logs missing agents and returns `agentPreference: undefined`, falling back to the default agent.
- `tests/datamachine-kimaki-adapter.sh`
- `node tests/effective-prompt/run.mjs`
- `tests/bridge-render.sh`
- `bash -n bridges/kimaki.sh bridges/kimaki/bin/datamachine-kimaki tests/datamachine-kimaki-adapter.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code/test/docs updates, refreshed snapshots, and ran targeted verification; Chris remains responsible for review and merge.