### PR TITLE
Refresh Kimaki context filter for 0.13

### DIFF
--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -1,30 +1,31 @@
 // dm-context-filter.ts — OpenCode plugin for WordPress agent VPSes with Data Machine.
 //
 // Strips Kimaki built-in features from the agent context when Data Machine
-// manages memory, scheduling, and other concerns.
+// owns the corresponding memory, scheduling, or site-runtime policy.
 //
 // What it removes from the system prompt:
-// 1. Scheduling — ~500 tokens of --send-at, cron, task management instructions.
-// 2. Tunnel / dev server — ~500 tokens about kimaki tunnel and tmux. DM-managed
+// 1. Scheduling — Data Machine owns recurring automation, flows, jobs, and
+//    reminders, so the agent should not learn a second scheduler path.
+// 2. Tunnel / dev server — DM-managed
 //    WordPress installs already have a site runtime (Studio locally, a live
 //    site on VPS). Tunnels are task-specific for inbound public URLs like
 //    webhooks/OAuth callbacks, not the default way to interact with the site.
-// 3. Critique — ~900 tokens of diff-sharing instructions. We use GitHub PRs.
-// 4. Waiting for sessions — ~150 tokens. Rarely used, discoverable via --help.
-// 5. Session/workspace conflicts — generic Kimaki agent override examples can
-//    bypass the Data Machine-bound default agent slot.
-// 8. Permissions — ~80 tokens describing which Discord roles can message the
+// 3. Permissions — metadata describing which Discord roles can message the
 //    bot. The agent has no capability to act on this; pure metadata leakage.
-// 9. Upgrading kimaki — ~80 tokens of /upgrade-and-restart playbook. The user
+// 4. Upgrading kimaki — the /upgrade-and-restart playbook. The user
 //    runs the slash command themselves when they want to upgrade.
-// 10. Reading other sessions — ~250 tokens documenting `kimaki session list
+// 5. Reading other sessions — cross-session discovery commands such as
+//    `kimaki session list
 //    --project` / `session search --channel <id>`. These are cross-project
 //    discovery vectors; on a single-project fleet server the agent only ever
 //    needs to list sessions in the current project (no flags required).
-// 11. Agent override inlines — `--agent <current_agent>` examples from the
-//    generic Kimaki prompt. On DM-managed sites the Discord channel owns the
-//    personal-agent binding; passing the runtime agent (for example `opencode`)
-//    bypasses that binding and starts the wrong kind of minion session.
+//
+// What it intentionally keeps under Kimaki 0.13:
+// - Generic `--agent <current_agent>` examples. Kimaki now falls back to the
+//   build agent when a requested agent does not exist, so Data Machine no
+//   longer needs prompt surgery to compensate for runtime-agent names.
+// - Critique instructions. wp-coding-agents starts managed Kimaki services with
+//   `--no-critique`, so the section is absent before this filter runs.
 //
 // This plugin is strip-only. Positive guidance about how to use Kimaki's
 // session bridge or the WordPress site runtime belongs in Data Machine's
@@ -40,7 +41,7 @@
 // 8. MEMORY.md injection — Kimaki reads MEMORY.md from the project directory and
 //    injects a condensed TOC. Conflicts with Data Machine's own memory files.
 // 9. "Update MEMORY.md" time-gap reminder — Redundant with external memory system.
-// Total savings: ~2,400+ tokens per session.
+// Total savings depends on the Kimaki version and managed startup flags.
 //
 // How to use:
 //   Add to opencode.json:  "plugin": ["/opt/kimaki-config/plugins/dm-context-filter.ts"]
@@ -61,17 +62,7 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "## upgrading kimaki");
         result = stripSection(result, "## scheduled sends and task management");
         result = stripSection(result, "## running dev servers with tunnel access");
-        result = stripSection(result, "## worktree");
         result = stripSection(result, "## reading other sessions");
