### PR TITLE
fix(homeboy): single-source homeboy_project_id and resolve real registered id

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -105,71 +105,9 @@ discover_dm_workspace_dir() {
   fi
 }
 
-homeboy_project_id() {
-  if [ -n "${HOMEBOY_PROJECT_ID:-}" ]; then
-    printf '%s\n' "$HOMEBOY_PROJECT_ID"
-    return 0
-  fi
-
-  # Preferred: explicit project config at the site root.
-  if [ -n "${SITE_PATH:-}" ] && [ -f "$SITE_PATH/homeboy.json" ]; then
-    local id
-    id="$(python3 - "$SITE_PATH/homeboy.json" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as handle:
-    project_id = json.load(handle).get("id", "")
-
-if project_id:
-    print(project_id)
-PY
-)"
-    if [ -n "$id" ]; then
-      printf '%s\n' "$id"
-      return 0
-    fi
-  fi
-
-  # Fallback: resolve from Homeboy's own registered projects by matching the
-  # project domain to the WordPress site domain. This is the same project a
-  # `homeboy project show` / `attach-path` resolves from the site cwd, so the
-  # resolver here stays consistent with what the attach loop actually targets
-  # even when there is no homeboy.json at the site root.
-  if [ -n "${SITE_DOMAIN:-}" ] && command -v homeboy >/dev/null 2>&1; then
-    local project_list resolved
-    project_list="$(homeboy project list 2>/dev/null)"
-    if [ -n "$project_list" ]; then
-      # Pass the JSON via env var (not stdin) so it does not collide with the
-      # heredoc that supplies the python source on stdin.
-      resolved="$(HOMEBOY_PROJECT_LIST="$project_list" HOMEBOY_SITE_DOMAIN="$SITE_DOMAIN" python3 <<'PY'
-import json
-import os
-
-site_domain = os.environ.get("HOMEBOY_SITE_DOMAIN", "").strip().lower()
-
-try:
-    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_LIST", ""))
-except Exception:
-    payload = {}
-
-projects = payload.get("data", {}).get("projects", [])
-for project in projects:
-    domain = (project.get("domain") or "").strip().lower()
-    if domain and domain == site_domain and project.get("id"):
-        print(project["id"])
-        break
-PY
-)"
-      if [ -n "$resolved" ]; then
-        printf '%s\n' "$resolved"
-        return 0
-      fi
-    fi
-  fi
-
-  return 1
-}
+# NOTE: homeboy_project_id() is defined once, in lib/homeboy.sh, which is
+# sourced after this file. A duplicate definition used to live here and was
+# silently shadowed by the homeboy.sh copy (see #170) — keep it single-sourced.
 
 sync_homeboy_project_components() {
   if ! command -v homeboy >/dev/null 2>&1; then

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -38,13 +38,80 @@ homeboy_server_json() {
 }
 
 homeboy_project_id() {
+  # 1. Explicit override.
   if [ -n "${HOMEBOY_PROJECT_ID:-}" ]; then
-    printf '%s' "$HOMEBOY_PROJECT_ID"
-  elif [ -n "${AGENT_SLUG:-}" ]; then
-    printf '%s' "$AGENT_SLUG"
-  else
-    homeboy_slugify "${SITE_DOMAIN:-$SITE_PATH}"
+    printf '%s\n' "$HOMEBOY_PROJECT_ID"
+    return 0
   fi
+
+  # 2. Project config at the site root.
+  if [ -n "${SITE_PATH:-}" ] && [ -f "$SITE_PATH/homeboy.json" ]; then
+    local id
+    id="$(python3 - "$SITE_PATH/homeboy.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    project_id = json.load(handle).get("id", "")
+
+if project_id:
+    print(project_id)
+PY
+)"
+    if [ -n "$id" ]; then
+      printf '%s\n' "$id"
+      return 0
+    fi
+  fi
+
+  # 3. Resolve from Homeboy's own registered projects by matching the project
+  # domain to the WordPress site domain. This is the id that `homeboy project
+  # show` / `attach-path` actually resolve from the site, so the resolver stays
+  # consistent with what the attach loop targets — even with no homeboy.json at
+  # the site root. Critically, this returns the REAL registered id (e.g.
+  # "extrachill-site"), not a domain-slug guess.
+  if [ -n "${SITE_DOMAIN:-}" ] && command -v homeboy >/dev/null 2>&1; then
+    local project_list resolved
+    project_list="$(homeboy project list 2>/dev/null)"
+    if [ -n "$project_list" ]; then
+      # Pass the JSON via env var (not stdin) so it does not collide with the
+      # heredoc that supplies the python source on stdin.
+      resolved="$(HOMEBOY_PROJECT_LIST="$project_list" HOMEBOY_SITE_DOMAIN="$SITE_DOMAIN" python3 <<'PY'
+import json
+import os
+
+site_domain = os.environ.get("HOMEBOY_SITE_DOMAIN", "").strip().lower()
+
+try:
+    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_LIST", ""))
+except Exception:
+    payload = {}
+
+projects = payload.get("data", {}).get("projects", [])
+for project in projects:
+    domain = (project.get("domain") or "").strip().lower()
+    if domain and domain == site_domain and project.get("id"):
+        print(project["id"])
+        break
+PY
+)"
+      if [ -n "$resolved" ]; then
+        printf '%s\n' "$resolved"
+        return 0
+      fi
+    fi
+  fi
+
+  # 4. Last-ditch fallbacks for setup-time (project not yet registered): an
+  # explicit agent slug, then a domain slug. These only ever produce an id to
+  # CREATE a project with — they must never win over a real registered project
+  # lookup above, which is why they run last.
+  if [ -n "${AGENT_SLUG:-}" ]; then
+    printf '%s\n' "$AGENT_SLUG"
+    return 0
+  fi
+
+  homeboy_slugify "${SITE_DOMAIN:-$SITE_PATH}"
 }
 
 homeboy_server_id() {


### PR DESCRIPTION
## Summary
- Removes the **duplicate** `homeboy_project_id()` (it lived in both `lib/data-machine.sh` and `lib/homeboy.sh`; the latter won by source order, silently shadowing the #169 fix).
- The surviving definition in `lib/homeboy.sh` now resolves in priority: `$HOMEBOY_PROJECT_ID` → site-root `homeboy.json` → **domain match against `homeboy project list`** (the real registered id). `$AGENT_SLUG` and `homeboy_slugify` remain only as last-ditch setup-time fallbacks for not-yet-registered projects.

## Why
The winning `homeboy.sh` copy's fallback ran `homeboy_slugify` on the site domain, turning `extrachill.com` into **`extrachill`** — not a registered project (the real one is `extrachill-site`). Homeboy returned `{"success": false, "code": "project.not_found"}`.

Latent until #169 made the attach loop parse `.success` instead of trusting the exit code: the now-truthful failure tripped `upgrade.sh`'s `set -e` and **aborted the upgrade at exit 4**, right after "Attaching Homeboy components".

xtrace proof:
```
++ homeboy_slugify extrachill.com
+ project_id=extrachill
++ homeboy project components attach-path extrachill /var/lib/.../agents-api
+ attach_output='{ "success": false, "error": { "code": "project.not_found", "details": { "id": "extrachill" } } }'
```

## Verification
End-to-end on a Homeboy-enabled install:
- Resolves `extrachill-site`; attach loop completes **`45 attached, 0 failed` (exit 0)** instead of aborting at exit 4.
- Setup-time unregistered domain (`brandnew-site.com`) still slugifies to `brandnew-site`, preserving create-project behavior.
- Only one `homeboy_project_id()` definition remains (`grep -rn 'homeboy_project_id()' lib/`).

Fixes #170