### PR TITLE
Own CLI dispatch transport in wp-coding-agents

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -40,6 +40,24 @@ jobs:
       - name: Run tests/opencode-wrapper-removal.sh
         run: ./tests/opencode-wrapper-removal.sh
 
+  cli-transport:
+    name: CLI dispatch transport runtime
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/cli-transport-install.sh
+        run: ./tests/cli-transport-install.sh
+      - name: Run tests/smoke-cli-transport.php
+        run: php tests/smoke-cli-transport.php
+
+  cli-channel-registry:
+    name: CLI channel registry permissions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/cli-channel-perms.sh
+        run: ./tests/cli-channel-perms.sh
+
   kimaki-agent-fallback:
     name: Kimaki native agent fallback regression
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Runs on a dedicated VPS for always-on autonomous operation, or locally on your M
 
 On activation, Data Machine creates a default agent and scaffolds its memory files. Additional agents get their own files when created. The runtime loads the selected agent's registered files for each session — the agent wakes up knowing who it is and what it's been working on. No memory management overhead in the context window.
 
+## Outbound CLI Dispatch
+
+Agents API owns the canonical `agents/dispatch-message` ability contract. wp-coding-agents owns the local CLI bridge runtime that fulfills that contract on machines where chat bridges are installed.
+
+Setup and upgrade sync two mu-plugins into the target WordPress install:
+
+- `wp-coding-agents-cli-transport.php` registers the generic local CLI transport for `agents/dispatch-message`.
+- `wp-coding-agents-channels.php` registers installed bridge command templates, such as `kimaki`, `cc-connect`, and `telegram`.
+
+Bridge installers publish channels through `wp_coding_agents_cli_channels`. The transport also reads the legacy `datamachine_code_cli_channels` registry during migration, so installs created before wp-coding-agents owned the runtime continue to dispatch without a manual config rewrite.
+
 ## Runtime Auto-Discovery
 
 Drop a file in `runtimes/`, it's available. The script scans `runtimes/*.sh` for available runtimes and auto-detects which one to use based on what's installed:
