### PR TITLE
Publish Homeboy Codebox agent task guidance

### DIFF
--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -14,6 +14,7 @@
 #   agents_md_guidance_ensure_mu_plugin_file
 #   agents_md_guidance_register <section_id> <priority> <label> <description> <content>
 #   agents_md_guidance_unregister <section_id>
+#   agents_md_guidance_sync_homeboy_codebox <available:true|false>
 #   agents_md_guidance_register_homeboy_codebox
 #   agents_md_guidance_unregister_homeboy_codebox
 #
@@ -90,6 +91,9 @@ agents_md_guidance_register() {
     return 1
   fi
 
+  _agents_md_guidance_validate_section_id "$section_id" || return 1
+  _agents_md_guidance_validate_priority "$priority" || return 1
+
   local file
   file="$(agents_md_guidance_mu_plugin_path)" || {
     warn "  agents_md_guidance_register: SITE_PATH not set — skipping section '$section_id'"
@@ -136,6 +140,8 @@ agents_md_guidance_unregister() {
     return 1
   fi
 
+  _agents_md_guidance_validate_section_id "$section_id" || return 1
+
   local file
   file="$(agents_md_guidance_mu_plugin_path)" || return 0
   [ -f "$file" ] || return 0
@@ -158,6 +164,18 @@ agents_md_guidance_unregister() {
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("AGENTS.md guidance removed: $section_id")
   fi
+}
+
+agents_md_guidance_sync_homeboy_codebox() {
+  local available="${1:-false}"
+  case "$available" in
+    true) agents_md_guidance_register_homeboy_codebox ;;
+    false) agents_md_guidance_unregister_homeboy_codebox ;;
+    *)
+      warn "  agents_md_guidance_sync_homeboy_codebox: expected true or false, got '$available'"
+      return 1
+      ;;
+  esac
 }
 
 agents_md_guidance_register_homeboy_codebox() {
@@ -240,6 +258,26 @@ print("        )")
 print("    );")
 print(f"    // END agents-md-guidance:{section_id}")
 PY
+}
+
+_agents_md_guidance_validate_section_id() {
+  local section_id="$1"
+  if printf '%s' "$section_id" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
+    return 0
+  fi
+
+  warn "  AGENTS.md guidance section id may only contain letters, numbers, dots, underscores, and hyphens: $section_id"
+  return 1
+}
+
+_agents_md_guidance_validate_priority() {
+  local priority="$1"
+  if printf '%s' "$priority" | grep -Eq '^-?[0-9]+$'; then
+    return 0
+  fi
+
+  warn "  AGENTS.md guidance priority must be an integer: $priority"
+  return 1
 }
 
 _agents_md_guidance_block_matches() {

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+# lib/agents-md-guidance.sh — AGENTS.md SectionRegistry guidance writer.
+#
+# wp-coding-agents owns integration-specific runtime guidance for the tools it
+# installs and wires together. Data Machine Code owns the generic AGENTS.md
+# composition substrate; this helper publishes wp-coding-agents' integration
+# guidance into that substrate through Data Machine's SectionRegistry without
+# making DMC know about Homeboy, Kimaki, OpenCode, or WP Codebox conventions.
+#
+# Resolved file: $SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agents-md.php
+#
+# Public surface:
+#   agents_md_guidance_mu_plugin_path
+#   agents_md_guidance_ensure_mu_plugin_file
+#   agents_md_guidance_register <section_id> <priority> <label> <description> <content>
+#   agents_md_guidance_unregister <section_id>
+#   agents_md_guidance_register_homeboy_codebox
+#   agents_md_guidance_unregister_homeboy_codebox
+#
+# Honors DRY_RUN (logs intent, makes no changes).
+
+agents_md_guidance_mu_plugin_path() {
+  if [ -z "${SITE_PATH:-}" ]; then
+    return 1
+  fi
+  printf '%s' "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+}
+
+agents_md_guidance_ensure_mu_plugin_file() {
+  local file
+  file="$(agents_md_guidance_mu_plugin_path)" || {
+    warn "  agents_md_guidance_ensure_mu_plugin_file: SITE_PATH not set — skipping"
+    return 1
+  }
+
+  if [ -f "$file" ]; then
+    return 0
+  fi
+
+  local dir="${file%/*}"
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would mkdir -p $dir"
+    echo -e "${BLUE}[dry-run]${NC} Would write AGENTS.md guidance mu-plugin to $file"
+    return 0
+  fi
+
+  mkdir -p "$dir"
+  cat > "$file" <<'PHP'
+<?php
+/**
+ * Plugin Name: wp-coding-agents — AGENTS.md guidance registry
+ * Description: Registers wp-coding-agents-owned integration guidance as
+ *              composable AGENTS.md sections through Data Machine's
+ *              SectionRegistry. Managed by wp-coding-agents setup/upgrade —
+ *              do not edit by hand.
+ *
+ * Each integration contributes a marker-delimited PHP block of the form:
+ *
+ *   // BEGIN agents-md-guidance:<section_id>
+ *   \DataMachine\Engine\AI\SectionRegistry::register( ... );
+ *   // END agents-md-guidance:<section_id>
+ *
+ * @package wp-coding-agents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'datamachine_sections', function () {
+    if ( ! class_exists( '\DataMachine\Engine\AI\SectionRegistry' ) ) {
+        return;
+    }
+
+    // BEGIN agents-md-guidance-sections
+    // END agents-md-guidance-sections
+} );
+PHP
+
+  chmod 0644 "$file"
+  log "  Wrote AGENTS.md guidance mu-plugin scaffold: $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("created $file")
+  fi
+}
+
+agents_md_guidance_register() {
+  local section_id="$1" priority="$2" label="$3" description="$4" content="$5"
+
+  if [ -z "$section_id" ] || [ -z "$priority" ] || [ -z "$label" ] || [ -z "$content" ]; then
+    warn "  agents_md_guidance_register: missing required args (section_id=$section_id priority=$priority label=$label)"
+    return 1
+  fi
+
+  local file
+  file="$(agents_md_guidance_mu_plugin_path)" || {
+    warn "  agents_md_guidance_register: SITE_PATH not set — skipping section '$section_id'"
+    return 1
+  }
+
+  agents_md_guidance_ensure_mu_plugin_file || return 1
+
+  local new_block
+  new_block=$(_agents_md_guidance_render_block "$section_id" "$priority" "$label" "$description" "$content")
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would register AGENTS.md guidance section '$section_id' in $file"
+    echo -e "${BLUE}[dry-run]${NC} Block:"
+    echo "$new_block" | sed 's/^/    /'
+    return 0
+  fi
+
+  if _agents_md_guidance_block_matches "$file" "$section_id" "$new_block"; then
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp "${file}.XXXXXX")
+  _agents_md_guidance_rewrite "$file" "$section_id" "$new_block" > "$tmp"
+
+  if cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+    return 0
+  fi
+
+  mv "$tmp" "$file"
+  chmod 0644 "$file"
+  log "  Registered AGENTS.md guidance section '$section_id' in $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("AGENTS.md guidance: $section_id")
+  fi
+}
+
+agents_md_guidance_unregister() {
+  local section_id="$1"
+  if [ -z "$section_id" ]; then
+    warn "  agents_md_guidance_unregister: missing section_id"
+    return 1
+  fi
+
+  local file
+  file="$(agents_md_guidance_mu_plugin_path)" || return 0
+  [ -f "$file" ] || return 0
+
+  if ! grep -q "// BEGIN agents-md-guidance:${section_id}\$" "$file"; then
+    return 0
+  fi
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would unregister AGENTS.md guidance section '$section_id' from $file"
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp "${file}.XXXXXX")
+  _agents_md_guidance_rewrite "$file" "$section_id" "" > "$tmp"
+  mv "$tmp" "$file"
+  chmod 0644 "$file"
+  log "  Unregistered AGENTS.md guidance section '$section_id' from $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("AGENTS.md guidance removed: $section_id")
+  fi
+}
+
+agents_md_guidance_register_homeboy_codebox() {
+  agents_md_guidance_register \
+    "homeboy-codebox-agent-tasks" \
+    36 \
+    "Homeboy Codebox agent tasks" \
+    "Homeboy-owned async coding-agent fan-out through WP Codebox sandboxes." \
+    "$(agents_md_guidance_homeboy_codebox_content)"
+}
+
+agents_md_guidance_unregister_homeboy_codebox() {
+  agents_md_guidance_unregister "homeboy-codebox-agent-tasks"
+}
+
+agents_md_guidance_homeboy_codebox_content() {
+  cat <<'MD'
+## Homeboy Agent Tasks
+
+Use Homeboy `agent-task` for async coding-agent fan-out instead of manual chat-session fleets. Homeboy owns task plans, durable run state, queueing, concurrency, retries, logs, artifacts, and promotion back into the review workflow.
+
+**Codebox executor:** the `codebox` backend runs each task in a disposable WP Codebox WordPress sandbox. WP Codebox owns sandbox recipes, plugin/runtime overlays, agent invocation, and artifact bundles; Homeboy owns orchestration around those recipes.
+
+**Common verbs:** `homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote`. Use `homeboy agent-task providers` to inspect registered executor providers.
+
+**Workspace shape:** pass an explicit workspace root for code edits, usually a Data Machine Code worktree under `/Users/chubes/Developer/<repo>@<slug>` locally or the equivalent mounted path inside a sandbox. Keep primary checkouts read-only and cook changes in worktrees.
+
+**WP Codebox agent mode:** use sandbox mode for Codebox coding tasks. Sandbox mode exposes the bounded workspace tools needed to read, edit, and verify files; conversational/default chat mode is only useful for answering questions.
+
+**Codex provider:** Codebox Codex tasks need the OpenAI Codex provider plugin/runtime overlay and `AI_PROVIDER_OPENAI_CODEX_*` secrets passed via `secret_env`. Never print token values in logs or task instructions.
+
+Use Kimaki, Discord, or other chat bridges as thin transport only. They should display task status and results, not own fleet scheduling or spawn worker sessions themselves.
+MD
+}
+
+_agents_md_guidance_render_block() {
+  local section_id="$1" priority="$2" label="$3" description="$4" content="$5"
+  AGENTS_MD_GUIDANCE_SECTION_ID="$section_id" \
+  AGENTS_MD_GUIDANCE_PRIORITY="$priority" \
+  AGENTS_MD_GUIDANCE_LABEL="$label" \
+  AGENTS_MD_GUIDANCE_DESCRIPTION="$description" \
+  AGENTS_MD_GUIDANCE_CONTENT="$content" \
+  python3 <<'PY'
+import os
+import re
+import sys
+
+section_id = os.environ["AGENTS_MD_GUIDANCE_SECTION_ID"]
+priority = os.environ["AGENTS_MD_GUIDANCE_PRIORITY"]
+label = os.environ["AGENTS_MD_GUIDANCE_LABEL"]
+description = os.environ.get("AGENTS_MD_GUIDANCE_DESCRIPTION", "")
+content = os.environ["AGENTS_MD_GUIDANCE_CONTENT"].rstrip("\n")
+
+if not re.fullmatch(r"[A-Za-z0-9_.-]+", section_id):
+    sys.stderr.write("AGENTS.md guidance section id may only contain letters, numbers, dots, underscores, and hyphens\n")
+    sys.exit(1)
+try:
+    priority_int = int(priority)
+except ValueError:
+    sys.stderr.write("AGENTS.md guidance priority must be an integer\n")
+    sys.exit(1)
+
+def esc(value):
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+print(f"    // BEGIN agents-md-guidance:{section_id}")
+print("    \\DataMachine\\Engine\\AI\\SectionRegistry::register(")
+print("        'AGENTS.md',")
+print(f"        '{esc(section_id)}',")
+print(f"        {priority_int},")
+print("        static function () {")
+print("            return <<<'MD'")
+print(content)
+print("MD;")
+print("        },")
+print("        array(")
+print(f"            'label'       => '{esc(label)}',")
+print(f"            'description' => '{esc(description)}',")
+print("        )")
+print("    );")
+print(f"    // END agents-md-guidance:{section_id}")
+PY
+}
+
+_agents_md_guidance_block_matches() {
+  local file="$1" section_id="$2" new_block="$3"
+  local existing
+  existing=$(awk -v sid="$section_id" '
+    $0 == "    // BEGIN agents-md-guidance:" sid { capturing=1 }
+    capturing { print }
+    $0 == "    // END agents-md-guidance:" sid { exit }
+  ' "$file")
+  [ "$existing" = "$new_block" ]
+}
+
+_agents_md_guidance_rewrite() {
+  local file="$1" section_id="$2" new_block="$3"
+  AGENTS_MD_GUIDANCE_NEW_BLOCK="$new_block" python3 - "$file" "$section_id" <<'PY'
+import os
+import sys
+
+file_path, section_id = sys.argv[1], sys.argv[2]
+new_block = os.environ.get("AGENTS_MD_GUIDANCE_NEW_BLOCK", "")
+begin_marker = f"    // BEGIN agents-md-guidance:{section_id}"
+end_marker = f"    // END agents-md-guidance:{section_id}"
+
+with open(file_path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+inserted = False
+skipping = False
+out = []
+
+for line in lines:
+    if line == begin_marker:
+        skipping = True
+        if new_block:
+            out.extend(new_block.splitlines())
+            inserted = True
+        continue
+
+    if skipping:
+        if line == end_marker:
+            skipping = False
+        continue
+
+    if not inserted and line == "    // END agents-md-guidance-sections":
+        if new_block:
+            out.extend(new_block.splitlines())
+            inserted = True
+
+    out.append(line)
+
+sys.stdout.write("\n".join(out))
+sys.stdout.write("\n")
+PY
+}

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -193,21 +193,17 @@ agents_md_guidance_unregister_homeboy_codebox() {
 
 agents_md_guidance_homeboy_codebox_content() {
   cat <<'MD'
-## Homeboy Agent Tasks
+**Agent tasks:** `homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote`; use `homeboy agent-task providers` to inspect registered executor providers. Homeboy owns task plans, durable run state, queueing, concurrency, retries, logs, artifacts, and promotion back into the review workflow.
 
-Use Homeboy `agent-task` for async coding-agent fan-out instead of manual chat-session fleets. Homeboy owns task plans, durable run state, queueing, concurrency, retries, logs, artifacts, and promotion back into the review workflow.
+**Codebox executor:** use the `codebox` backend for disposable WP Codebox WordPress sandboxes. WP Codebox owns sandbox recipes, plugin/runtime overlays, agent invocation, and artifact bundles; Homeboy owns orchestration around those recipes.
 
-**Codebox executor:** the `codebox` backend runs each task in a disposable WP Codebox WordPress sandbox. WP Codebox owns sandbox recipes, plugin/runtime overlays, agent invocation, and artifact bundles; Homeboy owns orchestration around those recipes.
+**Workspace shape:** pass an explicit workspace root for code edits, usually a Data Machine Code worktree under `<workspace>/<repo>@<slug>` locally or the equivalent mounted path inside a sandbox. Keep primary checkouts read-only and cook changes in worktrees.
 
-**Common verbs:** `homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote`. Use `homeboy agent-task providers` to inspect registered executor providers.
-
-**Workspace shape:** pass an explicit workspace root for code edits, usually a Data Machine Code worktree under `/Users/chubes/Developer/<repo>@<slug>` locally or the equivalent mounted path inside a sandbox. Keep primary checkouts read-only and cook changes in worktrees.
-
-**WP Codebox agent mode:** use sandbox mode for Codebox coding tasks. Sandbox mode exposes the bounded workspace tools needed to read, edit, and verify files; conversational/default chat mode is only useful for answering questions.
+**WP Codebox agent mode:** use sandbox mode for Codebox coding tasks. Sandbox mode exposes the bounded workspace tools needed to read, edit, and verify files.
 
 **Codex provider:** Codebox Codex tasks need the OpenAI Codex provider plugin/runtime overlay and `AI_PROVIDER_OPENAI_CODEX_*` secrets passed via `secret_env`. Never print token values in logs or task instructions.
 
-Use Kimaki, Discord, or other chat bridges as thin transport only. They should display task status and results, not own fleet scheduling or spawn worker sessions themselves.
+**Chat bridges:** Kimaki, Discord, and other chat bridges display task status and results while Homeboy remains the source of truth for task state and artifacts.
 MD
 }
 

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -200,6 +200,18 @@ homeboy_handle_failure() {
   return 0
 }
 
+sync_homeboy_agents_md_guidance() {
+  if ! declare -F agents_md_guidance_register_homeboy_codebox >/dev/null; then
+    return 0
+  fi
+
+  if [ "${HOMEBOY_WORDPRESS_READY:-false}" = true ] || homeboy_wordpress_extension_ready; then
+    agents_md_guidance_register_homeboy_codebox
+  else
+    agents_md_guidance_unregister_homeboy_codebox
+  fi
+}
+
 setup_homeboy_project() {
   if [ "${HOMEBOY_MODE:-auto}" = "disabled" ]; then
     log "Skipping Homeboy project setup (--no-homeboy)"
@@ -255,6 +267,7 @@ configure_homeboy_wordpress_extension() {
 
   if [ "${HOMEBOY_MODE:-auto}" = "disabled" ]; then
     sync_homeboy_availability
+    sync_homeboy_agents_md_guidance
     recompose_agents_md_for_homeboy
     return 0
   fi
@@ -262,6 +275,7 @@ configure_homeboy_wordpress_extension() {
   if ! command -v homeboy >/dev/null 2>&1; then
     homeboy_handle_failure "Homeboy is not callable from this setup/runtime PATH; skipping Homeboy WordPress extension setup."
     sync_homeboy_availability
+    sync_homeboy_agents_md_guidance
     recompose_agents_md_for_homeboy
     return 0
   fi
@@ -276,6 +290,7 @@ configure_homeboy_wordpress_extension() {
       warn "Homeboy is callable, but the WordPress extension is not ready. Run setup with --with-homeboy to install and verify it."
     fi
     sync_homeboy_availability
+    sync_homeboy_agents_md_guidance
     recompose_agents_md_for_homeboy
     return 0
   fi
@@ -288,6 +303,7 @@ configure_homeboy_wordpress_extension() {
     echo -e "${BLUE}[dry-run]${NC} homeboy extension setup wordpress"
     echo -e "${BLUE}[dry-run]${NC} homeboy extension list"
     echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update datamachine_code_homeboy_available 1"
+    echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy Codebox AGENTS.md guidance mu-plugin"
     print_homeboy_verification_commands
     return 0
   fi
@@ -315,6 +331,7 @@ configure_homeboy_wordpress_extension() {
   fi
 
   sync_homeboy_availability
+  sync_homeboy_agents_md_guidance
   recompose_agents_md_for_homeboy
   print_homeboy_verification_commands
 }

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -201,14 +201,14 @@ homeboy_handle_failure() {
 }
 
 sync_homeboy_agents_md_guidance() {
-  if ! declare -F agents_md_guidance_register_homeboy_codebox >/dev/null; then
+  if ! declare -F agents_md_guidance_sync_homeboy_codebox >/dev/null; then
     return 0
   fi
 
   if [ "${HOMEBOY_WORDPRESS_READY:-false}" = true ] || homeboy_wordpress_extension_ready; then
-    agents_md_guidance_register_homeboy_codebox
+    agents_md_guidance_sync_homeboy_codebox true
   else
-    agents_md_guidance_unregister_homeboy_codebox
+    agents_md_guidance_sync_homeboy_codebox false
   fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect wordpress infrastructure data-machine homeboy skills summary cli-channel runtime-signature; do
+for lib in common detect wordpress infrastructure data-machine homeboy skills summary cli-channel runtime-signature agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -84,10 +84,22 @@ assert_mode_0644() {
   fi
 }
 
+assert_fails() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  FAIL $name"
+    echo "    command unexpectedly succeeded: $*"
+    FAILED=$((FAILED + 1))
+  else
+    echo "  ok   $name"
+  fi
+}
+
 echo "==> register Homeboy Codebox guidance"
 (
   umask 077
-  agents_md_guidance_register_homeboy_codebox
+  agents_md_guidance_sync_homeboy_codebox true
 )
 
 assert_php_lint "$MU_FILE" "guidance mu-plugin parses with php -l"
@@ -102,9 +114,14 @@ fi
 
 echo "==> re-register Homeboy Codebox guidance (idempotent)"
 HASH_BEFORE=$(file_hash "$MU_FILE")
-agents_md_guidance_register_homeboy_codebox
+agents_md_guidance_sync_homeboy_codebox true
 HASH_AFTER=$(file_hash "$MU_FILE")
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-register"
+
+echo "==> invalid public API inputs fail before writing broken PHP"
+assert_fails "invalid section id rejected" agents_md_guidance_register "bad section" 36 "Bad" "Bad" "## Bad"
+assert_fails "invalid priority rejected" agents_md_guidance_register "bad-priority" "later" "Bad" "Bad" "## Bad"
+assert_fails "invalid sync availability rejected" agents_md_guidance_sync_homeboy_codebox maybe
 
 echo "==> apply datamachine_sections action and inspect SectionRegistry call"
 SHIM="$TMP/section-shim.php"
@@ -148,7 +165,7 @@ assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives Homeboy Codebox guidan
 
 echo "==> unregister Homeboy Codebox guidance"
 chmod 0600 "$MU_FILE"
-agents_md_guidance_unregister_homeboy_codebox
+agents_md_guidance_sync_homeboy_codebox false
 assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
 if grep -q "BEGIN agents-md-guidance:homeboy-codebox-agent-tasks" "$MU_FILE"; then
   echo "  FAIL Homeboy Codebox block still present after unregister"

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -153,14 +153,16 @@ namespace {
         'slug' => \$call[1] ?? null,
         'priority' => \$call[2] ?? null,
         'label' => \$call[4]['label'] ?? null,
+        'starts_with_homeboy_style_category' => str_starts_with( \$content, '**Agent tasks:**' ),
         'has_agent_task_verbs' => str_contains( \$content, 'homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote' ),
         'has_sandbox_mode' => str_contains( \$content, 'use sandbox mode for Codebox coding tasks' ),
+        'has_old_workflow_comparison' => str_contains( \$content, 'instead of' ) || str_contains( \$content, 'manual chat-session fleets' ),
     ]);
 }
 PHP
 
 RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","has_agent_task_verbs":true,"has_sandbox_mode":true}'
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","starts_with_homeboy_style_category":true,"has_agent_task_verbs":true,"has_sandbox_mode":true,"has_old_workflow_comparison":false}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives Homeboy Codebox guidance section"
 
 echo "==> unregister Homeboy Codebox guidance"

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# tests/agents-md-guidance.sh — Regression coverage for AGENTS.md guidance registry.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/wp-content/mu-plugins"
+export SITE_PATH="$TMP"
+export DRY_RUN=false
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/agents-md-guidance.sh"
+UPDATED_ITEMS=()
+
+VERBOSE=false
+for arg in "$@"; do
+  case "$arg" in
+    --verbose|-v) VERBOSE=true ;;
+  esac
+done
+if [ "$VERBOSE" = false ]; then
+  log() { :; }
+  warn() { echo "WARN: $1" >&2; }
+fi
+
+MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+FAILED=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "    got:  $got"
+    echo "    want: $want"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_php_lint() {
+  local file="$1" name="$2"
+  if php -l "$file" >/dev/null 2>&1; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    php -l "$file" 2>&1 | sed 's/^/    /'
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+file_hash() {
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$1" | cut -d' ' -f1
+  else
+    md5 -q "$1"
+  fi
+}
+
+file_mode() {
+  if stat -c %a "$1" >/dev/null 2>&1; then
+    stat -c %a "$1"
+  else
+    stat -f %Lp "$1"
+  fi
+}
+
+assert_mode_0644() {
+  local file="$1" name="$2" got
+  got=$(file_mode "$file")
+  if [ "$got" = "644" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "    got:  $got"
+    echo "    want: 644"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "==> register Homeboy Codebox guidance"
+(
+  umask 077
+  agents_md_guidance_register_homeboy_codebox
+)
+
+assert_php_lint "$MU_FILE" "guidance mu-plugin parses with php -l"
+assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after fresh write under umask 077"
+
+if grep -q "BEGIN agents-md-guidance:homeboy-codebox-agent-tasks" "$MU_FILE"; then
+  echo "  ok   Homeboy Codebox block present"
+else
+  echo "  FAIL Homeboy Codebox block missing"
+  FAILED=$((FAILED + 1))
+fi
+
+echo "==> re-register Homeboy Codebox guidance (idempotent)"
+HASH_BEFORE=$(file_hash "$MU_FILE")
+agents_md_guidance_register_homeboy_codebox
+HASH_AFTER=$(file_hash "$MU_FILE")
+assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-register"
+
+echo "==> apply datamachine_sections action and inspect SectionRegistry call"
+SHIM="$TMP/section-shim.php"
+cat > "$SHIM" <<PHP
+<?php
+namespace DataMachine\Engine\AI {
+    class SectionRegistry {
+        public static array \$calls = [];
+        public static function register( string \$filename, string \$slug, int \$priority, callable \$callback, array \$args = [] ): void {
+            self::\$calls[] = [ \$filename, \$slug, \$priority, \$callback, \$args ];
+        }
+    }
+}
+
+namespace {
+    define( 'ABSPATH', '/' );
+    \$GLOBALS['actions'] = [];
+    function add_action( \$tag, \$callback, \$priority = 10 ) {
+        \$GLOBALS['actions'][\$tag][] = \$callback;
+    }
+    require '$MU_FILE';
+    foreach ( \$GLOBALS['actions']['datamachine_sections'] ?? [] as \$callback ) {
+        \$callback();
+    }
+    \$call = \DataMachine\Engine\AI\SectionRegistry::\$calls[0] ?? null;
+    \$content = \$call ? (string) call_user_func( \$call[3] ) : '';
+    echo json_encode([
+        'filename' => \$call[0] ?? null,
+        'slug' => \$call[1] ?? null,
+        'priority' => \$call[2] ?? null,
+        'label' => \$call[4]['label'] ?? null,
+        'has_agent_task_verbs' => str_contains( \$content, 'homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote' ),
+        'has_sandbox_mode' => str_contains( \$content, 'use sandbox mode for Codebox coding tasks' ),
+    ]);
+}
+PHP
+
+RESULT=$(php "$SHIM")
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","has_agent_task_verbs":true,"has_sandbox_mode":true}'
+assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives Homeboy Codebox guidance section"
+
+echo "==> unregister Homeboy Codebox guidance"
+chmod 0600 "$MU_FILE"
+agents_md_guidance_unregister_homeboy_codebox
+assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
+if grep -q "BEGIN agents-md-guidance:homeboy-codebox-agent-tasks" "$MU_FILE"; then
+  echo "  FAIL Homeboy Codebox block still present after unregister"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   Homeboy Codebox block removed"
+fi
+assert_php_lint "$MU_FILE" "post-unregister file parses with php -l"
+
+echo
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAILED: $FAILED assertion(s)"
+  exit 1
+fi
+echo "OK: all AGENTS.md guidance assertions passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -65,7 +65,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect wordpress data-machine homeboy skills cli-channel runtime-signature; do
+for lib in common detect wordpress data-machine homeboy skills cli-channel runtime-signature agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -536,12 +536,14 @@ regenerate_agents_md() {
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would backup $AGENTS_MD → $BACKUP"
+    echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy Codebox AGENTS.md guidance mu-plugin"
     echo -e "${BLUE}[dry-run]${NC} Would run: $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG"
     echo -e "${BLUE}[dry-run]${NC} Would symlink $CLAUDE_MD → AGENTS.md (Claude-model context)"
     return 0
   fi
 
   sync_homeboy_availability
+  sync_homeboy_agents_md_guidance
 
   # Backup existing (compose writes in-place to the registered location)
   if [ -f "$AGENTS_MD" ]; then


### PR DESCRIPTION
## Summary
- Adds a wp-coding-agents-managed AGENTS.md guidance mu-plugin helper that registers marker-delimited SectionRegistry sections.
- Publishes Homeboy Codebox `agent-task` guidance when the Homeboy WordPress extension is ready, and removes it when unavailable.
- Wires setup/upgrade to sync the guidance before recomposing AGENTS.md.

## Testing
- `bash tests/agents-md-guidance.sh`
- `bash tests/runtime-signature.sh`
- `bash tests/cli-channel-perms.sh`
- `bash -n lib/agents-md-guidance.sh lib/homeboy.sh setup.sh upgrade.sh tests/agents-md-guidance.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the shell helper, setup/upgrade wiring, and regression tests; Chris remains responsible for review and merge.

Closes #179.