### PR TITLE
fix(tests): normalize HOME paths in effective-prompt snapshots

### DIFF
--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -17,7 +17,7 @@ Per-turn Discord metadata like the current user and current agent is delivered i
 
 ## debugging kimaki issues
 
-If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
 
 ## uploading files to discord
 

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -17,7 +17,7 @@ Per-turn Discord metadata like the current user and current agent is delivered i
 
 ## debugging kimaki issues
 
-If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
 
 ## uploading files to discord
 

--- a/tests/effective-prompt/__snapshots__/default.raw.txt
+++ b/tests/effective-prompt/__snapshots__/default.raw.txt
@@ -36,7 +36,7 @@ Do not restart the bot unless the user explicitly asks for it.
 
 ## debugging kimaki issues
 
-If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
 
 ## uploading files to discord
 

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -15,7 +15,7 @@ Per-turn Discord metadata like the current user and current agent is delivered i
 
 ## debugging kimaki issues
 
-If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
 
 ## uploading files to discord
 

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -15,7 +15,7 @@ Per-turn Discord metadata like the current user and current agent is delivered i
 
 ## debugging kimaki issues
 
-If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
 
 ## uploading files to discord
 

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
@@ -34,7 +34,7 @@ Do not restart the bot unless the user explicitly asks for it.
 
 ## debugging kimaki issues
 
-If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `/Users/chubes/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
 
 ## uploading files to discord
 

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -46,6 +46,7 @@ import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, unlink
 import { execSync } from "node:child_process"
 import { dirname, join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
+import { homedir } from "node:os"
 
 import { filters } from "./filters.mjs"
 
@@ -162,6 +163,37 @@ function detectLeaks(text, triggers, allowSections) {
 }
 
 // ---------------------------------------------------------------------------
+// HOME normalization.
+//
+// Kimaki's live system prompt interpolates the local $HOME into a few
+// instructions (e.g. the "debugging kimaki issues" log path
+// `<home>/.kimaki/kimaki.log`). Without canonicalizing those paths, the
+// committed snapshots are pinned to whatever home the author rendered them
+// on, and the test fails with spurious "snapshot drift" on every other
+// machine (every VPS: /home/<user>, /root; every other contributor's Mac).
+//
+// We replace the local home dir — and the common system home roots — with a
+// stable `$HOME` token before snapshotting, leak detection, and diffing, so
+// the test asserts on prompt *content*, not host identity.
+// ---------------------------------------------------------------------------
+
+function normalizeHome(text) {
+  if (typeof text !== "string") return text
+  let out = text
+  const home = homedir()
+  if (home && home !== "/") {
+    out = out.split(home).join("$HOME")
+  }
+  // Catch home-dir paths that don't match the current process home (e.g. a
+  // snapshot rendered under a different account than the one running the
+  // test). These cover the platform-conventional home roots.
+  out = out.replace(/\/Users\/[^/\s`"']+/g, "$HOME")
+  out = out.replace(/\/home\/[^/\s`"']+/g, "$HOME")
+  out = out.replace(/\/root(?=\/\.kimaki\b)/g, "$HOME")
+  return out
+}
+
+// ---------------------------------------------------------------------------
 // Snapshot + diff.
 // ---------------------------------------------------------------------------
 
@@ -211,8 +243,14 @@ async function runScenario(name, scenario) {
   } finally {
     store.setState({ critiqueEnabled: previousCritiqueEnabled })
   }
-  const baselineOut = await baselineFn(raw)
-  const filteredOut = await filterFn(raw)
+  // Canonicalize host-specific home-dir paths before any snapshot, leak
+  // detection, or diff so the test is portable across machines. Filters run
+  // on the normalized prompt too — they only strip content sections, never
+  // home paths, so normalizing first keeps filter behavior identical while
+  // making the recorded raw snapshot host-independent.
+  raw = normalizeHome(raw)
+  const baselineOut = normalizeHome(await baselineFn(raw))
+  const filteredOut = normalizeHome(await filterFn(raw))
 
   const baselineLeaks = detectLeaks(baselineOut, scenario.triggers, scenario.allowLeakInSection)
   const filteredLeaks = detectLeaks(filteredOut, scenario.triggers, scenario.allowLeakInSection)


### PR DESCRIPTION
## Summary
- Adds `normalizeHome()` to `tests/effective-prompt/run.mjs`, replacing the local `$HOME` (and the conventional home roots `/Users/<user>`, `/home/<user>`, `/root/.kimaki`) with a stable `$HOME` token before snapshot write/compare, leak detection, and diff.
- Refreshes the committed snapshots to use the `$HOME` token.

## Why
Kimaki's live system prompt interpolates the local `$HOME` into the "debugging kimaki issues" log path (`<home>/.kimaki/kimaki.log`). The committed snapshots pinned the author's macOS home (`/Users/chubes`), so the effective-prompt regression test failed with spurious **"snapshot drift"** on every other machine — every VPS (`/home/opencode`, `/root`) and every other contributor's Mac — even though the real correctness gate (leak detection) passed with `leaks: 0`.

That noise defeats the test's purpose during upgrade: an operator who sees "snapshot drift" on every box learns to ignore it, so a genuine future regression (a newly leaked `--worktree`/cross-project section) hides in the same failure.

## Verification
```
node tests/effective-prompt/run.mjs            # OK — 2 scenario(s) passed
node tests/effective-prompt/run.mjs --update   # snapshots use $HOME token, host-independent
grep -rEn '/Users/[a-z]|/home/[a-z]' tests/effective-prompt/__snapshots__/   # none remain
```

Filters still run on the normalized prompt — they only strip content sections, never home paths — so filter behavior is unchanged.

Fixes #166