@@ -185,6 +196,7 @@ SITE_DOMAIN=example.com ./setup.sh --dry-run
 | **[Data Machine Code](https://github.com/Extra-Chill/data-machine-code)** | Workspace management, GitHub integration, git operations | Installed with Data Machine |
 | **AI Provider for Claude Code** | wp-coding-agents-carried WP AI Client provider backed by Claude Code OAuth credentials | Installed when Claude Code is selected or detected |
 | **[Homeboy](https://github.com/Extra-Chill/homeboy)** | Optional developer power layer for project status, component-aware checks, review loops, and WordPress extension verification | `--with-homeboy` |
+| **wp-coding-agents CLI transport** | Local `agents/dispatch-message` runtime plus per-bridge command registry | Always synced by setup/upgrade |
 | **[Kimaki](https://kimaki.xyz)**, **[cc-connect](https://github.com/nichochar/cc-connect)**, or **[opencode-telegram](https://github.com/grinev/opencode-telegram-bot)** | Chat bridge (Discord, multi-platform, or Telegram) | `--no-chat` |
 | **SessionStart hook** | Syncs Data Machine agents into CLAUDE.md on every session (Claude Code and Studio Code) | Always installed |
 | **wp-coding-agents upgrade skill** | Ongoing upgrade runbook installed with the target agent. The setup skill is intentionally not installed; it is a single-use pre-install entrypoint kept in this repo for the operator's local agent. | `--no-skills` |
@@ -372,17 +384,18 @@ Credentials are stored in `~/.config/opencode-telegram-bot/.env` (chmod 600). Yo
 
 ## Outbound Dispatch (`agents/dispatch-message`)
 
-Each chat bridge installed by wp-coding-agents registers itself as a **CLI channel** with the Data Machine Code generic CLI transport runtime (Extra-Chill/data-machine-code#412). That runtime backs the `agents/dispatch-message` ability, so Data Machine flows can push messages out to whatever platform your bridge speaks — without bespoke webhooks, without HTTP detours, without per-bridge plumbing in DMC itself.
+Each chat bridge installed by wp-coding-agents registers itself as a **CLI channel** with the wp-coding-agents generic CLI transport runtime. That runtime backs the `agents/dispatch-message` ability, so Data Machine flows can push messages out to whatever platform your bridge speaks without bespoke webhooks, HTTP detours, or per-bridge plumbing in Data Machine Code.
 
 ### How it wires up
 
-On install (and every `upgrade.sh` run), each bridge writes its channel config into a mu-plugin file at:
+On install and every `upgrade.sh` run, wp-coding-agents syncs the transport runtime and bridge channel config into mu-plugin files:
 
 ```
+$WP_PATH/wp-content/mu-plugins/wp-coding-agents-cli-transport.php
 $WP_PATH/wp-content/mu-plugins/wp-coding-agents-channels.php
 ```
 
-The file is owned end-to-end by bridge installers: it is created on first registration, each bridge contributes a marker-delimited block (`// BEGIN bridge:<name>` … `// END bridge:<name>`), and the same install path can rewrite or remove its block idempotently. The file registers entries via the `datamachine_code_cli_channels` filter:
+The channel file is owned end-to-end by bridge installers: it is created on first registration, each bridge contributes a marker-delimited block (`// BEGIN bridge:<name>` … `// END bridge:<name>`), and the same install path can rewrite or remove its block idempotently. The file registers entries via `wp_coding_agents_cli_channels` and also registers the legacy `datamachine_code_cli_channels` filter during migration:
 
 ```php
 $channels['kimaki'] = [
@@ -420,7 +433,7 @@ agents/dispatch-message
 
 ### Migrating from the legacy `agent-ping` webhook
 
-Earlier wp-coding-agents installs on Extra Chill's VPS shipped an out-of-band Python webhook at `/opt/agent-ping-webhook/` that POSTed to a local HTTP listener and shelled `kimaki send`. Once the CLI-channel runtime (Extra-Chill/data-machine-code#412) and these bridge registrations are deployed, that stack is dead weight — the same dispatch goes through `agents/dispatch-message` with no HTTP hop.
+Earlier wp-coding-agents installs on Extra Chill's VPS shipped an out-of-band Python webhook at `/opt/agent-ping-webhook/` that POSTed to a local HTTP listener and shelled `kimaki send`. Once the wp-coding-agents CLI-channel runtime and these bridge registrations are deployed, that stack is dead weight — the same dispatch goes through `agents/dispatch-message` with no HTTP hop.
 
 Retirement is a one-time manual cleanup. There is no helper script: this stack only exists on one host, and shipping permanent automation for a one-shot deletion would be technical debt for an experimental feature. On a host that has the legacy stack:
 
@@ -444,7 +457,7 @@ Retirement is a one-time manual cleanup. There is no helper script: this stack o
    sudo rm -f /home/opencode/.secrets/agent-ping-token.txt
    ```
 
-After this, the only outbound message path is `agents/dispatch-message` → DMC CLI runtime → bridge CLI. If you weren't running the legacy webhook to begin with (every install of wp-coding-agents from v0.5.x onward), skip the migration entirely — the bridge registrations land on a clean disk.
+After this, the only outbound message path is `agents/dispatch-message` → wp-coding-agents CLI runtime → bridge CLI. If you weren't running the legacy webhook to begin with (every install of wp-coding-agents from v0.5.x onward), skip the migration entirely — the bridge registrations land on a clean disk.
 
 ## Worktree Session Attribution (Runtime Signatures)
 

--- a/bridges/cc-connect.sh
+++ b/bridges/cc-connect.sh
@@ -47,7 +47,7 @@ bridge_install() {
 
 # _cc_connect_register_cli_channel
 #
-# Register cc-connect with the Data Machine Code CLI transport runtime.
+# Register cc-connect with the wp-coding-agents CLI transport runtime.
 #
 # `recipient` semantics: cc-connect routes outgoing `send` commands through
 # its currently-active project/session as configured in $CC_DATA_DIR/config.toml

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -57,7 +57,7 @@ bridge_install() {
 
 # _kimaki_register_cli_channel
 #
-# Register kimaki with the Data Machine Code CLI transport runtime so that
+# Register kimaki with the wp-coding-agents CLI transport runtime so that
 # `agents/dispatch-message` (substrate: Automattic/agents-api) can deliver
 # messages to Discord channels by shelling kimaki. `recipient` is the Discord
 # channel ID (numeric string) the message is delivered to. `message` is the

--- a/bridges/telegram.sh
+++ b/bridges/telegram.sh
@@ -109,7 +109,7 @@ LOG_LEVEL=info"
 
 # _telegram_register_cli_channel
 #
-# Register telegram with the Data Machine Code CLI transport runtime.
+# Register telegram with the wp-coding-agents CLI transport runtime.
 #
 # Mismatch caveat: opencode-telegram-bot is a long-running INBOUND bot — it
 # polls Telegram for incoming messages and forwards them to a local opencode

--- a/lib/cli-channel.sh
+++ b/lib/cli-channel.sh
@@ -3,15 +3,17 @@
 #
 # Each chat bridge in bridges/<name>.sh exposes a CLI surface that can deliver
 # messages to a recipient on its platform (kimaki → Discord, cc-connect →
-# multi-platform, opencode-telegram → Telegram). Data Machine Code's generic
-# CLI transport runtime (Extra-Chill/data-machine-code#412) shells those CLIs
-# on behalf of the `agents/dispatch-message` ability, but only if it can
-# discover a channel definition mapping `<channel-name>` → command + argv.
+# multi-platform, opencode-telegram → Telegram). wp-coding-agents' generic CLI
+# transport runtime shells those CLIs on behalf of the `agents/dispatch-message`
+# ability, but only if it can discover a channel definition mapping
+# `<channel-name>` → command + argv.
 #
 # This module owns that discovery surface. It writes a mu-plugin file in the
 # target WordPress install that registers each bridge's channel entry via the
-# `datamachine_code_cli_channels` filter. Each bridge install/sync calls
-# cli_channel_register; each bridge uninstall calls cli_channel_unregister.
+# `wp_coding_agents_cli_channels` filter, with a legacy
+# `datamachine_code_cli_channels` registration kept for migration. Each bridge
+# install/sync calls cli_channel_register; each bridge uninstall calls
+# cli_channel_unregister.
 #
 # Design choices:
 #
@@ -42,7 +44,7 @@
 #   cli_channel_unregister <name>              — remove a bridge's block
 #
 # `args_json` is a JSON array literal (e.g. '["send","--channel","{recipient}",
-# "--prompt","{message}"]'). Substitution tokens supported by the DMC runtime:
+# "--prompt","{message}"]'). Substitution tokens supported by the transport:
 #   {recipient}  — the bridge-specific target identifier (see per-bridge docs)
 #   {message}    — the message body to deliver
 #
@@ -71,13 +73,14 @@ cli_channel_mu_plugin_path() {
 #
 # Create the mu-plugin file with the filter scaffold if it does not exist.
 # Idempotent — does nothing if the file already exists. The scaffold contains
-# a single `add_filter( 'datamachine_code_cli_channels', … )` callback whose
-# body is the marker-delimited region that bridges write into.
+# a single marker-delimited callback registered to both the new
+# `wp_coding_agents_cli_channels` filter and the legacy
+# `datamachine_code_cli_channels` filter.
 #
 # The PHP closure walks the existing $channels array, applies each
 # // BEGIN/END marker block in source order, and returns the merged map. If
-# DMC's CLI runtime is not loaded (no filter consumers), the array is built
-# and discarded — no harm.
+# no CLI runtime is loaded (no filter consumers), the array is built and
+# discarded — no harm.
 cli_channel_ensure_mu_plugin_file() {
   local file
   file="$(cli_channel_mu_plugin_path)" || {
@@ -106,7 +109,7 @@ cli_channel_ensure_mu_plugin_file() {
 /**
  * Plugin Name: wp-coding-agents — CLI channel registry
  * Description: Registers chat bridges installed by wp-coding-agents as CLI
- *              channels for the Data Machine Code generic CLI transport
+ *              channels for the wp-coding-agents generic CLI transport
  *              runtime, which backs the agents/dispatch-message ability.
  *              Managed by wp-coding-agents bridge installers — do not edit
  *              by hand. Bridge install/upgrade rewrites the marker blocks
@@ -123,27 +126,33 @@ cli_channel_ensure_mu_plugin_file() {
  *   ];
  *   // END bridge:<name>
  *
- * Substitution tokens are resolved by the DMC CLI runtime at dispatch time:
+ * Substitution tokens are resolved by the CLI transport at dispatch time:
  *   {recipient} — bridge-specific target identifier (see bridge docs).
  *   {message}   — the message body delivered by agents/dispatch-message.
  *
- * Filter contract: Extra-Chill/data-machine-code#412.
+ * New filter contract: wp_coding_agents_cli_channels.
+ * Legacy migration filter: datamachine_code_cli_channels.
  *
  * @package wp-coding-agents
  */
 
 defined( 'ABSPATH' ) || exit;
 
-add_filter( 'datamachine_code_cli_channels', function ( $channels ) {
-    if ( ! is_array( $channels ) ) {
-        $channels = [];
-    }
+if ( ! function_exists( 'wp_coding_agents_register_cli_channels' ) ) {
+    function wp_coding_agents_register_cli_channels( $channels ) {
+        if ( ! is_array( $channels ) ) {
+            $channels = [];
+        }
 
     // BEGIN bridges
     // END bridges
 
-    return $channels;
-} );
+        return $channels;
+    }
+}
+
+add_filter( 'wp_coding_agents_cli_channels', 'wp_coding_agents_register_cli_channels' );
+add_filter( 'datamachine_code_cli_channels', 'wp_coding_agents_register_cli_channels' );
 PHP
 
   chmod 0644 "$file"

--- a/lib/cli-transport.sh
+++ b/lib/cli-transport.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# lib/cli-transport.sh — wp-coding-agents-owned CLI dispatch transport writer.
+
+cli_transport_mu_plugin_path() {
+  if [ -z "${SITE_PATH:-}" ]; then
+    return 1
+  fi
+  printf '%s' "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-cli-transport.php"
+}
+
+cli_transport_install() {
+  local file template dir
+  file="$(cli_transport_mu_plugin_path)" || {
+    warn "  cli_transport_install: SITE_PATH not set — skipping"
+    return 1
+  }
+  template="$SCRIPT_DIR/templates/wp-coding-agents-cli-transport.php"
+  if [ ! -f "$template" ]; then
+    warn "  cli_transport_install: missing template $template"
+    return 1
+  fi
+
+  dir="${file%/*}"
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would mkdir -p $dir"
+    echo -e "${BLUE}[dry-run]${NC} Would sync CLI transport mu-plugin to $file"
+    return 0
+  fi
+
+  mkdir -p "$dir"
+  if [ -f "$file" ] && cmp -s "$template" "$file"; then
+    chmod 0644 "$file"
+    return 0
+  fi
+
+  cp "$template" "$file"
+  chmod 0644 "$file"
+  log "  Synced CLI transport mu-plugin: $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("CLI transport runtime")
+  fi
+}

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect wordpress infrastructure data-machine carried-plugins homeboy skills summary cli-channel runtime-signature agents-md-guidance; do
+for lib in common detect wordpress infrastructure data-machine carried-plugins homeboy skills summary cli-transport cli-channel runtime-signature agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -343,5 +343,6 @@ configure_homeboy_wordpress_extension
 runtime_generate_instructions
 runtime_merge_mcp_servers
 install_skills
+cli_transport_install
 install_chat_bridge
 print_summary

--- a/templates/wp-coding-agents-cli-transport.php
+++ b/templates/wp-coding-agents-cli-transport.php
@@ -426,13 +426,21 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 
 		/**
 		 * @param array<string, string> $configured Configured env map.
-		 * @return array<string, string>
+		 * @return array<string, string>|null
 		 */
-		private static function build_env_map( array $configured ): array {
-			$env         = array();
-			$parent_path = getenv( 'PATH' );
-			if ( is_string( $parent_path ) && '' !== $parent_path ) {
-				$env['PATH'] = $parent_path;
+		private static function build_env_map( array $configured ): ?array {
+			if ( empty( $configured ) ) {
+				return null;
+			}
+
+			$parent_env = getenv();
+			$env        = is_array( $parent_env ) ? array_filter( $parent_env, 'is_string' ) : array();
+
+			if ( ! isset( $env['PATH'] ) ) {
+				$parent_path = getenv( 'PATH' );
+				if ( is_string( $parent_path ) && '' !== $parent_path ) {
+					$env['PATH'] = $parent_path;
+				}
 			}
 
 			foreach ( $configured as $key => $value ) {

--- a/templates/wp-coding-agents-cli-transport.php
+++ b/templates/wp-coding-agents-cli-transport.php
@@ -258,25 +258,78 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 		 * @return array<string, mixed>|WP_Error
 		 */
 		private static function dispatch_detached( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env ) {
+			// Capture stderr so an early-exiting child can report WHY it died.
+			// proc_close() below waits for the child either way (it always has —
+			// "detached" here means new session, not fire-and-forget), so the
+			// exit code is available for free. Discarding it caused scheduled
+			// dispatches to be marked delivered when the CLI crashed at startup
+			// (ENOSPC, bad binary path, auth failure). See data-machine-code#643.
+			$stderr_file = tempnam( sys_get_temp_dir(), 'wpca-dispatch-' );
+			$stderr_spec = false !== $stderr_file
+				? array( 'file', $stderr_file, 'w' )
+				: array( 'file', '/dev/null', 'w' );
+
 			$descriptors = array(
 				0 => array( 'file', '/dev/null', 'r' ),
 				1 => array( 'file', '/dev/null', 'w' ),
-				2 => array( 'file', '/dev/null', 'w' ),
+				2 => $stderr_spec,
 			);
 
 			$started_at = microtime( true );
 			$process    = self::open_process( $argv, $descriptors, $cwd, $env, true );
 			if ( $process instanceof WP_Error ) {
+				if ( false !== $stderr_file ) {
+					@unlink( $stderr_file );
+				}
 				return $process;
 			}
 
-			$pid    = null;
-			$status = proc_get_status( $process );
+			$pid       = null;
+			$exit_code = null;
+			$status    = proc_get_status( $process );
 			if ( is_array( $status ) && isset( $status['pid'] ) ) {
 				$pid = (int) $status['pid'];
 			}
+			// exitcode is only valid the first time running flips false.
+			if ( is_array( $status ) && false === ( $status['running'] ?? true ) ) {
+				$exit_code = isset( $status['exitcode'] ) ? (int) $status['exitcode'] : null;
+			}
 
-			proc_close( $process );
+			$close_code = proc_close( $process );
+			if ( null === $exit_code && is_int( $close_code ) && -1 !== $close_code ) {
+				$exit_code = $close_code;
+			}
+
+			$stderr = '';
+			if ( false !== $stderr_file ) {
+				$raw = @file_get_contents( $stderr_file );
+				if ( is_string( $raw ) ) {
+					$stderr = trim( $raw );
+				}
+				@unlink( $stderr_file );
+			}
+
+			$duration_ms = (int) round( ( microtime( true ) - $started_at ) * 1000 );
+
+			if ( null !== $exit_code && 0 !== $exit_code ) {
+				return new WP_Error(
+					'wp_coding_agents_cli_dispatch_exit_nonzero',
+					sprintf(
+						'CLI dispatch process "%s" exited with code %d after %dms.%s',
+						$argv[0] ?? '',
+						$exit_code,
+						$duration_ms,
+						'' !== $stderr ? ' stderr: ' . self::truncate_output( $stderr ) : ''
+					),
+					array(
+						'channel'     => $channel,
+						'recipient'   => $recipient,
+						'exit_code'   => $exit_code,
+						'duration_ms' => $duration_ms,
+						'stderr'      => self::truncate_output( $stderr ),
+					)
+				);
+			}
 
 			return array(
 				'sent'       => true,
@@ -286,7 +339,8 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 				'metadata'   => array(
 					'mode'        => 'detached',
 					'pid'         => $pid,
-					'duration_ms' => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+					'exit_code'   => $exit_code,
+					'duration_ms' => $duration_ms,
 				),
 			);
 		}

--- a/templates/wp-coding-agents-cli-transport.php
+++ b/templates/wp-coding-agents-cli-transport.php
@@ -1,0 +1,456 @@
+<?php
+/**
+ * Plugin Name: wp-coding-agents — CLI dispatch transport
+ * Description: Generic local CLI transport for the agents/dispatch-message ability. Managed by wp-coding-agents setup/upgrade.
+ *
+ * @package wp-coding-agents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Registry', false ) ) {
+	/**
+	 * Registry lookup for local CLI dispatch channels.
+	 */
+	class WpCodingAgents_Cli_Channel_Registry {
+		/** New wp-coding-agents-owned registry key. */
+		public const REGISTRY_KEY = 'wp_coding_agents_cli_channels';
+
+		/** Legacy DMC registry key kept for migration compatibility. */
+		public const LEGACY_REGISTRY_KEY = 'datamachine_code_cli_channels';
+
+		/**
+		 * Return the normalized registered channel map.
+		 *
+		 * @return array<string, array<string, mixed>>
+		 */
+		public static function get_channels(): array {
+			$channels = array();
+
+			foreach ( array( self::LEGACY_REGISTRY_KEY, self::REGISTRY_KEY ) as $key ) {
+				$option_value = array();
+				if ( function_exists( 'get_option' ) ) {
+					$raw = get_option( $key, array() );
+					if ( is_array( $raw ) ) {
+						$option_value = $raw;
+					}
+				}
+
+				$registered = $option_value;
+				if ( function_exists( 'apply_filters' ) ) {
+					$filtered = apply_filters( $key, $registered );
+					if ( is_array( $filtered ) ) {
+						$registered = $filtered;
+					}
+				}
+
+				$channels = array_merge( $channels, $registered );
+			}
+
+			$valid = array();
+			foreach ( $channels as $name => $config ) {
+				if ( ! is_string( $name ) || '' === $name || ! is_array( $config ) ) {
+					continue;
+				}
+
+				$normalized = self::normalize_entry( $config );
+				if ( null !== $normalized ) {
+					$valid[ $name ] = $normalized;
+				}
+			}
+
+			return $valid;
+		}
+
+		/**
+		 * Look up a single channel by name.
+		 *
+		 * @param string $channel Channel identifier.
+		 * @return array<string, mixed>|null
+		 */
+		public static function lookup( string $channel ): ?array {
+			if ( '' === $channel ) {
+				return null;
+			}
+
+			$channels = self::get_channels();
+			return $channels[ $channel ] ?? null;
+		}
+
+		/**
+		 * Validate and normalize a channel config entry.
+		 *
+		 * @param array<string, mixed> $config Raw config entry.
+		 * @return array<string, mixed>|null
+		 */
+		public static function normalize_entry( array $config ): ?array {
+			$command = $config['command'] ?? null;
+			if ( ! is_string( $command ) || '' === trim( $command ) ) {
+				return null;
+			}
+
+			$args = $config['args'] ?? array();
+			if ( ! is_array( $args ) ) {
+				return null;
+			}
+
+			$normalized_args = array();
+			foreach ( $args as $arg ) {
+				if ( ! is_string( $arg ) ) {
+					return null;
+				}
+				$normalized_args[] = $arg;
+			}
+
+			$detach = $config['detach'] ?? true;
+			if ( ! is_bool( $detach ) ) {
+				$detach = (bool) $detach;
+			}
+
+			$timeout = $config['timeout'] ?? 30;
+			if ( ! is_int( $timeout ) || $timeout < 0 ) {
+				$timeout = 30;
+			}
+
+			$env = $config['env'] ?? array();
+			if ( ! is_array( $env ) ) {
+				$env = array();
+			}
+
+			$normalized_env = array();
+			foreach ( $env as $env_key => $env_value ) {
+				if ( is_string( $env_key ) && '' !== $env_key && is_scalar( $env_value ) ) {
+					$normalized_env[ $env_key ] = (string) $env_value;
+				}
+			}
+
+			$cwd = $config['cwd'] ?? null;
+			if ( null !== $cwd && ( ! is_string( $cwd ) || '' === $cwd ) ) {
+				$cwd = null;
+			}
+
+			return array(
+				'command' => $command,
+				'args'    => $normalized_args,
+				'detach'  => $detach,
+				'timeout' => $timeout,
+				'env'     => $normalized_env,
+				'cwd'     => $cwd,
+			);
+		}
+
+		/**
+		 * Substitute canonical dispatch-message tokens into argv templates.
+		 *
+		 * @param array<int, string>   $args  Template args.
+		 * @param array<string, mixed> $input Dispatch input.
+		 * @return array<int, string>
+		 */
+		public static function substitute_tokens( array $args, array $input ): array {
+			$replacements = array(
+				'{recipient}'       => self::stringify( $input['recipient'] ?? '' ),
+				'{message}'         => self::stringify( $input['message'] ?? '' ),
+				'{conversation_id}' => self::stringify( $input['conversation_id'] ?? '' ),
+				'{channel}'         => self::stringify( $input['channel'] ?? '' ),
+			);
+
+			$result = array();
+			foreach ( $args as $arg ) {
+				$result[] = strtr( $arg, $replacements );
+			}
+
+			return $result;
+		}
+
+		/**
+		 * Convert token input to a string.
+		 *
+		 * @param mixed $value Source value.
+		 */
+		private static function stringify( $value ): string {
+			if ( null === $value ) {
+				return '';
+			}
+
+			return is_scalar( $value ) ? (string) $value : '';
+		}
+	}
+}
+
+if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
+	/**
+	 * Generic CLI transport for agents/dispatch-message.
+	 */
+	class WpCodingAgents_Cli_Channel_Transport {
+		private const DEFAULT_TIMEOUT_SECONDS = 30;
+
+		/** Register the transport handler filter. */
+		public static function register(): void {
+			static $registered = false;
+			if ( $registered || ! function_exists( 'add_filter' ) ) {
+				return;
+			}
+			$registered = true;
+
+			add_filter( 'wp_agent_dispatch_message_handler', array( self::class, 'maybe_claim' ), 10, 2 );
+		}
+
+		/**
+		 * Claim dispatches for registered CLI channels.
+		 *
+		 * @param callable|null        $existing Existing handler.
+		 * @param array<string, mixed> $input    Dispatch input.
+		 * @return callable|null
+		 */
+		public static function maybe_claim( $existing, $input ) {
+			if ( null !== $existing && is_callable( $existing ) ) {
+				return $existing;
+			}
+
+			if ( ! is_array( $input ) || ! function_exists( 'proc_open' ) ) {
+				return $existing;
+			}
+
+			$channel = isset( $input['channel'] ) && is_string( $input['channel'] ) ? $input['channel'] : '';
+			if ( '' === $channel || null === WpCodingAgents_Cli_Channel_Registry::lookup( $channel ) ) {
+				return $existing;
+			}
+
+			return array( self::class, 'execute' );
+		}
+
+		/**
+		 * Execute the registered CLI dispatch.
+		 *
+		 * @param array<string, mixed> $input Dispatch input.
+		 * @return array<string, mixed>|WP_Error
+		 */
+		public static function execute( array $input ) {
+			$channel = isset( $input['channel'] ) && is_string( $input['channel'] ) ? $input['channel'] : '';
+			if ( '' === $channel ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_invalid_input', 'agents/dispatch-message input is missing a channel identifier.' );
+			}
+
+			$config = WpCodingAgents_Cli_Channel_Registry::lookup( $channel );
+			if ( null === $config ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_unknown_channel', sprintf( 'No CLI channel registered for "%s".', $channel ) );
+			}
+
+			$recipient    = isset( $input['recipient'] ) && is_scalar( $input['recipient'] ) ? (string) $input['recipient'] : '';
+			$command_args = WpCodingAgents_Cli_Channel_Registry::substitute_tokens( $config['args'], $input );
+			array_unshift( $command_args, $config['command'] );
+
+			$detach = (bool) ( $config['detach'] ?? true );
+			$timeout = isset( $config['timeout'] ) && is_int( $config['timeout'] ) ? $config['timeout'] : self::DEFAULT_TIMEOUT_SECONDS;
+			$cwd     = isset( $config['cwd'] ) && is_string( $config['cwd'] ) && '' !== $config['cwd'] ? $config['cwd'] : null;
+			$env     = self::build_env_map( isset( $config['env'] ) && is_array( $config['env'] ) ? $config['env'] : array() );
+
+			if ( $detach ) {
+				return self::dispatch_detached( $channel, $recipient, $command_args, $cwd, $env );
+			}
+
+			return self::dispatch_sync( $channel, $recipient, $command_args, $cwd, $env, $timeout );
+		}
+
+		/**
+		 * @param array<int, string>         $argv Command argv.
+		 * @param array<string, string>|null $env  Environment map.
+		 * @return array<string, mixed>|WP_Error
+		 */
+		private static function dispatch_detached( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env ) {
+			$descriptors = array(
+				0 => array( 'file', '/dev/null', 'r' ),
+				1 => array( 'file', '/dev/null', 'w' ),
+				2 => array( 'file', '/dev/null', 'w' ),
+			);
+
+			$started_at = microtime( true );
+			$process    = self::open_process( $argv, $descriptors, $cwd, $env, true );
+			if ( $process instanceof WP_Error ) {
+				return $process;
+			}
+
+			$pid    = null;
+			$status = proc_get_status( $process );
+			if ( is_array( $status ) && isset( $status['pid'] ) ) {
+				$pid = (int) $status['pid'];
+			}
+
+			proc_close( $process );
+
+			return array(
+				'sent'       => true,
+				'channel'    => $channel,
+				'recipient'  => $recipient,
+				'message_id' => null !== $pid ? (string) $pid : null,
+				'metadata'   => array(
+					'mode'        => 'detached',
+					'pid'         => $pid,
+					'duration_ms' => (int) round( ( microtime( true ) - $started_at ) * 1000 ),
+				),
+			);
+		}
+
+		/**
+		 * @param array<int, string>         $argv Command argv.
+		 * @param array<string, string>|null $env  Environment map.
+		 * @return array<string, mixed>|WP_Error
+		 */
+		private static function dispatch_sync( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env, int $timeout ) {
+			$descriptors = array(
+				0 => array( 'pipe', 'r' ),
+				1 => array( 'pipe', 'w' ),
+				2 => array( 'pipe', 'w' ),
+			);
+
+			$pipes      = array();
+			$started_at = microtime( true );
+			$process    = self::open_process( $argv, $descriptors, $cwd, $env, false, $pipes );
+			if ( $process instanceof WP_Error ) {
+				return $process;
+			}
+
+			if ( isset( $pipes[0] ) && is_resource( $pipes[0] ) ) {
+				fclose( $pipes[0] );
+			}
+			if ( isset( $pipes[1] ) && is_resource( $pipes[1] ) ) {
+				stream_set_blocking( $pipes[1], false );
+			}
+			if ( isset( $pipes[2] ) && is_resource( $pipes[2] ) ) {
+				stream_set_blocking( $pipes[2], false );
+			}
+
+			$stdout    = '';
+			$stderr    = '';
+			$timed_out = false;
+			$deadline  = $started_at + max( 1, $timeout );
+
+			while ( true ) {
+				$status = proc_get_status( $process );
+
+				if ( isset( $pipes[1] ) && is_resource( $pipes[1] ) ) {
+					$chunk = stream_get_contents( $pipes[1] );
+					if ( is_string( $chunk ) && '' !== $chunk ) {
+						$stdout .= $chunk;
+					}
+				}
+				if ( isset( $pipes[2] ) && is_resource( $pipes[2] ) ) {
+					$chunk = stream_get_contents( $pipes[2] );
+					if ( is_string( $chunk ) && '' !== $chunk ) {
+						$stderr .= $chunk;
+					}
+				}
+
+				if ( ! is_array( $status ) || false === $status['running'] ) {
+					break;
+				}
+				if ( microtime( true ) >= $deadline ) {
+					$timed_out = true;
+					proc_terminate( $process, 15 );
+					usleep( 100000 );
+					$status = proc_get_status( $process );
+					if ( is_array( $status ) && true === $status['running'] ) {
+						proc_terminate( $process, 9 );
+					}
+					break;
+				}
+
+				usleep( 20000 );
+			}
+
+			foreach ( array( 1, 2 ) as $fd ) {
+				if ( ! isset( $pipes[ $fd ] ) || ! is_resource( $pipes[ $fd ] ) ) {
+					continue;
+				}
+				$chunk = stream_get_contents( $pipes[ $fd ] );
+				if ( is_string( $chunk ) && '' !== $chunk ) {
+					if ( 1 === $fd ) {
+						$stdout .= $chunk;
+					} else {
+						$stderr .= $chunk;
+					}
+				}
+				fclose( $pipes[ $fd ] );
+			}
+
+			$exit_code   = proc_close( $process );
+			$duration_ms = (int) round( ( microtime( true ) - $started_at ) * 1000 );
+
+			if ( $timed_out ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_timeout', sprintf( 'CLI channel "%s" exceeded the %d second timeout.', $channel, $timeout ), array( 'channel' => $channel, 'recipient' => $recipient, 'stdout' => self::truncate_output( $stdout ), 'stderr' => self::truncate_output( $stderr ), 'duration_ms' => $duration_ms ) );
+			}
+
+			if ( 0 !== $exit_code ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_nonzero_exit', sprintf( 'CLI channel "%s" exited with code %d.', $channel, $exit_code ), array( 'channel' => $channel, 'recipient' => $recipient, 'exit_code' => $exit_code, 'stdout' => self::truncate_output( $stdout ), 'stderr' => self::truncate_output( $stderr ), 'duration_ms' => $duration_ms ) );
+			}
+
+			return array(
+				'sent'       => true,
+				'channel'    => $channel,
+				'recipient'  => $recipient,
+				'message_id' => null,
+				'metadata'   => array(
+					'mode'        => 'sync',
+					'exit_code'   => $exit_code,
+					'duration_ms' => $duration_ms,
+					'stdout'      => self::truncate_output( $stdout ),
+					'stderr'      => self::truncate_output( $stderr ),
+				),
+			);
+		}
+
+		/**
+		 * @param array<int, string>         $argv        Command argv.
+		 * @param array<int, mixed>          $descriptors Descriptor spec.
+		 * @param array<string, string>|null $env         Environment map.
+		 * @param array<int, resource>       $pipes       Output pipes.
+		 * @return resource|WP_Error
+		 */
+		private static function open_process( array $argv, array $descriptors, ?string $cwd, ?array $env, bool $detached, array &$pipes = array() ) {
+			if ( ! function_exists( 'proc_open' ) ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_no_proc_open', 'proc_open is not available on this host.' );
+			}
+
+			$options = array();
+			if ( $detached ) {
+				$options['start_new_session'] = true;
+			}
+
+			$process = @proc_open( $argv, $descriptors, $pipes, $cwd, $env, $options );
+			if ( ! is_resource( $process ) ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_spawn_failed', sprintf( 'Failed to spawn CLI process "%s".', $argv[0] ?? '' ) );
+			}
+
+			return $process;
+		}
+
+		/**
+		 * @param array<string, string> $configured Configured env map.
+		 * @return array<string, string>
+		 */
+		private static function build_env_map( array $configured ): array {
+			$env         = array();
+			$parent_path = getenv( 'PATH' );
+			if ( is_string( $parent_path ) && '' !== $parent_path ) {
+				$env['PATH'] = $parent_path;
+			}
+
+			foreach ( $configured as $key => $value ) {
+				$env[ $key ] = $value;
+			}
+
+			return $env;
+		}
+
+		private static function truncate_output( string $output ): string {
+			$limit = 8192;
+			if ( strlen( $output ) <= $limit ) {
+				return $output;
+			}
+
+			return substr( $output, 0, $limit ) . "\n[...truncated]";
+		}
+	}
+}
+
+WpCodingAgents_Cli_Channel_Transport::register();

--- a/tests/cli-transport-install.sh
+++ b/tests/cli-transport-install.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/wp-content/mu-plugins"
+export SITE_PATH="$TMP"
+export DRY_RUN=false
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/cli-transport.sh"
+UPDATED_ITEMS=()
+
+log() { :; }
+warn() { echo "WARN: $1" >&2; }
+
+MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-cli-transport.php"
+FAILED=0
+
+assert_mode_0644() {
+  local got
+  if stat -c %a "$MU_FILE" >/dev/null 2>&1; then
+    got=$(stat -c %a "$MU_FILE")
+  else
+    got=$(stat -f %Lp "$MU_FILE")
+  fi
+  if [ "$got" = "644" ]; then
+    echo "  ok   transport mu-plugin mode 0644"
+  else
+    echo "  FAIL transport mu-plugin mode got $got, want 644"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+(
+  umask 077
+  cli_transport_install
+)
+
+if [ ! -f "$MU_FILE" ]; then
+  echo "  FAIL transport mu-plugin was not written"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   transport mu-plugin written"
+fi
+
+if ! cmp -s "$SCRIPT_DIR/templates/wp-coding-agents-cli-transport.php" "$MU_FILE"; then
+  echo "  FAIL transport mu-plugin does not match template"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   transport mu-plugin matches template"
+fi
+
+assert_mode_0644
+
+chmod 0600 "$MU_FILE"
+cli_transport_install
+assert_mode_0644
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAILED: $FAILED assertion(s)"
+  exit 1
+fi
+
+echo "OK: CLI transport install assertions passed"

--- a/tests/smoke-cli-transport.php
+++ b/tests/smoke-cli-transport.php
@@ -89,10 +89,11 @@ $find_stub = static function ( array $candidates ): ?string {
 };
 
 $echo_bin  = $find_stub( array( '/bin/echo', '/usr/bin/echo' ) );
+$env_bin   = $find_stub( array( '/usr/bin/env', '/bin/env' ) );
 $true_bin  = $find_stub( array( '/bin/true', '/usr/bin/true' ) );
 $false_bin = $find_stub( array( '/bin/false', '/usr/bin/false' ) );
 $sleep_bin = $find_stub( array( '/bin/sleep', '/usr/bin/sleep' ) );
-foreach ( array( 'echo' => $echo_bin, 'true' => $true_bin, 'false' => $false_bin, 'sleep' => $sleep_bin ) as $name => $path ) {
+foreach ( array( 'echo' => $echo_bin, 'env' => $env_bin, 'true' => $true_bin, 'false' => $false_bin, 'sleep' => $sleep_bin ) as $name => $path ) {
 	if ( null === $path ) {
 		echo "  [SKIP] stub binary {$name} not present\n";
 		exit( 0 );
@@ -205,6 +206,21 @@ $wp_coding_agents_test_options = array(
 			'args'    => array(),
 			'detach'  => true,
 		),
+		'inherit-env'   => array(
+			'command' => $env_bin,
+			'args'    => array(),
+			'detach'  => false,
+			'timeout' => 5,
+		),
+		'configured-env' => array(
+			'command' => $env_bin,
+			'args'    => array(),
+			'detach'  => false,
+			'timeout' => 5,
+			'env'     => array(
+				'WP_CODING_AGENTS_CONFIGURED_ENV' => 'configured-ok',
+			),
+		),
 	),
 );
 
@@ -236,6 +252,15 @@ $assert( 'execute unknown returns WP_Error', $unknown instanceof WP_Error );
 
 $detached = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-true', 'recipient' => 'r', 'message' => 'm' ) );
 $assert( 'detached returns array', is_array( $detached ) && true === ( $detached['sent'] ?? false ) );
+
+putenv( 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' );
+$inherited = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'inherit-env', 'recipient' => 'r', 'message' => 'm' ) );
+$assert( 'empty channel env inherits parent env', is_array( $inherited ) && str_contains( (string) ( $inherited['metadata']['stdout'] ?? '' ), 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' ) );
+
+$configured = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'configured-env', 'recipient' => 'r', 'message' => 'm' ) );
+$configured_stdout = is_array( $configured ) ? (string) ( $configured['metadata']['stdout'] ?? '' ) : '';
+$assert( 'configured channel env keeps parent env', str_contains( $configured_stdout, 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' ) );
+$assert( 'configured channel env adds configured env', str_contains( $configured_stdout, 'WP_CODING_AGENTS_CONFIGURED_ENV=configured-ok' ) );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";

--- a/tests/smoke-cli-transport.php
+++ b/tests/smoke-cli-transport.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Pure-PHP smoke test for the wp-coding-agents CLI transport runtime.
+ *
+ *   php tests/smoke-cli-transport.php
+ *
+ * @package wp-coding-agents
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		global $wp_coding_agents_test_filters;
+		$wp_coding_agents_test_filters[ $hook ][ $priority ][] = $callback;
+		unset( $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, mixed $value, ...$args ): mixed {
+		global $wp_coding_agents_test_filters;
+		if ( empty( $wp_coding_agents_test_filters[ $hook ] ) ) {
+			return $value;
+		}
+
+		ksort( $wp_coding_agents_test_filters[ $hook ] );
+		foreach ( $wp_coding_agents_test_filters[ $hook ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$value = $callback( $value, ...$args );
+			}
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $key, mixed $default_value = false ): mixed {
+		global $wp_coding_agents_test_options;
+		return $wp_coding_agents_test_options[ $key ] ?? $default_value;
+	}
+}
+
+require __DIR__ . '/../templates/wp-coding-agents-cli-transport.php';
+
+$failures = array();
+$assert   = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	$failures[] = $label;
+	echo "  [FAIL] {$label}\n";
+};
+
+echo "=== smoke-cli-transport ===\n";
+
+$find_stub = static function ( array $candidates ): ?string {
+	foreach ( $candidates as $candidate ) {
+		if ( is_executable( $candidate ) ) {
+			return $candidate;
+		}
+	}
+	return null;
+};
+
+$echo_bin  = $find_stub( array( '/bin/echo', '/usr/bin/echo' ) );
+$true_bin  = $find_stub( array( '/bin/true', '/usr/bin/true' ) );
+$false_bin = $find_stub( array( '/bin/false', '/usr/bin/false' ) );
+$sleep_bin = $find_stub( array( '/bin/sleep', '/usr/bin/sleep' ) );
+foreach ( array( 'echo' => $echo_bin, 'true' => $true_bin, 'false' => $false_bin, 'sleep' => $sleep_bin ) as $name => $path ) {
+	if ( null === $path ) {
+		echo "  [SKIP] stub binary {$name} not present\n";
+		exit( 0 );
+	}
+}
+
+global $wp_coding_agents_test_options, $wp_coding_agents_test_filters;
+$wp_coding_agents_test_options = array();
+
+$valid_entry = array(
+	'command' => $echo_bin,
+	'args'    => array( '--', '{recipient}', '{message}' ),
+	'detach'  => false,
+	'timeout' => 5,
+);
+$normalized  = WpCodingAgents_Cli_Channel_Registry::normalize_entry( $valid_entry );
+$assert( 'valid entry normalizes', is_array( $normalized ) && $echo_bin === $normalized['command'] );
+$assert( 'missing command is rejected', null === WpCodingAgents_Cli_Channel_Registry::normalize_entry( array( 'args' => array() ) ) );
+$assert( 'non-string arg is rejected', null === WpCodingAgents_Cli_Channel_Registry::normalize_entry( array( 'command' => $echo_bin, 'args' => array( 123 ) ) ) );
+
+$wp_coding_agents_test_options['datamachine_code_cli_channels'] = array(
+	'legacy-option' => array(
+		'command' => $echo_bin,
+		'args'    => array( 'legacy-option' ),
+	),
+	'collision'     => array(
+		'command' => $echo_bin,
+		'args'    => array( 'legacy' ),
+	),
+);
+$wp_coding_agents_test_options['wp_coding_agents_cli_channels'] = array(
+	'new-option' => array(
+		'command' => $echo_bin,
+		'args'    => array( 'new-option' ),
+	),
+	'collision'  => array(
+		'command' => $echo_bin,
+		'args'    => array( 'new' ),
+	),
+);
+
+add_filter(
+	'datamachine_code_cli_channels',
+	static function ( array $channels ) use ( $echo_bin ): array {
+		$channels['legacy-filter'] = array(
+			'command' => $echo_bin,
+			'args'    => array( 'legacy-filter' ),
+		);
+		return $channels;
+	}
+);
+add_filter(
+	'wp_coding_agents_cli_channels',
+	static function ( array $channels ) use ( $echo_bin ): array {
+		$channels['new-filter'] = array(
+			'command' => $echo_bin,
+			'args'    => array( 'new-filter' ),
+		);
+		return $channels;
+	}
+);
+
+$channels = WpCodingAgents_Cli_Channel_Registry::get_channels();
+$assert( 'legacy option channel is present', isset( $channels['legacy-option'] ) );
+$assert( 'new option channel is present', isset( $channels['new-option'] ) );
+$assert( 'legacy filter channel is present', isset( $channels['legacy-filter'] ) );
+$assert( 'new filter channel is present', isset( $channels['new-filter'] ) );
+$assert( 'new registry wins collisions', isset( $channels['collision']['args'][0] ) && 'new' === $channels['collision']['args'][0] );
+
+$substituted = WpCodingAgents_Cli_Channel_Registry::substitute_tokens(
+	array( '--to', '{recipient}', '--msg', '{message}', '--conv', '{conversation_id}', '--ch', '{channel}' ),
+	array(
+		'recipient'       => 'user-123',
+		'message'         => 'hello $(rm -rf /)',
+		'conversation_id' => 'conv-abc',
+		'channel'         => 'fixture-channel',
+	)
+);
+$assert( 'message token substituted verbatim', 'hello $(rm -rf /)' === $substituted[3] );
+$assert( 'conversation token substituted', 'conv-abc' === $substituted[5] );
+
+$wp_coding_agents_test_options = array(
+	'wp_coding_agents_cli_channels' => array(
+		'sync-echo'     => array(
+			'command' => $echo_bin,
+			'args'    => array( '{recipient}:{message}' ),
+			'detach'  => false,
+			'timeout' => 5,
+		),
+		'sync-true'     => array(
+			'command' => $true_bin,
+			'args'    => array(),
+			'detach'  => false,
+			'timeout' => 5,
+		),
+		'sync-false'    => array(
+			'command' => $false_bin,
+			'args'    => array(),
+			'detach'  => false,
+			'timeout' => 5,
+		),
+		'sync-sleep'    => array(
+			'command' => $sleep_bin,
+			'args'    => array( '5' ),
+			'detach'  => false,
+			'timeout' => 1,
+		),
+		'detached-true' => array(
+			'command' => $true_bin,
+			'args'    => array(),
+			'detach'  => true,
+		),
+	),
+);
+
+$claim_known = WpCodingAgents_Cli_Channel_Transport::maybe_claim( null, array( 'channel' => 'sync-true' ) );
+$assert( 'claims registered channel', is_callable( $claim_known ) );
+$assert( 'declines unknown channel', null === WpCodingAgents_Cli_Channel_Transport::maybe_claim( null, array( 'channel' => 'unknown' ) ) );
+$prior = static fn() => null;
+$assert( 'preserves prior handler', $prior === WpCodingAgents_Cli_Channel_Transport::maybe_claim( $prior, array( 'channel' => 'sync-true' ) ) );
+
+$ok = WpCodingAgents_Cli_Channel_Transport::execute(
+	array(
+		'channel'   => 'sync-echo',
+		'recipient' => 'user-1',
+		'message'   => 'hi-there',
+	)
+);
+$assert( 'sync success returns array', is_array( $ok ) && ! ( $ok instanceof WP_Error ) );
+if ( is_array( $ok ) ) {
+	$assert( 'sync success captures stdout', isset( $ok['metadata']['stdout'] ) && 'user-1:hi-there' === trim( (string) $ok['metadata']['stdout'] ) );
+}
+
+$assert( 'sync true succeeds', is_array( WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-true', 'recipient' => 'r', 'message' => 'm' ) ) ) );
+$fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-false', 'recipient' => 'r', 'message' => 'm' ) );
+$assert( 'nonzero exit returns WP_Error', $fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_nonzero_exit' === $fail->get_error_code() );
+$timed = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-sleep', 'recipient' => 'r', 'message' => 'm' ) );
+$assert( 'timeout returns WP_Error', $timed instanceof WP_Error && 'wp_coding_agents_cli_dispatch_timeout' === $timed->get_error_code() );
+$unknown = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'unknown', 'recipient' => 'r', 'message' => 'm' ) );
+$assert( 'execute unknown returns WP_Error', $unknown instanceof WP_Error );
+
+$detached = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-true', 'recipient' => 'r', 'message' => 'm' ) );
+$assert( 'detached returns array', is_array( $detached ) && true === ( $detached['sent'] ?? false ) );
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";
+	foreach ( $failures as $failure ) {
+		echo "  - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\nOK\n";

--- a/tests/smoke-cli-transport.php
+++ b/tests/smoke-cli-transport.php
@@ -206,6 +206,11 @@ $wp_coding_agents_test_options = array(
 			'args'    => array(),
 			'detach'  => true,
 		),
+		'detached-false' => array(
+			'command' => $false_bin,
+			'args'    => array(),
+			'detach'  => true,
+		),
 		'inherit-env'   => array(
 			'command' => $env_bin,
 			'args'    => array(),
@@ -252,6 +257,11 @@ $assert( 'execute unknown returns WP_Error', $unknown instanceof WP_Error );
 
 $detached = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-true', 'recipient' => 'r', 'message' => 'm' ) );
 $assert( 'detached returns array', is_array( $detached ) && true === ( $detached['sent'] ?? false ) );
+
+// Regression: a detached child that exits non-zero must fail the dispatch
+// instead of being reported as delivered (data-machine-code#643).
+$detached_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-false', 'recipient' => 'r', 'message' => 'm' ) );
+$assert( 'detached early exit returns WP_Error', $detached_fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_exit_nonzero' === $detached_fail->get_error_code() );
 
 putenv( 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' );
 $inherited = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'inherit-env', 'recipient' => 'r', 'message' => 'm' ) );

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect wordpress data-machine carried-plugins wp-codebox homeboy skills cli-channel runtime-signature agents-md-guidance; do
+for lib in common detect wordpress data-machine carried-plugins wp-codebox homeboy skills cli-transport cli-channel runtime-signature agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -328,6 +328,13 @@ update_data_machine_plugins() {
   upgrade_data_machine_plugins
   sync_carried_plugins
   update_wp_codebox_plugin_subtree
+}
+
+sync_cli_transport_runtime() {
+  _run_filter_active kimaki || return 0
+
+  log "Phase 2b: Syncing CLI dispatch transport..."
+  cli_transport_install
 }
 
 # ============================================================================
@@ -782,6 +789,7 @@ _print_verify_block() {
 # ============================================================================
 
 update_data_machine_plugins
+sync_cli_transport_runtime
 sync_chat_bridge_config
 check_opencode_json_drift
 sync_skills

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -307,7 +307,7 @@ _run_filter_active() {
       plugins)   [ "$PLUGINS_ONLY" = true ]; return $? ;;
       skills)    [ "$SKILLS_ONLY" = true ]; return $? ;;
       agents-md) [ "$AGENTS_MD_ONLY" = true ]; return $? ;;
-      systemd|patch) return 1 ;;  # infrastructure phases skipped in *-only modes
+      transport|systemd|patch) return 1 ;;  # infrastructure phases skipped in *-only modes
       *)         return 1 ;;
     esac
   fi
@@ -331,7 +331,7 @@ update_data_machine_plugins() {
 }
 
 sync_cli_transport_runtime() {
-  _run_filter_active kimaki || return 0
+  _run_filter_active transport || return 0
 
   log "Phase 2b: Syncing CLI dispatch transport..."
   cli_transport_install


### PR DESCRIPTION
## Summary
- Add a wp-coding-agents-owned CLI transport mu-plugin for `agents/dispatch-message`, synced by setup and upgrade.
- Publish bridge channel config through `wp_coding_agents_cli_channels` while preserving legacy `datamachine_code_cli_channels` compatibility for existing installs.
- Update bridge/docs ownership language and add CI coverage for transport install, runtime dispatch, and channel registry permissions.

Closes #177.

## Verification
- `git diff --check`
- `php tests/smoke-cli-transport.php`
- `./tests/cli-transport-install.sh`
- `./tests/cli-channel-perms.sh`
- `./tests/bridge-render.sh`
- `./tests/opencode-wrapper-removal.sh`
- `./tests/kimaki-agent-fallback.sh`

## DMC follow-up
Data Machine Code should follow with a coordinated cleanup PR that stops registering/removes its generic `CliChannelTransport`/`CliChannelRegistry` runtime, leaving any DMC-specific channel contributions only if they exist. This wp-coding-agents PR keeps reading `datamachine_code_cli_channels` so that cleanup can happen after deployment without breaking existing bridge registrations.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the CLI transport migration, compatibility tests, docs, and PR body; Chris remains responsible for review and merge.