### PR TITLE
Make wp-coding-agents skills opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ EXISTING_WP=~/Studio/my-wordpress-website ./setup.sh --local --runtime claude-co
 EXISTING_WP=~/Studio/my-wordpress-website ./setup.sh --local --runtime studio-code
 ```
 
-On macOS, `--local` is auto-detected. The script installs Data Machine, the coding agent, agent skills, and optionally a chat bridge — no infrastructure, no root, no systemd.
+On macOS, `--local` is auto-detected. The script installs Data Machine, the coding agent runtime, and optionally a chat bridge — no infrastructure, no root, no systemd. Optional operator skills are installed only with `--with-skills`.
 
 Start your agent:
 
@@ -131,7 +131,8 @@ systemctl start kimaki  # or: systemctl start cc-connect
 | `--chat <bridge>` | Chat bridge: `kimaki` (Discord, default for OpenCode), `cc-connect` (default for Claude Code and Studio Code), `telegram` |
 | `--multisite` | Convert to WordPress Multisite (subdirectory by default) |
 | `--subdomain` | Subdomain multisite (use with `--multisite`, requires wildcard DNS) |
-| `--no-skills` | Skip wp-coding-agents skills |
+| `--with-skills` | Install optional wp-coding-agents setup/upgrade skills |
+| `--no-skills` | Do not install wp-coding-agents skills (default) |
 | `--skip-deps` | Skip apt packages |
 | `--skip-ssl` | Skip SSL/HTTPS |
 | `--root` | Run agent as root (default on VPS) |
@@ -186,7 +187,7 @@ SITE_DOMAIN=example.com ./setup.sh --dry-run
 | **[Homeboy](https://github.com/Extra-Chill/homeboy)** | Optional developer power layer for project status, component-aware checks, review loops, and WordPress extension verification | `--with-homeboy` |
 | **[Kimaki](https://kimaki.xyz)**, **[cc-connect](https://github.com/nichochar/cc-connect)**, or **[opencode-telegram](https://github.com/grinev/opencode-telegram-bot)** | Chat bridge (Discord, multi-platform, or Telegram) | `--no-chat` |
 | **SessionStart hook** | Syncs Data Machine agents into CLAUDE.md on every session (Claude Code and Studio Code) | Always installed |
-| **wp-coding-agents skills** | Setup and upgrade runbooks shipped with this repo. The composed `AGENTS.md` provides the site-specific WordPress, Data Machine, and Homeboy operating context, so setup does not install redundant external skills. | `--no-skills` |
+| **wp-coding-agents skills** | Optional setup and upgrade runbooks shipped with this repo for operators who use skill-capable agents. The composed `AGENTS.md` provides the site-specific WordPress, Data Machine, and Homeboy operating context; these skills are not needed for normal runtime operation. | `--with-skills` |
 
 ## VPS vs. Local
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ EXISTING_WP=~/Studio/my-wordpress-website ./setup.sh --local --runtime claude-co
 EXISTING_WP=~/Studio/my-wordpress-website ./setup.sh --local --runtime studio-code
 ```
 
-On macOS, `--local` is auto-detected. The script installs Data Machine, the coding agent runtime, and optionally a chat bridge — no infrastructure, no root, no systemd. Optional operator skills are installed only with `--with-skills`.
+On macOS, `--local` is auto-detected. The script installs Data Machine, the coding agent runtime, the upgrade skill, and optionally a chat bridge — no infrastructure, no root, no systemd.
 
 Start your agent:
 
@@ -131,8 +131,7 @@ systemctl start kimaki  # or: systemctl start cc-connect
 | `--chat <bridge>` | Chat bridge: `kimaki` (Discord, default for OpenCode), `cc-connect` (default for Claude Code and Studio Code), `telegram` |
 | `--multisite` | Convert to WordPress Multisite (subdirectory by default) |
 | `--subdomain` | Subdomain multisite (use with `--multisite`, requires wildcard DNS) |
-| `--with-skills` | Install optional wp-coding-agents setup/upgrade skills |
-| `--no-skills` | Do not install wp-coding-agents skills (default) |
+| `--no-skills` | Skip installing the wp-coding-agents upgrade skill |
 | `--skip-deps` | Skip apt packages |
 | `--skip-ssl` | Skip SSL/HTTPS |
 | `--root` | Run agent as root (default on VPS) |
