### PR TITLE
Fix Homeboy project detection when site URLs are blank

### DIFF
--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -120,13 +120,15 @@ detect_environment() {
       log "Detected WordPress Studio environment"
     fi
 
+    local detected_site_domain=""
     if [ "$DRY_RUN" = true ]; then
-      SITE_DOMAIN="${SITE_DOMAIN:-$(basename "$SITE_PATH")}"
+      detected_site_domain="${SITE_DOMAIN:-}"
     elif [ "$IS_STUDIO" = true ]; then
-      SITE_DOMAIN=$(studio wp option get siteurl 2>/dev/null | sed 's|https\?://||' || basename "$SITE_PATH")
+      detected_site_domain=$(studio wp option get siteurl --path="$SITE_PATH" 2>/dev/null | sed -E 's|^https?://||' || true)
     else
-      SITE_DOMAIN=$(cd "$SITE_PATH" && $WP_CMD option get siteurl $WP_ROOT_FLAG 2>/dev/null | sed 's|https\?://||' || basename "$SITE_PATH")
+      detected_site_domain=$(cd "$SITE_PATH" && $WP_CMD option get siteurl $WP_ROOT_FLAG 2>/dev/null | sed -E 's|^https?://||' || true)
     fi
+    SITE_DOMAIN="${SITE_DOMAIN:-${detected_site_domain:-$(basename "$SITE_PATH")}}"
     log "Existing WordPress at: $SITE_PATH ($SITE_DOMAIN)"
 
     # Detect if existing WP is multisite

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -62,6 +62,7 @@ PY
       printf '%s\n' "$id"
       return 0
     fi
+    return 1
   fi
 
   # 3. Resolve from Homeboy's own registered projects by matching the project
@@ -111,7 +112,11 @@ PY
     return 0
   fi
 
-  homeboy_slugify "${SITE_DOMAIN:-$SITE_PATH}"
+  if [ -n "${SITE_DOMAIN:-}" ]; then
+    homeboy_slugify "$SITE_DOMAIN"
+  elif [ -n "${SITE_PATH:-}" ]; then
+    homeboy_slugify "$(basename "$SITE_PATH")"
+  fi
 }
 
 homeboy_server_id() {

--- a/tests/detect-site-domain.sh
+++ b/tests/detect-site-domain.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# tests/detect-site-domain.sh — existing-site domain detection coverage.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/detect.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SITE_PATH="$TMP/intelligence-chubes4"
+mkdir -p "$SITE_PATH"
+touch "$SITE_PATH/wp-config.php" "$SITE_PATH/STUDIO.md"
+
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/studio" <<'SH'
+#!/bin/sh
+if [ "$1 $2 $3 $4" = "wp option get siteurl" ] && [ "$5" = "--path=$EXPECTED_SITE_PATH" ]; then
+  printf 'http://intelligence-chubes4.local\n'
+  exit 0
+fi
+if [ "$1 $2 $3 $4" = "wp option get siteurl" ]; then
+  exit 0
+fi
+if [ "$1" = "--version" ]; then
+  printf '1.0.0\n'
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$FAKE_BIN/studio"
+PATH="$FAKE_BIN:$PATH"
+EXPECTED_SITE_PATH="$SITE_PATH"
+export EXPECTED_SITE_PATH
+
+OS=""
+PLATFORM=""
+LOCAL_MODE=true
+MODE="existing"
+SKIP_DEPS=true
+SKIP_SSL=true
+RUN_AS_ROOT=false
+DRY_RUN=false
+EXISTING_WP="$SITE_PATH"
+RUNTIME="studio-code"
+MULTISITE=false
+MULTISITE_TYPE="subdirectory"
+SITE_DOMAIN=""
+WP_CMD="wp"
+
+detect_environment > "$TMP/output.log"
+
+if [ "$SITE_DOMAIN" != "intelligence-chubes4.local" ]; then
+  echo "FAIL: expected SITE_DOMAIN from path-scoped Studio siteurl, got '$SITE_DOMAIN'"
+  cat "$TMP/output.log"
+  exit 1
+fi
+
+if ! grep -q "Existing WordPress at: $SITE_PATH (intelligence-chubes4.local)" "$TMP/output.log"; then
+  echo "FAIL: expected log to include path-scoped site domain"
+  cat "$TMP/output.log"
+  exit 1
+fi
+
+SITE_DOMAIN=""
+detected_site_domain=""
+EXPECTED_SITE_PATH="$TMP/other-site"
+detect_environment > "$TMP/fallback-output.log"
+
+if [ "$SITE_DOMAIN" != "intelligence-chubes4" ]; then
+  echo "FAIL: expected SITE_DOMAIN fallback to basename when siteurl is empty, got '$SITE_DOMAIN'"
+  cat "$TMP/fallback-output.log"
+  exit 1
+fi
+
+echo "OK: existing-site domain detection scopes Studio WP-CLI to the site path and falls back when empty"

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -111,6 +111,6 @@ if [ -f "$HOMEBOY_ATTACH_LOG" ]; then
   cat "$HOMEBOY_ATTACH_LOG"
   exit 1
 fi
-assert_contains "Homeboy project config returned empty id — skipping DMC component attachment" "$TMP/empty-id-output.log"
+assert_contains "Homeboy project config not found at site root — skipping DMC component attachment" "$TMP/empty-id-output.log"
 
 echo "OK: Homeboy component attachment skips worktrees and metadata-less repos"


### PR DESCRIPTION
## Summary
- Scope Studio WP-CLI site URL detection to the target WordPress path with `studio wp option get siteurl --path=<site>` so upgrade/setup resolves the intended site instead of the ambient/default Studio context.
- Keep a basename fallback only as a last-resort guard when WP-CLI returns no site URL.
- Harden Homeboy project resolution so absolute site paths do not slugify to an empty project id, and preserve empty `homeboy.json` as a skip condition.

## Testing
- `bash tests/*.sh`
- `node tests/effective-prompt/run.mjs`
- Canary: `./upgrade.sh --skip-plugins --wp-path /Users/chubes/Studio/intelligence-chubes4` from this branch installed the generated AGENTS.md guidance without the empty Homeboy project warning.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed canary path, drafted the path-scoped resolver fix and regression test, ran local verification, and prepared this PR for Chris to review.