### PR TITLE
feat: keep WP Codebox current via subtree-aware plugin updates

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -47,3 +47,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests/kimaki-agent-fallback.sh
         run: ./tests/kimaki-agent-fallback.sh
+
+  wp-codebox-subtree:
+    name: WP Codebox subtree updater
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/wp-codebox-subtree.sh
+        run: ./tests/wp-codebox-subtree.sh

--- a/lib/wp-codebox.sh
+++ b/lib/wp-codebox.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# WP Codebox: subtree-aware plugin updates.
+#
+# WP Codebox is not a standalone single-repo plugin — it lives in the
+# `packages/wordpress-plugin/` subtree of a Node monorepo
+# (Automattic/wp-codebox). The generic update_plugin_to_latest_tag() helper
+# clones a whole repo into wp-content/plugins/<slug> and checks out a tag, which
+# would deposit the entire monorepo (not just the plugin) and never works for a
+# subtree-packaged plugin. As a result a WP Codebox install made from the
+# packaged subtree is NOT a git checkout, so update_plugin_to_latest_tag() skips
+# it and the install silently drifts behind upstream tags.
+#
+# This helper closes that gap: it sparse-checks-out the wordpress-plugin subtree
+# at the latest version tag and syncs it into wp-content/plugins/wp-codebox,
+# preserving the artifact-install shape (no .git in the plugin dir) while keeping
+# it current. It is a no-op unless WP Codebox is already installed (we do not
+# install it here — that remains the setup interview's job).
+
+WP_CODEBOX_REPO_URL="${WP_CODEBOX_REPO_URL:-https://github.com/Automattic/wp-codebox.git}"
+WP_CODEBOX_PLUGIN_SUBTREE="${WP_CODEBOX_PLUGIN_SUBTREE:-packages/wordpress-plugin}"
+
+# Resolve the latest version tag from the remote without a full clone.
+_wp_codebox_latest_tag() {
+  git ls-remote --tags --refs "$WP_CODEBOX_REPO_URL" 2>/dev/null \
+    | awk -F/ '{print $NF}' \
+    | grep -E '^v?[0-9]' \
+    | sort -V \
+    | tail -n 1
+}
+
+# Read the Version: header from a plugin main file.
+_wp_codebox_header_version() {
+  local main_file="$1"
+  [ -f "$main_file" ] || return 1
+  grep -m1 -E '^\s*\*?\s*Version:' "$main_file" \
+    | sed -E 's/.*Version:\s*([0-9][0-9.]*).*/\1/'
+}
+
+update_wp_codebox_plugin_subtree() {
+  if [ "$INSTALL_DATA_MACHINE" != true ]; then
+    return 0
+  fi
+
+  local plugin_dir="$SITE_PATH/wp-content/plugins/wp-codebox"
+
+  if [ ! -d "$plugin_dir" ]; then
+    log "WP Codebox not installed — skipping subtree update"
+    return 0
+  fi
+
+  # If it IS a git checkout, the generic tagged-release path already handles it;
+  # don't double-manage.
+  if [ -d "$plugin_dir/.git" ]; then
+    update_plugin_to_latest_tag wp-codebox "$WP_CODEBOX_REPO_URL"
+    return 0
+  fi
+
+  local latest_tag
+  latest_tag="$(_wp_codebox_latest_tag)"
+  if [ -z "$latest_tag" ]; then
+    warn "Could not resolve latest WP Codebox tag — skipping subtree update"
+    return 0
+  fi
+
+  local current_version
+  current_version="$(_wp_codebox_header_version "$plugin_dir/wp-codebox.php" || echo "")"
+  local target_version="${latest_tag#v}"
+
+  if [ -n "$current_version" ] && [ "$current_version" = "$target_version" ]; then
+    log "WP Codebox already at latest tag ($latest_tag)"
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Sparse-checkout ${WP_CODEBOX_PLUGIN_SUBTREE} at ${latest_tag} and sync into ${plugin_dir}"
+    echo -e "${BLUE}[dry-run]${NC} WP Codebox ${current_version:-unknown} → ${target_version}"
+    return 0
+  fi
+
+  log "Updating WP Codebox: ${current_version:-unknown} → ${target_version} (subtree sync)"
+
+  local staging
+  staging="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$staging'" RETURN
+
+  if ! git clone --depth 1 --branch "$latest_tag" --filter=blob:none --sparse \
+      "$WP_CODEBOX_REPO_URL" "$staging/repo" >/dev/null 2>&1; then
+    warn "Could not clone WP Codebox at ${latest_tag} — skipping subtree update"
+    return 0
+  fi
+
+  if ! git -C "$staging/repo" sparse-checkout set "$WP_CODEBOX_PLUGIN_SUBTREE" >/dev/null 2>&1; then
+    warn "Could not sparse-checkout ${WP_CODEBOX_PLUGIN_SUBTREE} — skipping subtree update"
+    return 0
+  fi
+
+  local src="$staging/repo/$WP_CODEBOX_PLUGIN_SUBTREE"
+  if [ ! -f "$src/wp-codebox.php" ]; then
+    warn "WP Codebox plugin subtree missing wp-codebox.php at ${latest_tag} — skipping subtree update"
+    return 0
+  fi
+
+  # Sync the subtree into the plugin dir. Replace src/ wholesale (the file set
+  # changes between versions), then copy the remaining top-level plugin files.
+  rm -rf "$plugin_dir/src"
+  cp -a "$src/src" "$plugin_dir/src"
+  [ -d "$src/assets" ] && { rm -rf "$plugin_dir/assets"; cp -a "$src/assets" "$plugin_dir/assets"; }
+  cp -a "$src/wp-codebox.php" "$plugin_dir/wp-codebox.php"
+  [ -f "$src/README.md" ] && cp -a "$src/README.md" "$plugin_dir/README.md"
+  [ -f "$src/package.json" ] && cp -a "$src/package.json" "$plugin_dir/package.json"
+
+  fix_ownership "$plugin_dir"
+  activate_plugin wp-codebox
+
+  UPDATED_ITEMS+=("wp-codebox $latest_tag")
+}