@@ -187,7 +186,7 @@ SITE_DOMAIN=example.com ./setup.sh --dry-run
 | **[Homeboy](https://github.com/Extra-Chill/homeboy)** | Optional developer power layer for project status, component-aware checks, review loops, and WordPress extension verification | `--with-homeboy` |
 | **[Kimaki](https://kimaki.xyz)**, **[cc-connect](https://github.com/nichochar/cc-connect)**, or **[opencode-telegram](https://github.com/grinev/opencode-telegram-bot)** | Chat bridge (Discord, multi-platform, or Telegram) | `--no-chat` |
 | **SessionStart hook** | Syncs Data Machine agents into CLAUDE.md on every session (Claude Code and Studio Code) | Always installed |
-| **wp-coding-agents skills** | Optional setup and upgrade runbooks shipped with this repo for operators who use skill-capable agents. The composed `AGENTS.md` provides the site-specific WordPress, Data Machine, and Homeboy operating context; these skills are not needed for normal runtime operation. | `--with-skills` |
+| **wp-coding-agents upgrade skill** | Ongoing upgrade runbook installed with the target agent. The setup skill is intentionally not installed; it is a single-use pre-install entrypoint kept in this repo for the operator's local agent. | `--no-skills` |
 
 ## VPS vs. Local
 

--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -60,7 +60,12 @@ else
 fi
 
 REQUIRED_PLUGINS=(dm-context-filter.ts dm-agent-sync.ts)
-WP_CODING_AGENTS_SKILLS=(upgrade-wp-coding-agents wp-coding-agents-setup)
+WP_CODING_AGENTS_SKILLS=(
+  upgrade-wp-coding-agents
+  wp-coding-agents-setup
+  wp-coding-agents-setup-interview
+  wp-coding-agents-setup-verify
+)
 
 is_wp_coding_agents_skill() {
   local candidate="$1"

--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -60,12 +60,7 @@ else
 fi
 
 REQUIRED_PLUGINS=(dm-context-filter.ts dm-agent-sync.ts)
-WP_CODING_AGENTS_SKILLS=(
-  upgrade-wp-coding-agents
-  wp-coding-agents-setup
-  wp-coding-agents-setup-interview
-  wp-coding-agents-setup-verify
-)
+WP_CODING_AGENTS_SKILLS=(upgrade-wp-coding-agents)
 
 is_wp_coding_agents_skill() {
   local candidate="$1"

--- a/lib/skills.sh
+++ b/lib/skills.sh
@@ -3,7 +3,12 @@
 # Site-specific WordPress, Data Machine, and Homeboy guidance belongs in the
 # composed AGENTS.md, which is fresher than static external skill snapshots.
 
-WP_CODING_AGENTS_SKILLS=(upgrade-wp-coding-agents wp-coding-agents-setup)
+WP_CODING_AGENTS_SKILLS=(
+  upgrade-wp-coding-agents
+  wp-coding-agents-setup
+  wp-coding-agents-setup-interview
+  wp-coding-agents-setup-verify
+)
 
 is_wp_coding_agents_skill() {
   local candidate="$1"
@@ -16,28 +21,6 @@ is_wp_coding_agents_skill() {
   return 1
 }
 
-remove_unmanaged_skills() {
-  local target_dir="$1"
-  local label="$2"
-
-  [ -d "$target_dir" ] || return
-
-  local removed=0
-  local skill_dir skill_name
-  for skill_dir in "$target_dir"/*/; do
-    [ -d "$skill_dir" ] || continue
-    skill_name=$(basename "$skill_dir")
-    if [ -f "$skill_dir/SKILL.md" ] && ! is_wp_coding_agents_skill "$skill_name"; then
-      rm -rf "$skill_dir"
-      removed=$((removed + 1))
-    fi
-  done
-
-  if [ "$removed" -gt 0 ]; then
-    log "Removed unmanaged skills from $label: $target_dir/ ($removed)"
-  fi
-}
-
 # Install skills shipped in this repo ($SCRIPT_DIR/skills/).
 # These are the skills that ship with wp-coding-agents itself — e.g.
 # upgrade-wp-coding-agents and wp-coding-agents-setup — so every install
@@ -47,7 +30,6 @@ install_skills_from_local_repo() {
   [ -d "$src_dir" ] || return
 
   if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} Would remove unmanaged skills from $SKILLS_DIR/"
     for skill_dir in "$src_dir"/*/; do
       local skill_name
       skill_name=$(basename "$skill_dir")
@@ -57,8 +39,6 @@ install_skills_from_local_repo() {
     done
     return
   fi
-
-  remove_unmanaged_skills "$SKILLS_DIR" "runtime skills dir"
 
   local copied=0
   for skill_dir in "$src_dir"/*/; do
@@ -103,8 +83,6 @@ install_skills_to_persistent_source() {
     warn "Could not create persistent skill source dir $persistent_dir — skipping mirror"
     return
   }
-
-  remove_unmanaged_skills "$persistent_dir" "persistent source"
 
   local copied=0
   for skill_dir in "$SCRIPT_DIR/skills"/*/; do

--- a/lib/skills.sh
+++ b/lib/skills.sh
@@ -3,12 +3,7 @@
 # Site-specific WordPress, Data Machine, and Homeboy guidance belongs in the
 # composed AGENTS.md, which is fresher than static external skill snapshots.
 
-WP_CODING_AGENTS_SKILLS=(
-  upgrade-wp-coding-agents
-  wp-coding-agents-setup
-  wp-coding-agents-setup-interview
-  wp-coding-agents-setup-verify
-)
+WP_CODING_AGENTS_SKILLS=(upgrade-wp-coding-agents)
 
 is_wp_coding_agents_skill() {
   local candidate="$1"
@@ -22,9 +17,9 @@ is_wp_coding_agents_skill() {
 }
 
 # Install skills shipped in this repo ($SCRIPT_DIR/skills/).
-# These are the skills that ship with wp-coding-agents itself — e.g.
-# upgrade-wp-coding-agents and wp-coding-agents-setup — so every install
-# can run them without a manual copy step.
+# The installed set intentionally excludes setup. Setup is a pre-install entry
+# point that should be used once from the operator's machine, then discarded.
+# Installed agents only need the upgrade runbook for ongoing maintenance.
 install_skills_from_local_repo() {
   local src_dir="$SCRIPT_DIR/skills"
   [ -d "$src_dir" ] || return

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -63,7 +63,7 @@ print_summary() {
   if [ "$INSTALL_SKILLS" = true ]; then
     echo "  Skills:   $SKILLS_DIR"
   else
-    echo "  Skills:   Skipped (optional; use --with-skills)"
+    echo "  Skills:   Skipped (--no-skills)"
   fi
   echo ""
 

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -63,7 +63,7 @@ print_summary() {
   if [ "$INSTALL_SKILLS" = true ]; then
     echo "  Skills:   $SKILLS_DIR"
   else
-    echo "  Skills:   Skipped (--no-skills)"
+    echo "  Skills:   Skipped (optional; use --with-skills)"
   fi
   echo ""
 

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ DRY_RUN=false
 RUN_AS_ROOT=true
 MULTISITE=false
 MULTISITE_TYPE="subdirectory"
-INSTALL_SKILLS=true
+INSTALL_SKILLS=false
 SKILLS_ONLY=false
 RUNTIME_ONLY=false
 WITH_HOMEBOY=false
@@ -69,6 +69,7 @@ while [[ $# -gt 0 ]]; do
   case $1 in
     --skills-only)
       SKILLS_ONLY=true
+      INSTALL_SKILLS=true
       shift
       ;;
     --existing)
@@ -126,6 +127,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-skills)
       INSTALL_SKILLS=false
+      shift
+      ;;
+    --with-skills)
+      INSTALL_SKILLS=true
       shift
       ;;
     --with-homeboy)
@@ -201,7 +206,8 @@ OPTIONS:
   --skip-deps        Skip apt package installation
   --multisite        Convert to WordPress Multisite (subdirectory by default)
   --subdomain        Use subdomain multisite (requires wildcard DNS; use with --multisite)
-  --no-skills        Skip wp-coding-agents skill installation
+  --with-skills      Install optional wp-coding-agents operator skills
+  --no-skills        Do not install wp-coding-agents skills (default)
   --with-homeboy     Create/update a Homeboy project and install/verify the
                      WordPress Homeboy extension
   --no-homeboy       Skip Homeboy project setup, even if homeboy is installed

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ DRY_RUN=false
 RUN_AS_ROOT=true
 MULTISITE=false
 MULTISITE_TYPE="subdirectory"
-INSTALL_SKILLS=false
+INSTALL_SKILLS=true
 SKILLS_ONLY=false
 RUNTIME_ONLY=false
 WITH_HOMEBOY=false
@@ -127,10 +127,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-skills)
       INSTALL_SKILLS=false
-      shift
-      ;;
-    --with-skills)
-      INSTALL_SKILLS=true
       shift
       ;;
     --with-homeboy)
@@ -206,14 +202,13 @@ OPTIONS:
   --skip-deps        Skip apt package installation
   --multisite        Convert to WordPress Multisite (subdirectory by default)
   --subdomain        Use subdomain multisite (requires wildcard DNS; use with --multisite)
-  --with-skills      Install optional wp-coding-agents operator skills
-  --no-skills        Do not install wp-coding-agents skills (default)
+  --no-skills        Skip installing the wp-coding-agents upgrade skill
   --with-homeboy     Create/update a Homeboy project and install/verify the
                      WordPress Homeboy extension
   --no-homeboy       Skip Homeboy project setup, even if homeboy is installed
   --homeboy-project-id <id>
                      Override Homeboy project ID (default: agent/site slug)
-  --skills-only      Only run wp-coding-agents skill installation on existing site
+  --skills-only      Only run wp-coding-agents upgrade skill installation on existing site
   --runtime-only     Only run runtime setup on an existing agent install
                      (use with --runtime <name> to add another runtime)
   --skip-ssl         Skip SSL/HTTPS configuration

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -12,7 +12,7 @@ By default it also updates the setup-installed Data Machine plugins (`data-machi
 
 If the install was created with the optional Homeboy layer, upgrade should preserve that model: the WordPress site root is the Homeboy **project**, primary Data Machine Code workspace checkouts are attached **components**, and `repo@branch` worktrees remain skipped by default. Homeboy is external to wp-coding-agents; do not vendor it or treat the site root as a component during upgrade guidance.
 
-Setup uses `wp-coding-agents-setup-interview` and `scripts/compile-setup-profile.mjs` to map a new install profile into commands. Upgrade intentionally does **not** duplicate that compiler: `upgrade.sh` owns detection, bridge selection, dry-run diffs, and summary commands for an already-installed environment.
+Setup uses `skills/wp-coding-agents-setup/interview.md` and `scripts/compile-setup-profile.mjs` to map a new install profile into commands. Upgrade intentionally does **not** duplicate that compiler: `upgrade.sh` owns detection, bridge selection, dry-run diffs, and summary commands for an already-installed environment.
 
 ## When to use
 

--- a/skills/wp-coding-agents-setup/SKILL.md
+++ b/skills/wp-coding-agents-setup/SKILL.md
@@ -76,7 +76,7 @@ Do not duplicate script internals in this skill. Compile commands from the user'
 - Use `WP_CMD="studio wp"` for WordPress Studio installs when the compiler selects that overlay.
 - Use `--with-homeboy` only when the user wants the optional developer layer.
 - Use `--no-chat` when the user wants terminal/SSH-only operation.
-- Use `--no-skills` only when the user explicitly wants to skip installing wp-coding-agents skills.
+- Use `--with-skills` only when the user explicitly wants optional wp-coding-agents setup/upgrade skills installed into the target runtime.
 
 ## When To Use
 

--- a/skills/wp-coding-agents-setup/SKILL.md
+++ b/skills/wp-coding-agents-setup/SKILL.md
@@ -12,11 +12,11 @@ This skill is only the orchestrator. Keep the setup matrix composable:
 
 ```text
 wp-coding-agents-setup
-  -> wp-coding-agents-setup-interview
+  -> skills/wp-coding-agents-setup/interview.md
   -> scripts/compile-setup-profile.mjs
   -> dry-run setup command
   -> confirmed setup command
-  -> wp-coding-agents-setup-verify
+  -> skills/wp-coding-agents-setup/verify.md
 ```
 
 ## Source Of Truth
@@ -44,8 +44,8 @@ Do not duplicate script internals in this skill. Compile commands from the user'
    ./setup.sh --help
    ```
 
-2. **Run the interview skill.**
-   Use `wp-coding-agents-setup-interview` to collect a structured JSON setup profile. The interview collects facts only; it does not choose commands or verification steps.
+2. **Follow the interview branch.**
+   Read `skills/wp-coding-agents-setup/interview.md` to collect a structured JSON setup profile. The interview collects facts only; it does not choose commands or verification steps.
 
 3. **Run the deterministic compiler script.**
    Save the profile to a temporary JSON file or pipe it on stdin, then run `node scripts/compile-setup-profile.mjs <profile.json>` to turn the profile into:
@@ -64,8 +64,8 @@ Do not duplicate script internals in this skill. Compile commands from the user'
 6. **Run setup after confirmation.**
    Drop `--dry-run` from the compiled command. Do not restart an existing live chat bridge unless the user explicitly asks; for a new install, follow the script's post-setup guidance.
 
-7. **Run the verification skill.**
-   Use `wp-coding-agents-setup-verify` with the compiler script's verification overlay names. Report exact failures and source them back to the relevant axis: install target, runtime, bridge, or optional overlay.
+7. **Follow the verification branch.**
+   Read `skills/wp-coding-agents-setup/verify.md` with the compiler script's verification overlay names. Report exact failures and source them back to the relevant axis: install target, runtime, bridge, or optional overlay.
 
 ## Policy Boundaries
 
@@ -76,7 +76,7 @@ Do not duplicate script internals in this skill. Compile commands from the user'
 - Use `WP_CMD="studio wp"` for WordPress Studio installs when the compiler selects that overlay.
 - Use `--with-homeboy` only when the user wants the optional developer layer.
 - Use `--no-chat` when the user wants terminal/SSH-only operation.
-- Use `--with-skills` only when the user explicitly wants optional wp-coding-agents setup/upgrade skills installed into the target runtime.
+- Use `--no-skills` only when the user explicitly wants to skip installing the upgrade skill on the target runtime.
 
 ## When To Use
 

--- a/skills/wp-coding-agents-setup/interview.md
+++ b/skills/wp-coding-agents-setup/interview.md
@@ -1,12 +1,6 @@
----
-name: wp-coding-agents-setup-interview
-description: "Collect a normalized wp-coding-agents setup profile without embedding install execution details or verification matrices."
-compatibility: "Use before scripts/compile-setup-profile.mjs. Does not run setup commands."
----
+# Setup Interview
 
-# WP Coding Agents Setup Interview
-
-Collect the facts needed to install wp-coding-agents. Do not build commands, run setup, or provide verification matrices from this skill. Output a normalized JSON setup profile for `scripts/compile-setup-profile.mjs`.
+Collect the facts needed to install wp-coding-agents. Do not build commands, run setup, or provide verification matrices from this branch. Output a normalized JSON setup profile for `scripts/compile-setup-profile.mjs`.
 
 ## Interview Questions
 

--- a/skills/wp-coding-agents-setup/verify.md
+++ b/skills/wp-coding-agents-setup/verify.md
@@ -1,12 +1,6 @@
----
-name: wp-coding-agents-setup-verify
-description: "Run post-setup verification for wp-coding-agents using overlay names emitted by the setup profile compiler script."
-compatibility: "Use after scripts/compile-setup-profile.mjs and setup.sh execution. Does not compile setup commands."
----
+# Setup Verification
 
-# WP Coding Agents Setup Verify
-
-Run the verification overlays emitted by `scripts/compile-setup-profile.mjs`. This skill owns concrete verification command recipes; the compiler script owns only deterministic command construction and overlay selection.
+Run post-setup verification using overlay names emitted by `scripts/compile-setup-profile.mjs`. This reference owns concrete verification command recipes; the compiler script owns only deterministic command construction and overlay selection.
 
 Use the commands printed by `setup.sh` when they are more specific than the generic recipes below. Treat the script summary as the source of truth for generated paths, service names, bridge restart commands, and local launchd/systemd details.
 

--- a/tests/post-upgrade-restore.sh
+++ b/tests/post-upgrade-restore.sh
@@ -204,12 +204,12 @@ FALLBACK_LIVE_SKILLS="$TMP/fallback-live/skills"
 FALLBACK_LIVE_PLUGINS="$TMP/fallback-live/plugins"
 mkdir -p \
   "$FALLBACK_DATA" \
-  "$FALLBACK_HOME/.kimaki/kimaki-config/skills/wp-coding-agents-setup" \
+  "$FALLBACK_HOME/.kimaki/kimaki-config/skills/upgrade-wp-coding-agents" \
   "$FALLBACK_HOME/.kimaki/kimaki-config/plugins" \
   "$FALLBACK_LIVE_SKILLS"
-cat > "$FALLBACK_HOME/.kimaki/kimaki-config/skills/wp-coding-agents-setup/SKILL.md" <<'EOF'
+cat > "$FALLBACK_HOME/.kimaki/kimaki-config/skills/upgrade-wp-coding-agents/SKILL.md" <<'EOF'
 ---
-name: wp-coding-agents-setup
+name: upgrade-wp-coding-agents
 description: fallback fixture
 ---
 body
@@ -224,7 +224,7 @@ KIMAKI_DATA_DIR="$FALLBACK_DATA" \
 KIMAKI_SKILLS_DIR="$FALLBACK_LIVE_SKILLS" \
   "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run4.log" 2>&1
 
-if [[ ! -f "$FALLBACK_LIVE_SKILLS/wp-coding-agents-setup/SKILL.md" ]]; then
+if [[ ! -f "$FALLBACK_LIVE_SKILLS/upgrade-wp-coding-agents/SKILL.md" ]]; then
   echo "FAIL: missing KIMAKI_DATA_DIR skills source should fall through to HOME source"
   cat "$TMP/run4.log"
   exit 1
@@ -234,7 +234,7 @@ if [[ -e "$FALLBACK_LIVE_PLUGINS" ]]; then
   cat "$TMP/run4.log"
   exit 1
 fi
-if ! grep -q "restored skill wp-coding-agents-setup" "$TMP/run4.log"; then
+if ! grep -q "restored skill upgrade-wp-coding-agents" "$TMP/run4.log"; then
   echo "FAIL: fallback run should restore the HOME-backed skill"
   cat "$TMP/run4.log"
   exit 1

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -101,7 +101,7 @@ SKIP_DEPS=true
 SKIP_SSL=true
 INSTALL_DATA_MACHINE=true
 INSTALL_CHAT=true
-INSTALL_SKILLS=true
+INSTALL_SKILLS=false
 RUN_AS_ROOT=true
 MULTISITE=false
 MULTISITE_TYPE="subdirectory"
@@ -116,7 +116,8 @@ while [[ $# -gt 0 ]]; do
     --dry-run)       DRY_RUN=true; shift ;;
     --kimaki-only)   KIMAKI_ONLY=true; shift ;;
     --plugins-only)  PLUGINS_ONLY=true; shift ;;
-    --skills-only)   SKILLS_ONLY=true; shift ;;
+    --skills-only)   SKILLS_ONLY=true; INSTALL_SKILLS=true; shift ;;
+    --with-skills)   INSTALL_SKILLS=true; shift ;;
     --agents-md-only) AGENTS_MD_ONLY=true; shift ;;
     --repair-opencode-json) REPAIR_OPENCODE_JSON=true; shift ;;
     --skip-plugins)  SKIP_PLUGINS=true; shift ;;
