### PR TITLE
Fix runtime attribution env signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,9 +423,9 @@ After this, the only outbound message path is `agents/dispatch-message` → DMC 
 
 ## Worktree Session Attribution (Runtime Signatures)
 
-When a coding-agent session asks Data Machine Code to create a worktree, DMC captures **origin-session metadata** so the worktree carries a breadcrumb back to the session that spawned it (Discord thread URL, opencode session ID, run ID, etc.). DMC reads that metadata from environment variables the runtime sets on the worktree-creating process.
+When a coding-agent session asks Data Machine Code to create a worktree, DMC captures **origin-session metadata** so the worktree carries a breadcrumb back to the runtime that spawned it. DMC reads that metadata from environment variables the runtime sets on the worktree-creating process.
 
-The env-var names are vendor-specific (`KIMAKI_SESSION_ID`, `OPENCODE_SESSION_ID`, `OPENCODE_RUN_ID`, …) so DMC cannot enumerate them without knowing about kimaki and opencode — a layer-purity violation per the platform's coding rules. The fix (Extra-Chill/data-machine-code#416) moves the env-var → field map out of DMC into a filter:
+The env-var names are vendor-specific (`OPENCODE_RUN_ID`, etc.) so DMC cannot enumerate them without knowing about opencode or any other runtime — a layer-purity violation per the platform's coding rules. The fix (Extra-Chill/data-machine-code#416) moves the env-var → field map out of DMC into a filter:
 
 ```php
 apply_filters( 'datamachine_code_worktree_runtime_signatures', [] );
@@ -444,29 +444,20 @@ $WP_PATH/wp-content/mu-plugins/wp-coding-agents-runtimes.php
 The file is owned end-to-end by wp-coding-agents installers: created on first registration, each runtime contributes a marker-delimited block (`// BEGIN runtime:<id>` … `// END runtime:<id>`), and the same install path can rewrite or remove its block idempotently. The file registers entries via the filter:
 
 ```php
-$signatures['kimaki'] = [
-    'session_id' => 'KIMAKI_SESSION_ID',
-    'thread_id'  => 'KIMAKI_THREAD_ID',
-    'thread_url' => 'KIMAKI_THREAD_URL',
-];
-
 $signatures['opencode'] = [
-    'session_id' => 'OPENCODE_SESSION_ID',
-    'run_id'     => 'OPENCODE_RUN_ID',
+    'run_id' => 'OPENCODE_RUN_ID',
 ];
 ```
 
 DMC reads the map, walks each runtime's subkeys, and sniffs the named env vars at worktree-create time. The subkey set is open — DMC does not validate against a closed schema. Conventional subkeys are `session_id`, `thread_id`, `thread_url`, `run_id`; integrations may add more.
 
+Kimaki 0.13 does not currently export stable session/thread attribution env vars such as `KIMAKI_SESSION_ID`, `KIMAKI_THREAD_ID`, or `KIMAKI_THREAD_URL` to OpenCode/tool subprocesses. OpenCode source and a live Kimaki/OpenCode runtime smoke show `OPENCODE_RUN_ID`, but not `OPENCODE_SESSION_ID`. Rich Discord thread attribution is tracked upstream in https://github.com/remorses/kimaki/issues/137; until Kimaki ships a documented contract, wp-coding-agents registers only the env vars that actually exist.
+
 ### Registered signatures
 
 | Runtime ID  | Subkey       | Env var                | What it identifies                                  |
 |-------------|--------------|------------------------|-----------------------------------------------------|
