### PR TITLE
Scope agent task guidance to available tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,22 +43,22 @@ runtimes/
 
 Each runtime implements the same interface — install, config generation, MCP merge, skills directory. Adding a new runtime means implementing those functions in a single file.
 
-## Standalone or Fleet
+## Standalone Or Orchestrated
 
 wp-coding-agents works in two modes with the same setup:
 
 **Standalone** — Data Machine handles autonomy. The agent self-schedules flows, queues tasks, runs on cron. No orchestrator needed.
 
-**Fleet member** — An orchestrator routes tasks via Agent Ping webhooks and Discord mentions. The agent executes on its own site, reports back. Multiple agents, each focused on their own WordPress site.
+**Orchestrated** — Optional tools can route work to the agent without becoming universal requirements. Homeboy is the optional repo-aware coding-task orchestrator when installed with `--with-homeboy`; chat bridges such as Kimaki, cc-connect, and Telegram are communication paths for the selected install.
 
 ```
- Orchestrator (fleet-wide context)
-   ├── Agent Ping / @mention ──▶  agent @ site-a.com
-   ├── Agent Ping / @mention ──▶  agent @ site-b.com
-   └── Agent Ping / @mention ──▶  agent @ site-c.com
+ Optional orchestrator / chat bridge
+   ├── Homeboy agent-task ──▶  repo-aware Codebox task
+   ├── CLI dispatch ───────▶  selected chat bridge
+   └── direct session ─────▶  agent @ WordPress site
 ```
 
-This isn't theoretical. It's running in production right now — agents on separate VPS instances, each with their own WordPress site, coordinated through Discord and DM webhooks.
+Installs without Homeboy still use Data Machine workspaces, flows, jobs, and bridge dispatch. Installs without Kimaki use the selected bridge or terminal runtime; Kimaki-specific routing only applies when Kimaki is selected.
 
 ## Quick Start
 
@@ -194,7 +194,7 @@ SITE_DOMAIN=example.com ./setup.sh --dry-run
 | **Scheduled flows** | Cron-driven briefings, digests | No overnight automation |
 | **Infrastructure** | apt, nginx, SSL, systemd | None — uses your existing WordPress |
 | **Root required** | Yes (default) | No |
-| **Best for** | Production agents, fleet members | Development, personal use, testing |
+| **Best for** | Production agents, always-on automation | Development, personal use, testing |
 
 Both modes use the same Data Machine agent engine, same abilities, same memory system. The difference is just infrastructure.
 
@@ -237,7 +237,7 @@ Data Machine is the substrate wp-coding-agents composes on top of — memory, sc
 - Persistent memory across sessions (SOUL.md, USER.md, MEMORY.md)
 - Self-scheduling via flows and cron
 - Task queues for multi-phase projects
-- Agent Ping webhooks for fleet coordination
+- Agent Ping webhooks and CLI bridge dispatch for cross-agent coordination
 - AI tools (content generation, publishing, search)
 - Managed workspace for git repos (`/var/lib/datamachine/workspace/`) with **per-branch worktrees** so multiple parallel agent sessions can edit different branches of the same repo without stepping on each other (`workspace worktree add <repo> <branch>` → operate on the `<repo>@<branch-slug>` handle)
 - GitHub integration (issues, PRs, repos)
@@ -246,6 +246,8 @@ Data Machine is the substrate wp-coding-agents composes on top of — memory, sc
 ## Optional Homeboy Layer
 
 `--with-homeboy` adds Homeboy as an optional, recommended developer power layer. Homeboy is not bundled or vendorized by wp-coding-agents; setup verifies or installs the external Homeboy CLI, verifies the WordPress extension, then exposes its availability to Data Machine Code so composed agent instructions can include Homeboy workflows.
+
+When Homeboy is available, the composed `AGENTS.md` Homeboy Codebox section is the canonical guidance for repo-aware coding fan-out: use `homeboy agent-task` plans/runs with WP Codebox sandboxes for isolated tasks. Without Homeboy, agents should continue using Data Machine Code worktrees, normal git review, and the selected chat or terminal runtime; do not assume Homeboy commands exist.
 
 The setup model is intentionally specific:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ runtimes/
 
 Each runtime implements the same interface — install, config generation, MCP merge, skills directory. Adding a new runtime means implementing those functions in a single file.
 
-## Standalone Or Orchestrated
+## Standalone or Orchestrated
 
 wp-coding-agents works in two modes with the same setup:
 