@@ -141,7 +142,8 @@ USAGE:
                                 backwards compat — also handles cc-connect
                                 and telegram when they are the detected bridge)
   ./upgrade.sh --plugins-only   Only update setup-installed Data Machine plugins
-  ./upgrade.sh --skills-only    Only sync wp-coding-agents skills
+  ./upgrade.sh --skills-only    Only sync optional wp-coding-agents skills
+  ./upgrade.sh --with-skills    Sync optional wp-coding-agents skills during full run
   ./upgrade.sh --agents-md-only Only regenerate AGENTS.md
   ./upgrade.sh --skip-plugins   Skip Data Machine plugin updates during full run
   ./upgrade.sh --repair-opencode-json
@@ -507,6 +509,11 @@ check_opencode_json_drift() {
 
 sync_skills() {
   _run_filter_active skills || return 0
+
+  if [ "$INSTALL_SKILLS" != true ]; then
+    log "Phase 4: Skipping wp-coding-agents skills (use --with-skills or --skills-only)"
+    return 0
+  fi
 
   log "Phase 4: Syncing wp-coding-agents skills..."
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -35,7 +35,7 @@
 #   ./upgrade.sh --dry-run       # preview without changes
 #   ./upgrade.sh --kimaki-only   # only sync kimaki config + plugins
 #   ./upgrade.sh --plugins-only  # only update Data Machine plugins
-#   ./upgrade.sh --skills-only   # only sync wp-coding-agents skills
+#   ./upgrade.sh --skills-only   # only sync the wp-coding-agents upgrade skill
 #   ./upgrade.sh --agents-md-only  # only regenerate AGENTS.md
 #   ./upgrade.sh --local --wp-path <path>  # local install (auto on macOS)
 #
@@ -101,7 +101,7 @@ SKIP_DEPS=true
 SKIP_SSL=true
 INSTALL_DATA_MACHINE=true
 INSTALL_CHAT=true
-INSTALL_SKILLS=false
+INSTALL_SKILLS=true
 RUN_AS_ROOT=true
 MULTISITE=false
 MULTISITE_TYPE="subdirectory"
@@ -116,8 +116,7 @@ while [[ $# -gt 0 ]]; do
     --dry-run)       DRY_RUN=true; shift ;;
     --kimaki-only)   KIMAKI_ONLY=true; shift ;;
     --plugins-only)  PLUGINS_ONLY=true; shift ;;
-    --skills-only)   SKILLS_ONLY=true; INSTALL_SKILLS=true; shift ;;
-    --with-skills)   INSTALL_SKILLS=true; shift ;;
+    --skills-only)   SKILLS_ONLY=true; shift ;;
     --agents-md-only) AGENTS_MD_ONLY=true; shift ;;
     --repair-opencode-json) REPAIR_OPENCODE_JSON=true; shift ;;
     --skip-plugins)  SKIP_PLUGINS=true; shift ;;
