### PR TITLE
fix(homeboy): report attach-path results truthfully and resolve project id consistently

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -111,11 +111,10 @@ homeboy_project_id() {
     return 0
   fi
 
-  if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/homeboy.json" ]; then
-    return 1
-  fi
-
-  python3 - "$SITE_PATH/homeboy.json" <<'PY'
+  # Preferred: explicit project config at the site root.
+  if [ -n "${SITE_PATH:-}" ] && [ -f "$SITE_PATH/homeboy.json" ]; then
+    local id
+    id="$(python3 - "$SITE_PATH/homeboy.json" <<'PY'
 import json
 import sys
 
@@ -125,6 +124,51 @@ with open(sys.argv[1], encoding="utf-8") as handle:
 if project_id:
     print(project_id)
 PY
+)"
+    if [ -n "$id" ]; then
+      printf '%s\n' "$id"
+      return 0
+    fi
+  fi
+
+  # Fallback: resolve from Homeboy's own registered projects by matching the
+  # project domain to the WordPress site domain. This is the same project a
+  # `homeboy project show` / `attach-path` resolves from the site cwd, so the
+  # resolver here stays consistent with what the attach loop actually targets
+  # even when there is no homeboy.json at the site root.
+  if [ -n "${SITE_DOMAIN:-}" ] && command -v homeboy >/dev/null 2>&1; then
+    local project_list resolved
+    project_list="$(homeboy project list 2>/dev/null)"
+    if [ -n "$project_list" ]; then
+      # Pass the JSON via env var (not stdin) so it does not collide with the
+      # heredoc that supplies the python source on stdin.
+      resolved="$(HOMEBOY_PROJECT_LIST="$project_list" HOMEBOY_SITE_DOMAIN="$SITE_DOMAIN" python3 <<'PY'
+import json
+import os
+
+site_domain = os.environ.get("HOMEBOY_SITE_DOMAIN", "").strip().lower()
+
+try:
+    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_LIST", ""))
+except Exception:
+    payload = {}
+
+projects = payload.get("data", {}).get("projects", [])
+for project in projects:
+    domain = (project.get("domain") or "").strip().lower()
+    if domain and domain == site_domain and project.get("id"):
+        print(project["id"])
+        break
+PY
+)"
+      if [ -n "$resolved" ]; then
+        printf '%s\n' "$resolved"
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
 }
 
 sync_homeboy_project_components() {
@@ -191,15 +235,70 @@ sync_homeboy_project_components() {
       continue
     fi
 
-    if homeboy project components attach-path "$project_id" "$repo_path" >/dev/null; then
+    local attach_output attach_status
+    attach_output="$(homeboy project components attach-path "$project_id" "$repo_path" 2>&1)"
+    attach_status=$?
+
+    # Trust Homeboy's JSON `.success` field over the raw exit code: the CLI
+    # can print a success payload while still returning a non-zero status (or
+    # vice versa). Fall back to the exit code only when the output is not
+    # parseable JSON.
+    if homeboy_attach_succeeded "$attach_output" "$attach_status"; then
       log "  attached $repo_name"
       attached=$((attached + 1))
     else
       warn "  failed $repo_name: homeboy attach-path failed"
+      if [ -n "$attach_output" ]; then
+        warn "    $(printf '%s' "$attach_output" | head -n 3 | tr '\n' ' ')"
+      fi
       failed=$((failed + 1))
     fi
   done
   shopt -u nullglob
 
   log "Homeboy component sync complete: $attached attached, $skipped skipped, $failed failed"
+}
+
+# Decide whether a `homeboy ... attach-path` invocation succeeded. Prefers the
+# JSON `.success` field in the command output; falls back to the process exit
+# status when the output is not JSON (e.g. an early crash before any payload).
+homeboy_attach_succeeded() {
+  local output="$1"
+  local status="$2"
+
+  local verdict
+  # Pass the command output via env var (not stdin) so it does not collide
+  # with the heredoc that supplies the python source on stdin.
+  verdict="$(HOMEBOY_ATTACH_OUTPUT="$output" python3 <<'PY' 2>/dev/null
+import json
+import os
+
+raw = os.environ.get("HOMEBOY_ATTACH_OUTPUT", "").strip()
+if not raw:
+    print("nojson")
+    raise SystemExit(0)
+
+# Output may include leading log lines before the JSON object; isolate the
+# outermost JSON object if present.
+start = raw.find("{")
+end = raw.rfind("}")
+if start == -1 or end == -1 or end < start:
+    print("nojson")
+    raise SystemExit(0)
+
+try:
+    payload = json.loads(raw[start : end + 1])
+except Exception:
+    print("nojson")
+    raise SystemExit(0)
+
+print("ok" if payload.get("success") is True else "fail")
+PY
+)"
+
+  case "$verdict" in
+    ok)   return 0 ;;
+    fail) return 1 ;;
+    *)    [ "$status" -eq 0 ] ;;  # nojson / unknown -> trust exit code
+  esac
 }

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -149,7 +149,13 @@ setup_homeboy_project() {
 
   local project_id server_id spec
   project_id="$(homeboy_project_id)"
-  HOMEBOY_PROJECT_ID="$project_id"
+  # Only cache a non-empty id. Caching an empty string here would otherwise
+  # satisfy a later `[ -n "$HOMEBOY_PROJECT_ID" ]` check is false, but more
+  # importantly it must never shadow the resolver's homeboy.json / registered-
+  # project fallbacks with a blank value.
+  if [ -n "$project_id" ]; then
+    HOMEBOY_PROJECT_ID="$project_id"
+  fi
   server_id="$(homeboy_server_id)"
   HOMEBOY_SERVER_ID_RESOLVED="$server_id"
   spec="$(homeboy_project_json "$SITE_DOMAIN" "$SITE_PATH" "$server_id")"


### PR DESCRIPTION
## Summary
- `homeboy_project_id()` now falls back to matching the **site domain** against `homeboy project list` when there's no site-root `homeboy.json` and `$HOMEBOY_PROJECT_ID` is unset — so the resolver agrees with how `homeboy project show` / `attach-path` actually resolve the project.
- `setup_homeboy_project()` no longer caches an **empty** project id over that fallback.
- The attach loop now parses Homeboy's JSON `.success` field (via new `homeboy_attach_succeeded()`) instead of trusting the process exit code through `>/dev/null`, falling back to the exit code only for non-JSON output. Failure output is now surfaced (first 3 lines) for diagnosis.

## Why
On a Homeboy-enabled VPS install, the upgrade's Phase 5 component sync reported:

```
Homeboy component sync complete: 0 attached, 75 skipped, 45 failed
```

…even though `homeboy project components attach-path` **succeeds** when run manually (exit 0, `{"success": true, ...}`). Two root causes:

1. **Resolver divergence.** `homeboy_project_id()` only knew about `$HOMEBOY_PROJECT_ID` / site-root `homeboy.json`. This install has neither, so it returned non-zero — yet `attach-path` resolves the project from the registered project set by domain (`extrachill.com` → `extrachill-site`). The resolver and the actual attach target disagreed.
2. **Exit-code-only success check.** `if homeboy ... >/dev/null; then` didn't reflect Homeboy's real outcome.

## Implementation note
Both python helpers pass their JSON payload via **env var**, not stdin — a heredoc supplying the python source already occupies stdin, so a piped payload would be silently swallowed (verified this was the actual failure mode while developing the fix).

## Verification
Unit-tested `homeboy_attach_succeeded` across success / `success:false` / non-JSON+exit1 / non-JSON+exit0 / empty / leading-log-lines cases — all correct.

End-to-end on this install, the report flips from `0 attached, 45 failed` to:

```
Homeboy component sync complete: 45 attached, 77 skipped, 0 failed
```

Worktrees (`repo@branch`) and repos without `homeboy.json` are still correctly skipped.

Fixes #167