### PR TITLE
feat: derive opencode instructions from Data Machine injectable memory files

### DIFF
--- a/bridges/kimaki/plugins/dm-agent-sync.ts
+++ b/bridges/kimaki/plugins/dm-agent-sync.ts
@@ -1,8 +1,20 @@
 // dm-agent-sync.ts — OpenCode plugin that refreshes Data Machine memory.
 //
-// On session start, asks Data Machine to recompose memory files such as
-// AGENTS.md. Agent identity stays in Data Machine's channel/session binding and
-// OpenCode's top-level instructions instead of mutating config.agent.* prompts.
+// On session start it:
+//   1. Recomposes Data Machine's composable memory files (e.g. AGENTS.md) so
+//      they match live WordPress state before OpenCode reads them.
+//   2. Derives OpenCode's top-level `instructions` list from Data Machine's
+//      registered injectable memory files, instead of relying on a static,
+//      hand-maintained list in opencode.json that silently drifts whenever a
+//      new memory file is registered in Data Machine.
+//
+// Agent identity stays in Data Machine's channel/session binding and OpenCode's
+// top-level instructions instead of mutating config.agent.* prompts.
+//
+// Layer note: Data Machine is agnostic to how its memory files are consumed —
+// `datamachine memory injectable-files` returns generic resolved paths and
+// knows nothing about OpenCode. The OpenCode-specific knowledge (writing those
+// paths into config.instructions) lives here, in the integration layer.
 //
 // How to use:
 //   Add to opencode.json:  "plugin": ["path/to/dm-agent-sync.ts"]
@@ -13,13 +25,22 @@
  */
 import type { Plugin } from "@opencode-ai/plugin";
 