@@ -142,8 +141,7 @@ USAGE:
                                 backwards compat — also handles cc-connect
                                 and telegram when they are the detected bridge)
   ./upgrade.sh --plugins-only   Only update setup-installed Data Machine plugins
-  ./upgrade.sh --skills-only    Only sync optional wp-coding-agents skills
-  ./upgrade.sh --with-skills    Sync optional wp-coding-agents skills during full run
+  ./upgrade.sh --skills-only    Only sync the wp-coding-agents upgrade skill
   ./upgrade.sh --agents-md-only Only regenerate AGENTS.md
   ./upgrade.sh --skip-plugins   Skip Data Machine plugin updates during full run
   ./upgrade.sh --repair-opencode-json
@@ -509,11 +507,6 @@ check_opencode_json_drift() {
 
 sync_skills() {
   _run_filter_active skills || return 0
-
-  if [ "$INSTALL_SKILLS" != true ]; then
-    log "Phase 4: Skipping wp-coding-agents skills (use --with-skills or --skills-only)"
-    return 0
-  fi
 
   log "Phase 4: Syncing wp-coding-agents skills..."
 


### PR DESCRIPTION
## Summary
- Keep installing the ongoing `upgrade-wp-coding-agents` skill by default, while ensuring the one-shot setup skill is never installed onto target runtimes.
- Preserve unmanaged/user skills instead of deleting anything outside the wp-coding-agents-owned upgrade skill.
- Collapse setup interview/verification branches into plain markdown files referenced by the setup skill, instead of exposing them as separate fragmented skills.

## Testing
- `tests/post-upgrade-restore.sh`
- `tests/bridge-render.sh`
- `bash -n setup.sh upgrade.sh lib/skills.sh bridges/kimaki/post-upgrade.sh lib/summary.sh tests/post-upgrade-restore.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, ran targeted verification, and prepared the PR summary for Chris to review.