-        result = stripSection(result, "## waiting for a session to finish");
-        result = stripSection(result, "## running opencode commands via kimaki send");
-        result = stripSection(result, "## switching agents in the current session");
-        result = stripSection(result, "## showing diffs");
-        result = stripSection(result, "## about critique");
-        result = stripSection(result, "### always show diff at end of session");
-        result = stripSection(result, "### fetching user comments from critique diffs");
-        result = stripSection(result, "### reviewing diffs with AI");
-        result = stripAgentOverrideInlines(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");
         return result;
@@ -159,41 +150,6 @@ function stripSection(block: string, heading: string): string {
   const before = lines.slice(0, start);
   const after = lines.slice(end);
   return [...before, ...after].join("\n");
-}
-
-/**
- * Remove generic Kimaki agent override examples from surviving sections.
- *
- * On Data Machine-managed sites the Discord channel selects the personal
- * agent. Passing `--agent <current_agent>` teaches the runtime agent to turn
- * the synthetic reminder value (often `opencode`) into a real session routing
- * override, bypassing the channel-bound Franklin agent.
- *
- * @param {string} block System prompt block.
- * @return {string} System prompt block without agent override examples.
- */
-function stripAgentOverrideInlines(block: string): string {
-  let result = block;
-
-  // Delete the generic instruction that recommends passing the current runtime
-  // agent to spawned sessions.
-  result = result.replace(
-    /\n+Prefer passing the current agent with `--agent <current_agent>`[^\n]*\n/g,
-    "\n"
-  );
-
-  // Remove the generic "pick an agent" example from the surviving start-new-
-  // sessions section; normal minions should rely on the channel binding.
-  result = result.replace(
-    /\n+Use --agent to specify which agent to use for the session:[\s\S]*?\nkimaki send --channel [^\n]* --agent [^\n]*\n/g,
-    "\n"
-  );
-
-  // Surviving `kimaki send` examples should rely on channel routing and the
-  // Data Machine-bound default agent slot.
-  result = result.replace(/ --agent <current_agent>/g, "");
-
-  return result;
 }
 
 export default fleetContextFilter;

--- a/lib/cli-channel.sh
+++ b/lib/cli-channel.sh
@@ -354,7 +354,17 @@ _cli_channel_block_matches() {
 # <new_block> removes the bridge's block entirely (used by unregister).
 _cli_channel_rewrite() {
   local file="$1" name="$2" new_block="$3"
-  awk -v name="$name" -v new_block="$new_block" '
+  local block_file status
+  block_file=$(mktemp)
+  printf '%s\n' "$new_block" > "$block_file"
+  status=0
+  awk -v name="$name" -v block_file="$block_file" -v has_block="$([ -n "$new_block" ] && printf 1 || printf 0)" '
+    function print_block(  line) {
+      while ((getline line < block_file) > 0) {
+        print line
+      }
+      close(block_file)
+    }
     BEGIN {
       begin_marker = "    // BEGIN bridge:" name
       end_marker   = "    // END bridge:" name
@@ -364,8 +374,8 @@ _cli_channel_rewrite() {
     {
       if ($0 == begin_marker) {
         skipping = 1
-        if (new_block != "") {
-          print new_block
+        if (has_block == "1") {
+          print_block()
           inserted = 1
         }
         next
@@ -377,12 +387,14 @@ _cli_channel_rewrite() {
         next
       }
       if (!inserted && $0 == "    // END bridges") {
-        if (new_block != "") {
-          print new_block
+        if (has_block == "1") {
+          print_block()
           inserted = 1
         }
       }
       print
     }
-  ' "$file"
+  ' "$file" || status=$?
+  rm -f "$block_file"
+  return "$status"
 }

--- a/lib/runtime-signature.sh
+++ b/lib/runtime-signature.sh
@@ -348,7 +348,17 @@ _runtime_signature_block_matches() {
 # <new_block> removes the runtime's block entirely (used by unregister).
 _runtime_signature_rewrite() {
   local file="$1" runtime_id="$2" new_block="$3"
-  awk -v rid="$runtime_id" -v new_block="$new_block" '
+  local block_file status
+  block_file=$(mktemp)
+  printf '%s\n' "$new_block" > "$block_file"
+  status=0
+  awk -v rid="$runtime_id" -v block_file="$block_file" -v has_block="$([ -n "$new_block" ] && printf 1 || printf 0)" '
+    function print_block(  line) {
+      while ((getline line < block_file) > 0) {
+        print line
+      }
+      close(block_file)
+    }
     BEGIN {
       begin_marker = "    // BEGIN runtime:" rid
       end_marker   = "    // END runtime:" rid
@@ -358,8 +368,8 @@ _runtime_signature_rewrite() {
     {
       if ($0 == begin_marker) {
         skipping = 1
-        if (new_block != "") {
-          print new_block
+        if (has_block == "1") {
+          print_block()
           inserted = 1
         }
         next
@@ -371,12 +381,14 @@ _runtime_signature_rewrite() {
         next
       }
       if (!inserted && $0 == "    // END runtimes") {
-        if (new_block != "") {
-          print new_block
+        if (has_block == "1") {
+          print_block()
           inserted = 1
         }
       }
       print
     }
-  ' "$file"
+  ' "$file" || status=$?
+  rm -f "$block_file"
+  return "$status"
 }

--- a/tests/cli-channel-perms.sh
+++ b/tests/cli-channel-perms.sh
@@ -51,7 +51,11 @@ FAILED=0
 assert_mode_0644() {
   local file="$1" name="$2"
   local got
-  got=$(stat -c %a "$file")
+  if stat -c %a "$file" >/dev/null 2>&1; then
+    got=$(stat -c %a "$file")
+  else
+    got=$(stat -f %Lp "$file")
+  fi
   if [ "$got" = "644" ]; then
     echo "  ok   $name"
   else

--- a/tests/effective-prompt/README.md
+++ b/tests/effective-prompt/README.md
@@ -2,16 +2,22 @@
 
 Pluggable harness that renders the kimaki opencode system prompt, runs the
 `dm-context-filter` plugin over it, snapshots the result, and asserts that
-no banned `--agent` override examples leak into the filtered prompt that an
-opencode session actually sees.
+Data Machine-owned Kimaki policy sections do not leak into the filtered prompt
+that an opencode session actually sees.
 
 ## Why
 
-`dm-context-filter.ts` is a security-and-context plugin. It strips ~5,000
-tokens of kimaki-shipped instructions that conflict with Data Machine's
-memory and channel-bound agent model. When the filter has a bug,
+`dm-context-filter.ts` is a security-and-context plugin. It strips
+kimaki-shipped instructions that conflict with Data Machine's memory,
+scheduling, and managed WordPress runtime policy. When the filter has a bug,
 the leaked content is invisible until you go reading the system prompt by
 hand. This harness catches those leaks at test time.
+
+The harness models wp-coding-agents' managed Kimaki startup flags. In
+particular, services run with `--no-critique`, so critique instructions should
+be absent before `dm-context-filter` runs. Kimaki 0.13 also falls back to the
+build agent when a requested agent does not exist, so generic `--agent
+<current_agent>` guidance is no longer treated as a filter leak.
 
 ## Run it
 
@@ -48,9 +54,13 @@ Each scenario is a JSON file in `scenarios/`. Override any of:
 - **`filter`** — name from `filters.mjs`. Default `"current"`.
 - **`baseline`** — name from `filters.mjs`. Default
   `"broken-stripsection"` (kept as diff evidence for reviewers).
+- **`critiqueEnabled`** — boolean passed into Kimaki's prompt store before
+  rendering. Defaults to `false` to match the managed `--no-critique` service
+  configuration.
 - **`triggers`** — array of `{ name, pattern }`. Pattern is a JS regex
-  string; prefix with `(?i)` for case-insensitive. Default: `--agent`, which
-  catches generic Kimaki agent override examples.
+  string; prefix with `(?i)` for case-insensitive. Defaults catch the headings
+  that Data Machine still intentionally filters: permissions, Kimaki upgrades,
+  Kimaki scheduling, dev-server tunnels, and cross-session history.
 - **`allowLeakInSection`** — array of section headings (e.g. `"## Minion
   Session Routing"`) where trigger matches are intentional and must not
   count as leaks.

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -25,6 +25,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -62,7 +78,7 @@ kimaki project list --json  # machine-readable output
 # Or use --project to resolve from directory
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 Use cases:
@@ -72,7 +88,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
 
 # Wait for a session that was already started elsewhere
 kimaki session wait <session_id>
@@ -87,57 +103,6 @@ Use `--wait` when you need to:
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 # Start the dev server in a named background session
 bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -25,6 +25,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -52,9 +68,10 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:
@@ -65,31 +82,31 @@ Before sending, choose the right destination:
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt 'follow-up prompt'
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt 'follow-up prompt'
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user '<discord-user-id>'
 
 Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --user '<discord-user-id>'
 
 Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
 
-kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --user '<discord-user-id>'
 
 Use --cwd to start a session in an existing project subfolder or git worktree directory:
 
-kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 
 Important:
 - NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
@@ -98,9 +115,30 @@ Important:
 - Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
 - Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
 
+Use --agent to specify which agent to use for the session:
+
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --user '<discord-user-id>'
+
 Available agents:
 - `build`: default coding agent
 - `plan`: planning agent
+
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
 
 ## creating worktrees
 
@@ -109,7 +147,7 @@ ONLY create worktrees when the user explicitly asks for one. Never proactively u
 When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --user '<discord-user-id>'
 ```
 
 This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
@@ -125,7 +163,7 @@ Critical recursion guard:
 Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
@@ -139,7 +177,7 @@ This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
 When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
@@ -172,13 +210,13 @@ To send a task to another project:
 
 ```bash
 # Send to a specific channel
-kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2'
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
 
 # Or use --project to resolve from directory
-kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0'
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
@@ -188,48 +226,39 @@ Use cases:
 - **Coordinating changes** across related repos (e.g., SDK + docs)
 - **Delegating subtasks** to isolated sessions in other projects
 
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
+# Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait --agent <current_agent>
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
 
 ## markdown formatting
 

--- a/tests/effective-prompt/__snapshots__/default.raw.txt
+++ b/tests/effective-prompt/__snapshots__/default.raw.txt
@@ -44,6 +44,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -348,117 +364,6 @@ Use `--wait` when you need to:
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
 
-
-## showing diffs
-
-IMPORTANT: After editing any files, you MUST execute the critique command using the Bash tool to get a diff URL, then share that URL with the user.
-IMPORTANT: The user cannot see tool results directly. If critique prints a URL in the Bash tool output, you MUST copy that URL into your final message yourself.
-IMPORTANT: When the user asks to see a diff, show a diff, or review changes, ALWAYS use critique to generate a web URL instead of showing raw git diff output.
-
-Typical usage examples:
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### always show diff at end of session
-
-If you edited any files during the current session, you MUST run `bunx critique --web` at the end of your final message to generate a diff URL and share it with the user. This applies even if the user did not ask to see a diff — always show what changed. Pass the file paths you edited as `--filter` arguments so the diff only includes your changes. Skip this only if the session was purely read-only (no file edits, no writes).
-The final user-facing message must include the actual critique URL as plain text or markdown link, because the user cannot see the Bash tool output.
-
-Example — if you edited `src/config.ts` and `src/utils.ts`:
-
-```bash
-bunx critique --web "Short title describing the changes" --filter "src/config.ts" --filter "src/utils.ts"
-```
-
-The string after `--web` becomes the diff page title — make it reflect what the changes do (e.g. "Add retry logic to API client", "Fix auth timeout bug").
-
-### fetching user comments from critique diffs
-
-Users can add line-level comments (annotations) on any critique diff page via the Agentation widget (bottom-right corner of the diff page). To read those comments:
-
-```bash
-curl https://critique.work/v/<id>/annotations
-```
-
-Returns `text/markdown` with each annotation showing the file, line, and comment text.
-Use this when the user says they left comments on a critique diff and you need to read them.
-You can also use WebFetch on `https://critique.work/v/<id>/annotations` to get the markdown directly.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
-
-### reviewing diffs with AI
-
-`bunx critique review --web` generates an AI-powered review of a diff and uploads it as a shareable URL.
-It spawns a separate opencode session that analyzes the diff, groups related changes, and produces
-a structured review with explanations, diagrams, and suggestions. This is useful when the user
-asks you to explain or review a diff — the output is much richer than a plain diff URL.
-
-**WARNING: This command is very slow (up to 20 minutes for large diffs).** Only run it when the
-user explicitly asks for a code review or diff explanation. Always warn the user it will take
-a while before running it. Set Bash tool timeout to at least 25 minutes (`timeout: 1_500_000`).
-
-Always pass `--agent opencode` and `--session ses_EFFECTIVE_PROMPT_TEST` so the reviewer has context about
-why the changes were made. If you know other session IDs that produced the diff (e.g. from
-`kimaki session list` or from the thread history), pass them too with additional `--session` flags.
-
-Examples:
-
-```bash
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_EFFECTIVE_PROMPT_TEST --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 
 ## running dev servers with tunnel access

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -23,6 +23,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -60,7 +76,7 @@ kimaki project list --json  # machine-readable output
 # Or use --project to resolve from directory
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 Use cases:
@@ -70,7 +86,7 @@ Use cases:
 # Start a session and wait for it to finish
 
 # Send to an existing thread and wait
-kimaki send --thread <thread_id> --prompt 'Run the tests' --wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
 
 # Wait for a session that was already started elsewhere
 kimaki session wait <session_id>
@@ -85,57 +101,6 @@ Use `--wait` when you need to:
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_MINIMAL
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_MINIMAL
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_MINIMAL --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_MINIMAL --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 # Start the dev server in a named background session
 bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -23,6 +23,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -50,9 +66,10 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 
 To start a new thread/session in this channel pro-grammatically, run:
 
-kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
 
 You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:
@@ -63,31 +80,31 @@ Before sending, choose the right destination:
 
 To send a prompt to an existing thread instead of creating a new one:
 
-kimaki send --thread <thread_id> --prompt 'follow-up prompt'
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you already have the Discord thread ID.
 
 To send to the thread associated with a known session:
 
-kimaki send --session <session_id> --prompt 'follow-up prompt'
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
 
 Use this when you have the OpenCode session ID.
 
 Use --notify-only to create a notification thread without starting an AI session:
 
-kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user '<discord-user-id>'
 
 Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
 
-kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --user '<discord-user-id>'
 
 Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
 
-kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --user '<discord-user-id>'
 
 Use --cwd to start a session in an existing project subfolder or git worktree directory:
 
-kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 
 Important:
 - NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
@@ -96,6 +113,27 @@ Important:
 - Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
 - Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
 
+Use --agent to specify which agent to use for the session:
+
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --user '<discord-user-id>'
+
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
+
 ## creating worktrees
 
 ONLY create worktrees when the user explicitly asks for one. Never proactively use `--worktree` for normal tasks.
@@ -103,7 +141,7 @@ ONLY create worktrees when the user explicitly asks for one. Never proactively u
 When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --user '<discord-user-id>'
 ```
 
 This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
@@ -119,7 +157,7 @@ Critical recursion guard:
 Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
@@ -133,7 +171,7 @@ This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
 When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
 
 ```bash
-kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --user '<discord-user-id>'
 ```
 
 The command automatically handles long prompts (over 2000 chars) by sending them as file attachments.
@@ -166,13 +204,13 @@ To send a task to another project:
 
 ```bash
 # Send to a specific channel
-kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2'
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
 
 # Or use --project to resolve from directory
-kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0'
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
 
 # Or use --cwd for an existing checkout/worktree path
-kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout'
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
 ```
 
 When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
@@ -182,48 +220,39 @@ Use cases:
 - **Coordinating changes** across related repos (e.g., SDK + docs)
 - **Delegating subtasks** to isolated sessions in other projects
 
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
+# Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait --agent <current_agent>
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
 ## submodules
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
 
 ## markdown formatting
 

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
@@ -42,6 +42,22 @@ To upload files to the Discord thread (images, screenshots, long files that woul
 
 kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
 
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
 ## requesting files from the user
 
 To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
@@ -342,117 +358,6 @@ Use `--wait` when you need to:
 
 When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
 
-
-## showing diffs
-
-IMPORTANT: After editing any files, you MUST execute the critique command using the Bash tool to get a diff URL, then share that URL with the user.
-IMPORTANT: The user cannot see tool results directly. If critique prints a URL in the Bash tool output, you MUST copy that URL into your final message yourself.
-IMPORTANT: When the user asks to see a diff, show a diff, or review changes, ALWAYS use critique to generate a web URL instead of showing raw git diff output.
-
-Typical usage examples:
-
-# Share working tree changes
-bunx critique --web "Describe pending changes"
-
-# Share staged changes
-bunx critique --staged --web "Describe staged changes"
-
-# Share changes since base branch (use when you're on a feature branch)
-bunx critique main --web "Describe branch changes"
-
-# Share new-branch changes compared to main
-bunx critique main...new-branch --web "Describe branch changes"
-
-# Share a single commit
-bunx critique --commit HEAD --web "Describe latest commit"
-
-If the user asks to see a diff and you already committed the changes, prefer showing a separate diff URL for each commit instead of one unified diff. Run one `bunx critique --commit <hash> --web` per commit so each change is clearly scoped. Run all the critique calls in parallel tool calls.
-
-If there are other unrelated changes in the working directory, filter to only show the files you edited:
-
-# Share only specific files
-bunx critique --web "Fix database connection retry" --filter "path/to/file1.ts" --filter "path/to/file2.ts"
-
-Do this in case you committed the changes yourself (only if the user asks so, never commit otherwise).
-
-To compare two branches:
-
-bunx critique main feature-branch --web "Compare branches"
-
-The command outputs a URL - share that URL with the user so they can see the diff.
-
-### always show diff at end of session
-
-If you edited any files during the current session, you MUST run `bunx critique --web` at the end of your final message to generate a diff URL and share it with the user. This applies even if the user did not ask to see a diff — always show what changed. Pass the file paths you edited as `--filter` arguments so the diff only includes your changes. Skip this only if the session was purely read-only (no file edits, no writes).
-The final user-facing message must include the actual critique URL as plain text or markdown link, because the user cannot see the Bash tool output.
-
-Example — if you edited `src/config.ts` and `src/utils.ts`:
-
-```bash
-bunx critique --web "Short title describing the changes" --filter "src/config.ts" --filter "src/utils.ts"
-```
-
-The string after `--web` becomes the diff page title — make it reflect what the changes do (e.g. "Add retry logic to API client", "Fix auth timeout bug").
-
-### fetching user comments from critique diffs
-
-Users can add line-level comments (annotations) on any critique diff page via the Agentation widget (bottom-right corner of the diff page). To read those comments:
-
-```bash
-curl https://critique.work/v/<id>/annotations
-```
-
-Returns `text/markdown` with each annotation showing the file, line, and comment text.
-Use this when the user says they left comments on a critique diff and you need to read them.
-You can also use WebFetch on `https://critique.work/v/<id>/annotations` to get the markdown directly.
-
-### about critique
-
-critique is an open source tool (MIT license) at https://github.com/remorses/critique.
-Each diff URL is unique and unguessable, only the person who created it can share it.
-No code is stored permanently, diffs are ephemeral. The tool and website are fully open source.
-If the user asks about critique or expresses concern about their code being uploaded,
-reassure them: their data is safe, URLs are unique and not indexed, and they can disable
-this feature by restarting kimaki with the `--no-critique` flag.
-
-### reviewing diffs with AI
-
-`bunx critique review --web` generates an AI-powered review of a diff and uploads it as a shareable URL.
-It spawns a separate opencode session that analyzes the diff, groups related changes, and produces
-a structured review with explanations, diagrams, and suggestions. This is useful when the user
-asks you to explain or review a diff — the output is much richer than a plain diff URL.
-
-**WARNING: This command is very slow (up to 20 minutes for large diffs).** Only run it when the
-user explicitly asks for a code review or diff explanation. Always warn the user it will take
-a while before running it. Set Bash tool timeout to at least 25 minutes (`timeout: 1_500_000`).
-
-Always pass `--agent opencode` and `--session ses_MINIMAL` so the reviewer has context about
-why the changes were made. If you know other session IDs that produced the diff (e.g. from
-`kimaki session list` or from the thread history), pass them too with additional `--session` flags.
-
-Examples:
-
-```bash
-# Review working tree changes
-bunx critique review --web --agent opencode --session ses_MINIMAL
-
-# Review staged changes
-bunx critique review --staged --web --agent opencode --session ses_MINIMAL
-
-# Review a specific commit
-bunx critique review --commit HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review branch changes compared to main
-bunx critique review main...HEAD --web --agent opencode --session ses_MINIMAL
-
-# Review with multiple session contexts (current + the session that made the changes)
-bunx critique review --commit abc1234 --web --agent opencode --session ses_MINIMAL --session ses_other_session_id
-
-# Review only specific files
-bunx critique review --web --agent opencode --session ses_MINIMAL --filter "src/**/*.ts"
-```
-
-The command prints a preview URL when done — share that URL with the user.
 
 
 ## running dev servers with tunnel access

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -71,14 +71,6 @@ function stripProjectDiscoveryInlines(block) {
   return result
 }
 
-function stripAgentOverrideInlines(block) {
-  let result = block
-  result = result.replace(/\n+Prefer passing the current agent with `--agent <current_agent>`[^\n]*\n/g, "\n")
-  result = result.replace(/\n+Use --agent to specify which agent to use for the session:[\s\S]*?\nkimaki send --channel [^\n]* --agent [^\n]*\n/g, "\n")
-  result = result.replace(/ --agent <current_agent>/g, "")
-  return result
-}
-
 function appendDataMachineSessionHandoffInstruction(block) {
   const instruction = `
 
@@ -158,7 +150,6 @@ function brokenFilter(block) {
   r = stripSectionBroken(r, "### reviewing diffs with AI")
   r = stripWorktreeInlines(r)
   r = stripProjectDiscoveryInlines(r)
-  r = stripAgentOverrideInlines(r)
   r = r.replace(/\n{3,}/g, "\n\n")
   r = appendWordPressSiteRuntimeInstruction(r)
   r = appendDataMachineSessionHandoffInstruction(r)

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -27,8 +27,8 @@
 //     "broken-stripsection" (the regex-only stripSection that misfires
 //     on fenced bash comments). The harness keeps baseline output available
 //     as diff evidence, but leak detection is the correctness gate.
-//   - triggers: array of { name, pattern }. Default: --agent override
-//     examples that bypass the Data Machine-bound agent slot.
+//   - triggers: array of { name, pattern }. Defaults to Data Machine-owned
+//     Kimaki policy sections that must not survive the filter.
 //     Lines matching any trigger in the filtered output count as leaks.
 //   - allowLeakInSection: array of section headings where trigger
 //     matches are intentional (e.g. the appended Minion Routing note
@@ -55,6 +55,7 @@ const SNAPSHOT_DIR = join(__dirname, "__snapshots__")
 const SCENARIO_DIR = join(__dirname, "scenarios")
 const KIMAKI_DIST_DIR = process.env.KIMAKI_DIST_DIR || join(execSync("npm root -g", { encoding: "utf8" }).trim(), "kimaki", "dist")
 const { getOpencodeSystemMessage } = await import(pathToFileURL(join(KIMAKI_DIST_DIR, "system-message.js")).href)
+const { store } = await import(pathToFileURL(join(KIMAKI_DIST_DIR, "store.js")).href)
 
 if (!existsSync(SNAPSHOT_DIR)) mkdirSync(SNAPSHOT_DIR, { recursive: true })
 
@@ -74,7 +75,11 @@ const VERBOSE = args.includes("--verbose")
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TRIGGERS = [
-  { name: "--agent",         pattern: "--agent"                  },
+  { name: "permissions",     pattern: "^## permissions$"                         },
+  { name: "upgrade",         pattern: "^## upgrading kimaki$"                    },
+  { name: "scheduler",       pattern: "^## scheduled sends and task management$" },
+  { name: "site-runtime",    pattern: "^## running dev servers with tunnel access$" },
+  { name: "session-history", pattern: "^## reading other sessions$"              },
 ]
 
 // The filter is strip-only — it never appends sections. Any trigger word
@@ -96,6 +101,9 @@ const DEFAULT_SCENARIO = {
     ],
     username: "chubes",
   },
+  // wp-coding-agents managed Kimaki services run with --no-critique, so the
+  // effective prompt harness should exercise that managed startup contract.
+  critiqueEnabled: false,
   filter: "current",
   baseline: "broken-stripsection",
   triggers: DEFAULT_TRIGGERS,
@@ -193,7 +201,16 @@ async function runScenario(name, scenario) {
   const baselineFn = filters[scenario.baseline]
   if (!baselineFn) throw new Error(`scenario ${name}: unknown baseline "${scenario.baseline}"`)
 
-  const raw = getOpencodeSystemMessage(scenario.args)
+  const previousCritiqueEnabled = store.getState().critiqueEnabled
+  let raw
+  try {
+    if (typeof scenario.critiqueEnabled === "boolean") {
+      store.setState({ critiqueEnabled: scenario.critiqueEnabled })
+    }
+    raw = getOpencodeSystemMessage(scenario.args)
+  } finally {
+    store.setState({ critiqueEnabled: previousCritiqueEnabled })
+  }
   const baselineOut = await baselineFn(raw)
   const filteredOut = await filterFn(raw)
 

--- a/tests/runtime-signature.sh
+++ b/tests/runtime-signature.sh
@@ -86,7 +86,11 @@ assert_php_lint() {
 assert_mode_0644() {
   local file="$1" name="$2"
   local got
-  got=$(stat -c %a "$file")
+  if stat -c %a "$file" >/dev/null 2>&1; then
+    got=$(stat -c %a "$file")
+  else
+    got=$(stat -f %Lp "$file")
+  fi
   if [ "$got" = "644" ]; then
     echo "  ok   $name"
   else
@@ -119,10 +123,18 @@ fi
 
 # --- 2. Idempotency --------------------------------------------------------
 echo "==> re-register kimaki with same signature (idempotent)"
-HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)
+if command -v md5sum >/dev/null 2>&1; then
+  HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)
+else
+  HASH_BEFORE=$(md5 -q "$MU_FILE")
+fi
 runtime_signature_register "kimaki" \
   '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
-HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
+if command -v md5sum >/dev/null 2>&1; then
+  HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
+else
+  HASH_AFTER=$(md5 -q "$MU_FILE")
+fi
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-register"
 
 # --- 3. Add opencode without disturbing kimaki -----------------------------


### PR DESCRIPTION
## Summary
- Refresh `dm-context-filter` for the Kimaki 0.13 prompt shape.
- Stop stripping generic `--agent <current_agent>` guidance; Kimaki 0.13 now falls back to the default build agent when a requested agent does not exist.
- Treat critique instructions as managed by startup flags (`--no-critique`) instead of filter surgery, and document the sections that remain intentionally filtered.
- Make the effective-prompt harness model the managed `--no-critique` service contract and refresh snapshots against Kimaki 0.13.
- Fix the mu-plugin marker rewrite helpers so multiline blocks are portable on macOS `awk`, and make affected tests portable across GNU/BSD `stat` and checksum tools.

Closes #143.

## Verification
- `KIMAKI_DIST_DIR="/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/kimaki-0.13-harness/node_modules/kimaki/dist" node tests/effective-prompt/run.mjs`
- `for t in tests/*.sh; do printf '==> %s\n' "$t"; bash "$t"; done`
- Verified Kimaki 0.13 fallback in package source: `dist/session-handler/agent-utils.js` falls back to the default agent when a requested agent is absent.

## Notes
- Issue #145 was read and its Kimaki 0.13 fallback clarification is incorporated here for prompt filtering. This PR does not remove the `datamachine-kimaki` adapter shim; it only stops using prompt filtering as compensation for the old fallback behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the code/test/doc changes, refreshing snapshots, running local verification, and preparing this PR body. Chris remains responsible for review and merge.