--- a/tests/wp-codebox-subtree.sh
+++ b/tests/wp-codebox-subtree.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# tests/wp-codebox-subtree.sh — unit test for the WP Codebox subtree updater.
+#
+# Verifies the drift-prevention helper without touching the network: a stubbed
+# `git ls-remote` provides the latest tag, and the test asserts the helper's
+# decisions (skip when not installed, no-op when already current, sync when
+# behind, delegate when it is a real git checkout).
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/wp-codebox.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Minimal harness state + stubs the helper depends on. -------------------
+BLUE=""
+NC=""
+DRY_RUN=false
+INSTALL_DATA_MACHINE=true
+declare -a UPDATED_ITEMS=()
+declare -a LOG_LINES=()
+
+log()  { LOG_LINES+=("$*"); }
+warn() { LOG_LINES+=("WARN: $*"); }
+fix_ownership() { :; }
+activate_plugin() { :; }
+update_plugin_to_latest_tag() { LOG_LINES+=("DELEGATED: $1"); }
+
+logged_contains() {
+  local needle="$1"
+  local line
+  for line in "${LOG_LINES[@]}"; do
+    case "$line" in
+      *"$needle"*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Stub git: only `git ls-remote --tags ...` is used for tag resolution here.
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/git" <<'SH'
+#!/bin/bash
+if [ "$1" = "ls-remote" ]; then
+  # Emit a couple of refs; helper takes the highest via sort -V.
+  printf 'abc\trefs/tags/v0.4.0\n'
+  printf 'def\trefs/tags/v0.5.0\n'
+  exit 0
+fi
+# Any clone/sparse-checkout in these tests is unexpected; make it loud.
+echo "unexpected git invocation: $*" >&2
+exit 1
+SH
+chmod +x "$FAKE_BIN/git"
+PATH="$FAKE_BIN:$PATH"
+export PATH
+
+make_plugin_dir() {
+  local version="$1"
+  local dir="$TMP/site/wp-content/plugins/wp-codebox"
+  rm -rf "$dir"
+  mkdir -p "$dir/src"
+  cat > "$dir/wp-codebox.php" <<PHP
+<?php
+/**
+ * Plugin Name: WP Codebox
+ * Version: ${version}
+ */
+PHP
+  echo "$dir"
+}
+
+# --- Case 1: not installed → skip cleanly. ----------------------------------
+SITE_PATH="$TMP/empty-site"
+mkdir -p "$SITE_PATH/wp-content/plugins"
+LOG_LINES=()
+update_wp_codebox_plugin_subtree
+logged_contains "not installed" || fail "Case 1: expected not-installed skip"
+
+# --- Case 2: installed and already at latest (0.5.0) → no-op. ----------------
+SITE_PATH="$TMP/site"
+make_plugin_dir "0.5.0" >/dev/null
+LOG_LINES=()
+update_wp_codebox_plugin_subtree
+logged_contains "already at latest tag (v0.5.0)" || fail "Case 2: expected already-at-latest no-op"
+[ "${#UPDATED_ITEMS[@]}" -eq 0 ] || fail "Case 2: must not record an update when current"
+
+# --- Case 3: real git checkout → delegate to update_plugin_to_latest_tag. -----
+SITE_PATH="$TMP/site"
+plugin_dir="$(make_plugin_dir "0.4.0")"
+mkdir -p "$plugin_dir/.git"
+LOG_LINES=()
+update_wp_codebox_plugin_subtree
+logged_contains "DELEGATED: wp-codebox" || fail "Case 3: expected delegation for a git checkout"
+rm -rf "$plugin_dir/.git"
+
+# --- Case 4: behind + dry-run → reports the intended sync, performs no write. -
+# Dry-run lines are emitted to stdout (echo), matching the codebase convention,
+# so capture stdout rather than the log buffer for this case.
+SITE_PATH="$TMP/site"
+make_plugin_dir "0.4.0" >/dev/null
+DRY_RUN=true
+UPDATED_ITEMS=()
+case4_out="$(update_wp_codebox_plugin_subtree)"
+case "$case4_out" in
+  *"0.4.0 → 0.5.0"*) : ;;
+  *) fail "Case 4: expected dry-run to report 0.4.0 → 0.5.0 (got: $case4_out)" ;;
+esac
+[ "${#UPDATED_ITEMS[@]}" -eq 0 ] || fail "Case 4: dry-run must not record an update"
+DRY_RUN=false
+
+# --- Case 5: --no-data-machine equivalent (INSTALL_DATA_MACHINE=false) skips. -
+SITE_PATH="$TMP/site"
+make_plugin_dir "0.4.0" >/dev/null
+INSTALL_DATA_MACHINE=false
+LOG_LINES=()
+update_wp_codebox_plugin_subtree
+[ "${#LOG_LINES[@]}" -eq 0 ] || fail "Case 5: expected a clean skip when Data Machine install is disabled"
+INSTALL_DATA_MACHINE=true
+
+echo "wp-codebox-subtree tests passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -6,7 +6,8 @@
 # Phases:
 #   1. Detect environment (auto-detects local vs VPS, runtime, chat bridge —
 #      supports kimaki, cc-connect, telegram).