--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -164,9 +164,28 @@ function stripSection(block: string, heading: string): string {
  * @return {string} System prompt block without the stale helper-session hint.
  */
 function stripHelperSessionFleetHint(block: string): string {
+  if (!block.includes("spawn") && !block.includes("spawned")) {
+    return block;
+  }
+
   return block
-    .replace(/\n+You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results\.\n/g, "\n")
-    .replace(/\n+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching\. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder\.\n/g, "\n");
+    .split("\n")
+    .filter((line) => !isHelperSessionFleetHintLine(line))
+    .join("\n");
+}
+
+/**
+ * Identify Kimaki helper-session lines that promote manual thread spawning as
+ * orchestration. Match on stable concepts instead of the complete sentence.
+ *
+ * @param {string} line - System prompt line.
+ * @return {boolean} Whether the line should be stripped.
+ */
+function isHelperSessionFleetHintLine(line: string): boolean {
+  return (
+    line.includes('"spawn" parallel helper sessions') ||
+    (line.includes("spawned or scheduled sessions") && line.includes("<current_agent>"))
+  );
 }
 
 export default fleetContextFilter;

--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -19,6 +19,8 @@
 //    --project` / `session search --channel <id>`. These are cross-project
 //    discovery vectors; on a single-project fleet server the agent only ever
 //    needs to list sessions in the current project (no flags required).
+// 6. Kimaki's generic helper-session fleet hint. On managed installs, composed
+//    site guidance owns orchestration policy; Kimaki is the chat/session bridge.
 //
 // What it intentionally keeps under Kimaki 0.13:
 // - Generic `--agent <current_agent>` examples. Kimaki now falls back to the
@@ -63,6 +65,7 @@ const fleetContextFilter: Plugin = async () => {
         result = stripSection(result, "## scheduled sends and task management");
         result = stripSection(result, "## running dev servers with tunnel access");
         result = stripSection(result, "## reading other sessions");
+        result = stripHelperSessionFleetHint(result);
         // Clean up leftover double/triple blank lines.
         result = result.replace(/\n{3,}/g, "\n\n");
         return result;
@@ -150,6 +153,20 @@ function stripSection(block: string, heading: string): string {
   const before = lines.slice(0, start);
   const after = lines.slice(end);
   return [...before, ...after].join("\n");
+}
+
+/**
+ * Remove Kimaki's generic helper-session wording that frames manual thread
+ * spawning as an orchestration primitive. Keep the command examples themselves
+ * available for Kimaki chat/session routing.
+ *
+ * @param {string} block - System prompt block.
+ * @return {string} System prompt block without the stale helper-session hint.
+ */
+function stripHelperSessionFleetHint(block: string): string {
+  return block
+    .replace(/\n+You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results\.\n/g, "\n")
+    .replace(/\n+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching\. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder\.\n/g, "\n");
 }
 
 export default fleetContextFilter;

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -203,6 +203,8 @@ agents_md_guidance_homeboy_codebox_content() {
 
 **Codex provider:** Codebox Codex tasks need the OpenAI Codex provider plugin/runtime overlay and `AI_PROVIDER_OPENAI_CODEX_*` secrets passed via `secret_env`. Never print token values in logs or task instructions.
 
+**Operator verbs:** `homeboy release`, `homeboy deploy`, `homeboy fleet`, and `homeboy ssh` are operator actions. Use them only when the user explicitly asks for that action.
+
 **Chat bridges:** Kimaki, Discord, and other chat bridges display task status and results while Homeboy remains the source of truth for task state and artifacts.
 MD
 }

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -156,13 +156,14 @@ namespace {
         'starts_with_homeboy_style_category' => str_starts_with( \$content, '**Agent tasks:**' ),
         'has_agent_task_verbs' => str_contains( \$content, 'homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote' ),
         'has_sandbox_mode' => str_contains( \$content, 'use sandbox mode for Codebox coding tasks' ),
+        'has_operator_boundary' => str_contains( \$content, 'homeboy release' ) && str_contains( \$content, 'Use them only when the user explicitly asks' ),
         'has_old_workflow_comparison' => str_contains( \$content, 'instead of' ) || str_contains( \$content, 'manual chat-session fleets' ),
     ]);
 }
 PHP
 
 RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","starts_with_homeboy_style_category":true,"has_agent_task_verbs":true,"has_sandbox_mode":true,"has_old_workflow_comparison":false}'
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","starts_with_homeboy_style_category":true,"has_agent_task_verbs":true,"has_sandbox_mode":true,"has_operator_boundary":true,"has_old_workflow_comparison":false}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives Homeboy Codebox guidance section"
 
 echo "==> unregister Homeboy Codebox guidance"

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -69,6 +69,7 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 To start a new thread/session in this channel pro-grammatically, run:
 
 kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
+
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -69,9 +69,6 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 To start a new thread/session in this channel pro-grammatically, run:
 
 kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
-
-You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -67,6 +67,7 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 To start a new thread/session in this channel pro-grammatically, run:
 
 kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
+
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -67,9 +67,6 @@ This returns user IDs you can use for Discord mentions. It can fail when Server 
 To start a new thread/session in this channel pro-grammatically, run:
 
 kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --user '<discord-user-id>'
-
-You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
-Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
 When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
 
 Before sending, choose the right destination:

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/homeboy.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/data-machine.sh"
 
 TMP="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- Replaces README fleet-cooking framing with optional orchestration guidance that keeps Homeboy and Kimaki gated to installs that selected them.
- Tightens the composed Homeboy Codebox AGENTS.md section with an explicit operator-verb boundary for `release`, `deploy`, `fleet`, and `ssh`.
- Filters Kimaki's generic helper-session spawning hint from managed prompts while preserving Kimaki chat/session command examples.
- Fixes the Homeboy component test harness to source the helper that owns `homeboy_project_id`.

Fixes https://github.com/Extra-Chill/wp-coding-agents/issues/181

## Verification
- `bash tests/agents-md-guidance.sh`
- `node tests/effective-prompt/run.mjs --update && node tests/effective-prompt/run.mjs`
- `set -e; fail=0; while IFS= read -r -d '' f; do if ! bash -n "$f"; then echo "FAIL: $f"; fail=1; fi; done < <(find . -type f -name '*.sh' -not -path './.git/*' -print0); exit "$fail"`
- `./tests/bridge-render.sh`
- `./tests/opencode-wrapper-removal.sh`
- `./tests/kimaki-agent-fallback.sh`
- `node tests/setup-profile-compiler.mjs`
- `node tests/dm-agent-sync.mjs`
- `./tests/runtime-signature.sh`
- `./tests/homeboy-components.sh`
- `./tests/post-upgrade-restore.sh`
- `bash tests/repair-opencode-json.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the guidance/filter/test changes and ran local verification. Chris remains responsible for review and testing.