+interface InjectableFile {
+  filename: string;
+  layer: string;
+  path: string;
+  priority: number;
+}
+
 const dmAgentSync: Plugin = async ({ $ }) => {
   return {
-    config: async () => {
+    config: async (input) => {
       const wpAvailable = await $`command -v wp`.quiet().nothrow();
       if (wpAvailable.exitCode !== 0) {
         return;
       }
+
+      const sitePath = getSitePath();
 
       // Refresh composable files before the session reads them.
       // DM SectionRegistry callbacks render live state (configured sources,
@@ -28,7 +49,6 @@ const dmAgentSync: Plugin = async ({ $ }) => {
       // edits, or other external processes would leave AGENTS.md stale.
       // Running compose here guarantees the file matches live state at the
       // moment OpenCode loads the session prompt.
-      const sitePath = getSitePath();
       const composeResult = sitePath
         ? await $`wp --path=${sitePath} datamachine memory compose --allow-root`.quiet().nothrow()
         : await $`wp datamachine memory compose --allow-root`.quiet().nothrow();
@@ -39,9 +59,62 @@ const dmAgentSync: Plugin = async ({ $ }) => {
       }
       // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
       console.warn("[dm-agent-sync] recomposed Data Machine memory");
+
+      // Derive the instructions list from DM's registered injectable memory
+      // files so it stays in sync with the registry. If DM is too old to
+      // provide the command, or it returns nothing usable, leave whatever
+      // static list opencode.json already has untouched (graceful no-op).
+      await syncInstructions(input, sitePath, $);
     },
   };
 };
+
+/**
+ * Replace config.instructions with the absolute paths Data Machine reports as
+ * injectable for the active agent. Only existing files are included (DM already
+ * filters to on-disk files), so a registered-but-not-yet-written file like a
+ * freshly added briefing won't break session load.
+ */
+async function syncInstructions(
+  input: { instructions?: string[] },
+  sitePath: string,
+  $: any,
+): Promise<void> {
+  const result = sitePath
+    ? await $`wp --path=${sitePath} datamachine memory injectable-files --format=json --allow-root`.quiet().nothrow()
+    : await $`wp datamachine memory injectable-files --format=json --allow-root`.quiet().nothrow();
+
+  if (result.exitCode !== 0) {
+    // DM predates the command, or the call failed — keep the existing list.
+    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+    console.warn(`[dm-agent-sync] injectable-files unavailable (exit ${result.exitCode}); leaving instructions unchanged`);
+    return;
+  }
+
+  const raw = await shellOutputText(result);
+  let files: InjectableFile[];
+  try {
+    files = JSON.parse(raw);
+  } catch {
+    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+    console.warn("[dm-agent-sync] could not parse injectable-files output; leaving instructions unchanged");
+    return;
+  }
+
+  const paths = Array.isArray(files)
+    ? files.map((f) => f?.path).filter((p): p is string => typeof p === "string" && p.length > 0)
+    : [];
+
+  if (paths.length === 0) {
+    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+    console.warn("[dm-agent-sync] injectable-files returned no paths; leaving instructions unchanged");
+    return;
+  }
+
+  input.instructions = paths;
+  // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+  console.warn(`[dm-agent-sync] synced ${paths.length} instruction file(s) from Data Machine`);
+}
 
 function getSitePath(): string {
   return process.env.DATAMACHINE_SITE_PATH || process.env.SITE_PATH || process.env.PWD || "";


### PR DESCRIPTION
## Summary

Extends the `dm-agent-sync` opencode plugin so the top-level `instructions` list is **derived from Data Machine's registered injectable memory files** instead of a static, hand-maintained array in `opencode.json` that silently drifts whenever a new memory file is registered in DM.

Closes #192. Depends on **Extra-Chill/data-machine#2568** (the `injectable-files` command this consumes).

## Problem

Two disconnected injection systems existed:
1. **DM runtime AI calls** — inject all registered memory files (incl. new ones like WAKE.md). ✓
2. **opencode sessions** — read a **static** `instructions` array in `opencode.json` that nothing keeps in sync with DM's registry.

`dm-agent-sync` previously only ran `datamachine memory compose` (refreshing composable files like AGENTS.md); it never touched the instructions list. So any memory file DM registers for injection was invisible to opencode sessions until someone hand-edited `opencode.json` — a latent drift bug for the whole class of "new memory file."

## Fix

In the plugin's `config` hook, after the existing compose, call:
```
wp datamachine memory injectable-files --format=json
```
parse the resolved absolute paths, and write them into `config.instructions`. The opencode `config(input)` hook receives a mutable `Config` whose `instructions?: string[]` field we replace. Now any file DM registers for injection flows to opencode automatically — zero hand-edits, drift bug gone.

## Graceful degradation

Leaves the existing instructions list **untouched** if:
- DM predates the command (call exits non-zero),
- output can't be parsed as JSON,
- or no paths come back.

DM already filters to on-disk files, so a registered-but-not-yet-written file (e.g. a briefing before its task first runs) can't break session load.

## Layer boundary (correct split)

- **data-machine (#2568)** answers "which of MY files should inject?" — generic resolved paths, no opencode knowledge.
- **this plugin** owns "how opencode consumes that" — the `injectable-files` call + writing `config.instructions`. Runtime-specific code lives here, the only place it belongs.

## Verification

- **TypeScript transpiles clean** (`bun build bridges/kimaki/plugins/dm-agent-sync.ts`).
- The consumed command was verified live in the DM PR (#2570 / data-machine#2568): for the primary agent it returns NETWORK/SITE/RULES/SOUL/USER/MEMORY — **exactly the set currently hardcoded in `opencode.json`** — so this swap is behavior-preserving today, and additive (WAKE.md etc.) once those land.

> Note: `homeboy lint` on the local VPS dev box currently fails ESLint with a `js-yaml` parse error trying to load `eslint.config.mjs` via the legacy eslintrc loader — that's an environment/toolchain mismatch on this box (ESLint 8.57 + flat config), **not** a finding against this file (0 findings reported). CI uses its own pinned toolchain.

## Constraints honored

- Conventional commit (`feat:`).
- No version bumps / changelog edits (homeboy-managed).