-#   2. Update setup-installed Data Machine plugins to latest tagged releases.
+#   2. Update setup-installed Data Machine plugins to latest tagged releases,
+#      and sync WP Codebox (subtree-packaged) to its latest tag when installed.
 #   3. Sync chat-bridge config (dispatches per bridge)
 #        kimaki:
 #          VPS:   /opt/kimaki-config (plugins + post-upgrade.sh + skill filters)
@@ -65,7 +66,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect wordpress data-machine homeboy skills cli-channel runtime-signature agents-md-guidance; do
+for lib in common detect wordpress data-machine wp-codebox homeboy skills cli-channel runtime-signature agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -323,6 +324,7 @@ _run_filter_active() {
 update_data_machine_plugins() {
   _run_filter_active plugins || return 0
   upgrade_data_machine_plugins
+  update_wp_codebox_plugin_subtree
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`upgrade.sh` never updated WP Codebox, so installs **silently drift behind upstream**. Observed in the field: a WP Codebox install pinned at **0.1.0** while upstream had shipped **0.5.0** — four minor versions of browser-probe runtime behind, which broke the WordPress extension's PHPUnit-via-WP-Codebox test harness until the plugin was manually synced.

## Root cause

WP Codebox is packaged as the `packages/wordpress-plugin/` **subtree of a Node monorepo** (`Automattic/wp-codebox`), not a standalone single-repo plugin. The generic `update_plugin_to_latest_tag()` helper clones a whole repo into `wp-content/plugins/<slug>` and checks out a tag — which cannot work for a subtree-packaged plugin (it would deposit the entire monorepo). So a WP Codebox install made from the packaged subtree is **not a git checkout**, the tagged-release path skips it (`"…is not a git checkout — skipping tagged release update"`), and it never advances.

## The fix

New `lib/wp-codebox.sh::update_wp_codebox_plugin_subtree()`, wired into the plugins phase right after the Data Machine plugin update:

- Resolves the latest version tag via `git ls-remote` (no full clone).
- When the install is behind, **sparse-checks-out the `packages/wordpress-plugin` subtree at that tag** and syncs `src/`, `assets/`, `wp-codebox.php`, `README.md`, `package.json` into `wp-content/plugins/wp-codebox`, preserving the artifact-install shape (no `.git` in the plugin dir).
- **No-op when WP Codebox is not installed** — installation stays the setup interview's job.
- **Delegates** to `update_plugin_to_latest_tag()` when the install *is* a real git checkout.
- Honors `--dry-run`, `--skip-plugins`, and `--no-data-machine` like the existing plugin phase.

Verified against the live site in dry-run: `WP Codebox already at latest tag (v0.5.0)`.

## Tests

`tests/wp-codebox-subtree.sh` (network-free; stubbed `git ls-remote`) covers:
1. not-installed → clean skip
2. already-at-latest → no-op, records no update
3. real git checkout → delegates to `update_plugin_to_latest_tag`
4. behind + dry-run → reports `0.4.0 → 0.5.0`, performs no write
5. `INSTALL_DATA_MACHINE=false` → clean skip

Registered in `.github/workflows/shell.yml`. All passing locally.