-| `kimaki`    | `session_id` | `KIMAKI_SESSION_ID`    | Kimaki session (1:1 with a Discord thread)          |
-| `kimaki`    | `thread_id`  | `KIMAKI_THREAD_ID`     | Discord thread the session lives in                 |
-| `kimaki`    | `thread_url` | `KIMAKI_THREAD_URL`    | Deep link to that Discord thread                    |
-| `opencode`  | `session_id` | `OPENCODE_SESSION_ID`  | opencode session inside the kimaki/opencode runtime |
-| `opencode`  | `run_id`     | `OPENCODE_RUN_ID`      | Specific opencode run within that session           |
+| `opencode`  | `run_id`     | `OPENCODE_RUN_ID`      | Specific OpenCode run in the current process tree   |
 
 Adding a new runtime is a one-liner: register a new block in the relevant `runtimes/<name>.sh` or `bridges/<name>.sh` via `runtime_signature_register <runtime_id> <signature_json>` (see `lib/runtime-signature.sh`).
 

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -91,22 +91,17 @@ _kimaki_register_cli_channel() {
 
 # _kimaki_register_runtime_signature
 #
-# Publish kimaki's worktree session-attribution env-var contract for the Data
-# Machine Code worktree-attribution code (Extra-Chill/data-machine-code#416).
-# kimaki sets KIMAKI_SESSION_ID, KIMAKI_THREAD_ID, and KIMAKI_THREAD_URL on
-# the opencode-serve children it spawns (see Kimaki source). DMC reads those
-# env vars at worktree-create time to record which kimaki session originated
-# the worktree, what Discord thread the session lives in, and the deep link
-# to that thread.
-#
-# The registration is data, not config: the runtime ID 'kimaki' is what
-# wp-coding-agents *calls* the runtime here, and the env-var names are what
-# the kimaki binary actually sets. DMC stays naive — it doesn't know kimaki
-# exists; it just sniffs whatever env vars the filter map tells it to.
+# Kimaki 0.13 does not currently export stable session/thread attribution env
+# vars to OpenCode/tool subprocesses. Keep this hook so upgrades remove stale
+# Kimaki runtime-signature blocks from previous wp-coding-agents releases.
+# Rich Discord thread attribution needs upstream Kimaki support first:
+# https://github.com/remorses/kimaki/issues/137
 _kimaki_register_runtime_signature() {
-  runtime_signature_register \
-    "kimaki" \
-    '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+  if ! declare -F runtime_signature_unregister >/dev/null; then
+    return 0
+  fi
+
+  runtime_signature_unregister "kimaki"
 }
 
 _kimaki_sync_bin_helpers() {

--- a/lib/runtime-signature.sh
+++ b/lib/runtime-signature.sh
@@ -5,7 +5,7 @@
 # Data Machine Code's worktree-attribution code captures "origin session"
 # metadata when an agent spawns a worktree. Historically DMC hardcoded the
 # env-var → field map for each coding-agent runtime it knew about
-# (KIMAKI_SESSION_ID → kimaki_session_id, OPENCODE_RUN_ID → opencode_run_id,
+# (OPENCODE_RUN_ID → opencode_run_id,
 # etc.). Per the platform's layer-purity rule, those vendor names do not
 # belong in DMC — DMC is runtime-agnostic substrate.
 #
@@ -58,7 +58,7 @@
 #   runtime_signature_unregister <runtime_id>
 #
 # `signature_json` is a JSON object mapping subkey → env-var name, e.g.:
-#   '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+#   '{"run_id":"OPENCODE_RUN_ID"}'
 #
 # Honors DRY_RUN (logs intent, makes no changes).
 
@@ -200,8 +200,8 @@ _runtime_signature_php_escape() {
 
 # _runtime_signature_json_to_php_map <json_object_literal>
 #
-# Convert a JSON object like {"session_id":"KIMAKI_SESSION_ID",...} into a
-# PHP associative array literal [ 'session_id' => 'KIMAKI_SESSION_ID', ... ].
+# Convert a JSON object like {"run_id":"OPENCODE_RUN_ID"} into a
+# PHP associative array literal [ 'run_id' => 'OPENCODE_RUN_ID' ].
 # Uses python3 (every host that runs wp-coding-agents already depends on
 # python3 — see lib/repair-opencode-json.py and runtimes/opencode.sh).
 # Keys are emitted in the order they appear in the JSON for stable diffs.
@@ -348,35 +348,42 @@ _runtime_signature_block_matches() {
 # <new_block> removes the runtime's block entirely (used by unregister).
 _runtime_signature_rewrite() {
   local file="$1" runtime_id="$2" new_block="$3"
-  awk -v rid="$runtime_id" -v new_block="$new_block" '
-    BEGIN {
-      begin_marker = "    // BEGIN runtime:" rid
-      end_marker   = "    // END runtime:" rid
-      inserted = 0
-      skipping = 0
-    }
-    {
-      if ($0 == begin_marker) {
-        skipping = 1
-        if (new_block != "") {
-          print new_block
-          inserted = 1
-        }
-        next
-      }
-      if (skipping) {
-        if ($0 == end_marker) {
-          skipping = 0
-        }
-        next
-      }
-      if (!inserted && $0 == "    // END runtimes") {
-        if (new_block != "") {
-          print new_block
-          inserted = 1
-        }
-      }
-      print
-    }
-  ' "$file"
+  RUNTIME_SIGNATURE_NEW_BLOCK="$new_block" python3 - "$file" "$runtime_id" <<'PY'
+import os, sys
+
+file_path, runtime_id = sys.argv[1], sys.argv[2]
+new_block = os.environ.get("RUNTIME_SIGNATURE_NEW_BLOCK", "")
+begin_marker = f"    // BEGIN runtime:{runtime_id}"
+end_marker = f"    // END runtime:{runtime_id}"
+
+with open(file_path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+inserted = False
+skipping = False
+out = []
+
+for line in lines:
+    if line == begin_marker:
+        skipping = True
+        if new_block:
+            out.extend(new_block.splitlines())
+            inserted = True
+        continue
+
+    if skipping:
+        if line == end_marker:
+            skipping = False
+        continue
+
+    if not inserted and line == "    // END runtimes":
+        if new_block:
+            out.extend(new_block.splitlines())
+            inserted = True
+
+    out.append(line)
+
+sys.stdout.write("\n".join(out))
+sys.stdout.write("\n")
+PY
 }

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -18,9 +18,9 @@ runtime_install() {
 #
 # Publish opencode's worktree session-attribution env-var contract for the
 # Data Machine Code worktree-attribution code (Extra-Chill/data-machine-code#416).
-# opencode sets OPENCODE_SESSION_ID and OPENCODE_RUN_ID on processes it
-# spawns; DMC reads those at worktree-create time to record which opencode
-# session/run originated the worktree.
+# OpenCode sets OPENCODE_RUN_ID on worker/tool processes. Source review and a
+# live Kimaki/OpenCode 0.13 smoke did not find OPENCODE_SESSION_ID, so only the
+# real exported run identifier is registered here.
 #
 # Registered from runtime_install (setup-time) and from the legacy-wrapper-
 # removal phase in upgrade.sh, which is the upgrade-time entry point that
@@ -37,7 +37,7 @@ _opencode_register_runtime_signature() {
   fi
   runtime_signature_register \
     "opencode" \
-    '{"session_id":"OPENCODE_SESSION_ID","run_id":"OPENCODE_RUN_ID"}'
+    '{"run_id":"OPENCODE_RUN_ID"}'
 }
 
 # Remove any legacy wp-coding-agents-opencode-wrapper-v2 bash shim that prior

--- a/tests/runtime-signature.sh
+++ b/tests/runtime-signature.sh
@@ -83,10 +83,26 @@ assert_php_lint() {
   fi
 }
 
+file_hash() {
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$1" | cut -d' ' -f1
+  else
+    md5 -q "$1"
+  fi
+}
+
+file_mode() {
+  if stat -c %a "$1" >/dev/null 2>&1; then
+    stat -c %a "$1"
+  else
+    stat -f %Lp "$1"
+  fi
+}
+
 assert_mode_0644() {
   local file="$1" name="$2"
   local got
-  got=$(stat -c %a "$file")
+  got=$(file_mode "$file")
   if [ "$got" = "644" ]; then
     echo "  ok   $name"
   else
@@ -97,41 +113,41 @@ assert_mode_0644() {
   fi
 }
 
-# --- 1. Fresh scaffold + register kimaki -----------------------------------
+# --- 1. Fresh scaffold + register opencode ---------------------------------
 # Use a hostile umask (matches root cron/systemd default 0077) to prove the
 # helper forces 0644 regardless of caller umask — see issue #133.
-echo "==> register kimaki (fresh scaffold, umask 077)"
+echo "==> register opencode (fresh scaffold, umask 077)"
 (
   umask 077
-  runtime_signature_register "kimaki" \
-    '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
+  runtime_signature_register "opencode" \
+    '{"run_id":"OPENCODE_RUN_ID"}'
 )
 assert_file_exists "$MU_FILE" "mu-plugin created"
 assert_php_lint "$MU_FILE" "scaffold parses with php -l"
 assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after fresh write under umask 077"
 
-if grep -q "BEGIN runtime:kimaki" "$MU_FILE"; then
-  echo "  ok   kimaki block present"
+if grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
+  echo "  ok   opencode block present"
 else
-  echo "  FAIL kimaki block missing"
+  echo "  FAIL opencode block missing"
   FAILED=$((FAILED + 1))
 fi
 
 # --- 2. Idempotency --------------------------------------------------------
-echo "==> re-register kimaki with same signature (idempotent)"
-HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)
-runtime_signature_register "kimaki" \
-  '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
-HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
+echo "==> re-register opencode with same signature (idempotent)"
+HASH_BEFORE=$(file_hash "$MU_FILE")
+runtime_signature_register "opencode" \
+  '{"run_id":"OPENCODE_RUN_ID"}'
+HASH_AFTER=$(file_hash "$MU_FILE")
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-register"
 
-# --- 3. Add opencode without disturbing kimaki -----------------------------
+# --- 3. Add legacy kimaki without disturbing opencode -----------------------
 # Simulate a legacy 0600 file from a pre-#133 install. The next register call
 # must self-heal it back to 0644 via the mktemp+mv path.
 echo "==> simulate legacy 0600 file and verify self-heal on next register"
 chmod 0600 "$MU_FILE"
-runtime_signature_register "opencode" \
-  '{"session_id":"OPENCODE_SESSION_ID","run_id":"OPENCODE_RUN_ID"}'
+runtime_signature_register "kimaki" \
+  '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
 assert_php_lint "$MU_FILE" "two-runtime file parses with php -l"
 assert_mode_0644 "$MU_FILE" "mu-plugin mode self-healed to 0644 after sibling register"
 
@@ -142,36 +158,36 @@ else
   FAILED=$((FAILED + 1))
 fi
 
-# --- 4. Mutation: replace kimaki block, opencode untouched -----------------
-echo "==> re-register kimaki with mutated signature"
-runtime_signature_register "kimaki" \
-  '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL","run_id":"KIMAKI_RUN_ID"}'
-if grep -q "KIMAKI_RUN_ID" "$MU_FILE"; then
-  echo "  ok   kimaki block updated"
+# --- 4. Mutation: replace opencode block, kimaki untouched -----------------
+echo "==> re-register opencode with mutated signature"
+runtime_signature_register "opencode" \
+  '{"run_id":"OPENCODE_RUN_ID","process_role":"OPENCODE_PROCESS_ROLE"}'
+if grep -q "OPENCODE_PROCESS_ROLE" "$MU_FILE"; then
+  echo "  ok   opencode block updated"
 else
-  echo "  FAIL kimaki block did not pick up new subkey"
+  echo "  FAIL opencode block did not pick up new subkey"
   FAILED=$((FAILED + 1))
 fi
-if grep -q "OPENCODE_SESSION_ID" "$MU_FILE"; then
-  echo "  ok   opencode block preserved across kimaki mutation"
+if grep -q "KIMAKI_SESSION_ID" "$MU_FILE"; then
+  echo "  ok   kimaki block preserved across opencode mutation"
 else
-  echo "  FAIL opencode block clobbered by kimaki re-register"
+  echo "  FAIL kimaki block clobbered by opencode re-register"
   FAILED=$((FAILED + 1))
 fi
 
-# --- 5. Unregister opencode ------------------------------------------------
-echo "==> unregister opencode"
-runtime_signature_unregister "opencode"
-if grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
-  echo "  FAIL opencode block still present after unregister"
+# --- 5. Unregister stale kimaki --------------------------------------------
+echo "==> unregister kimaki"
+runtime_signature_unregister "kimaki"
+if grep -q "BEGIN runtime:kimaki" "$MU_FILE"; then
+  echo "  FAIL kimaki block still present after unregister"
   FAILED=$((FAILED + 1))
 else
-  echo "  ok   opencode block removed"
+  echo "  ok   kimaki block removed"
 fi
-if grep -q "BEGIN runtime:kimaki" "$MU_FILE"; then
-  echo "  ok   kimaki block preserved across opencode unregister"
+if grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
+  echo "  ok   opencode block preserved across kimaki unregister"
 else
-  echo "  FAIL kimaki block clobbered by opencode unregister"
+  echo "  FAIL opencode block clobbered by kimaki unregister"
   FAILED=$((FAILED + 1))
 fi
 assert_php_lint "$MU_FILE" "post-unregister file parses with php -l"
@@ -198,8 +214,8 @@ require '$MU_FILE';
 echo json_encode( \$result );
 PHP
 RESULT=$(php "$SHIM")
-EXPECTED='{"kimaki":{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL","run_id":"KIMAKI_RUN_ID"}}'
-assert_eq "$RESULT" "$EXPECTED" "filter returns surviving kimaki signature"
+EXPECTED='{"opencode":{"run_id":"OPENCODE_RUN_ID","process_role":"OPENCODE_PROCESS_ROLE"}}'
+assert_eq "$RESULT" "$EXPECTED" "filter returns surviving opencode signature"
 
 # --- Done ------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Summary
- Fixes #142.
- Removes the stale Kimaki runtime-signature registration because Kimaki 0.13 does not export `KIMAKI_SESSION_ID`, `KIMAKI_THREAD_ID`, or `KIMAKI_THREAD_URL` to OpenCode/tool subprocesses.
- Narrows the OpenCode runtime signature to the real exported `OPENCODE_RUN_ID`; source review and live smoke did not find `OPENCODE_SESSION_ID`.
- Documents upstream Kimaki follow-up for richer Discord attribution: https://github.com/remorses/kimaki/issues/137.
- Keeps runtime-specific names in wp-coding-agents, not Data Machine Code.

## Verification
- `./tests/runtime-signature.sh`
- `for f in **/*.sh(.); do bash -n "$f" || exit 1; done`
- `homeboy test --path /Users/chubes/Developer/wp-coding-agents@fix-runtime-signature-env --extension wordpress` reached plugin install/activation, then reported no PHPUnit files discovered for this repo.

## Evidence
- Kimaki source review: `cli/src/opencode.ts` exports operational process env such as `KIMAKI_DATA_DIR`, `KIMAKI_LOCK_PORT`, `KIMAKI_PARENT_LOCK_PORT`, and `KIMAKI_OPENCODE_PROCESS`, not session/thread attribution vars.
- OpenCode source review: `packages/opencode/src/util/opencode-process.ts` defines and ensures `OPENCODE_RUN_ID`; source search found no `OPENCODE_SESSION_ID`.
- Live Kimaki/OpenCode tool env smoke showed `OPENCODE_RUN_ID` present and no `OPENCODE_SESSION_ID`/`KIMAKI_SESSION_ID`/`KIMAKI_THREAD_ID`/`KIMAKI_THREAD_URL`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Source/runtime verification, patch drafting, tests, and PR preparation; Chris remains responsible for review and merge.
