### PR TITLE
Document setup as regular onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ cd ~/Studio/my-wordpress-website && kimaki         # OpenCode + Discord
 
 #### Let Your Agent Do It
 
-Use the one-shot `wp-coding-agents-setup` entrypoint with your local coding agent (Claude Code, Cursor, etc.):
+Use the one-shot setup guide with your local coding agent (Claude Code, Cursor, etc.):
 
 ```
-operator-entrypoints/wp-coding-agents-setup/
+operator-entrypoints/wp-coding-agents-setup/setup.md
 ```
 
 Then: "Help me set up wp-coding-agents on my VPS"

--- a/operator-entrypoints/wp-coding-agents-setup/setup.md
+++ b/operator-entrypoints/wp-coding-agents-setup/setup.md
@@ -1,17 +1,11 @@
----
-name: wp-coding-agents-setup
-description: "Orchestrate wp-coding-agents setup on a VPS or local WordPress install by collecting a setup profile, compiling the exact setup.sh command, dry-running it, and guiding verification."
-compatibility: "For VPS: requires SSH access, Ubuntu/Debian recommended. For local: requires an existing WordPress install (WordPress Studio, MAMP, manual, etc.) and Node.js."
----
-
 # WP Coding Agents Setup
 
-Use this skill from the operator's **local machine** to install wp-coding-agents on a remote VPS or an existing local WordPress install. Once the runtime and chat bridge are installed, the new site agent takes over ongoing WordPress management.
+This is the one-shot setup guide for installing wp-coding-agents on a remote VPS or existing local WordPress install. Use it from the operator's local machine before the target agent exists. Once the runtime and chat bridge are installed, the site agent takes over ongoing WordPress management.
 
-This skill is only the orchestrator. Keep the setup matrix composable:
+## Onboarding Flow
 
 ```text
-wp-coding-agents-setup
+operator-entrypoints/wp-coding-agents-setup/setup.md
   -> operator-entrypoints/wp-coding-agents-setup/interview.md
   -> scripts/compile-setup-profile.mjs
   -> dry-run setup command
@@ -33,7 +27,7 @@ Use the scripts for operational details:
 | WordPress/WP-CLI behavior | `lib/wordpress.sh` |
 | Upgrade behavior | `./upgrade.sh --help` and `upgrade-wp-coding-agents` |
 
-Do not duplicate script internals in this skill. Compile commands from the user's setup profile, then verify against script output.
+Do not duplicate script internals in this guide. Compile commands from the setup profile, then verify against script output.
 
 ## Procedure
 
@@ -74,13 +68,13 @@ Do not duplicate script internals in this skill. Compile commands from the user'
 - Keep Codebox minion provider auth separate from optional WP AI Gateway external-client setup.
 - Keep Homeboy external to wp-coding-agents. The WordPress site root is a Homeboy project, not a component.
 - Use `WP_CMD="studio wp"` for WordPress Studio installs when the compiler selects that overlay.
-- Use `--with-homeboy` only when the user wants the optional developer layer.
-- Use `--no-chat` when the user wants terminal/SSH-only operation.
-- Use `--no-skills` only when the user explicitly wants to skip installing the upgrade skill on the target runtime.
+- Use `--with-homeboy` only when the operator wants the optional developer layer.
+- Use `--no-chat` when the operator wants terminal/SSH-only operation.
+- Use `--no-skills` only when the operator explicitly wants to skip installing the upgrade skill on the target runtime.
 
 ## When To Use
 
-Use when the user says things like:
+Use when the operator says things like:
 
 - "Help me install wp-coding-agents on my server"
 - "Set up a coding agent on this VPS"

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -12,7 +12,7 @@ By default it also updates the setup-installed Data Machine plugins (`data-machi
 
 If the install was created with the optional Homeboy layer, upgrade should preserve that model: the WordPress site root is the Homeboy **project**, primary Data Machine Code workspace checkouts are attached **components**, and `repo@branch` worktrees remain skipped by default. Homeboy is external to wp-coding-agents; do not vendor it or treat the site root as a component during upgrade guidance.
 
-Setup uses `operator-entrypoints/wp-coding-agents-setup/interview.md` and `scripts/compile-setup-profile.mjs` to map a new install profile into commands. Upgrade intentionally does **not** duplicate that compiler: `upgrade.sh` owns detection, bridge selection, dry-run diffs, and summary commands for an already-installed environment.
+Setup uses the one-shot guide at `operator-entrypoints/wp-coding-agents-setup/setup.md`, plus `operator-entrypoints/wp-coding-agents-setup/interview.md` and `scripts/compile-setup-profile.mjs`, to map a new install profile into commands. Upgrade intentionally does **not** duplicate that compiler: `upgrade.sh` owns detection, bridge selection, dry-run diffs, and summary commands for an already-installed environment.
 
 ## When to use
 


### PR DESCRIPTION
## Summary
- Rename the one-shot setup operator entrypoint from `SKILL.md` to `setup.md` so it is regular onboarding documentation, not a runtime skill.
- Point the README and upgrade skill at the setup guide path.
- Keep only `upgrade-wp-coding-agents` as the managed runtime-installed skill.

## Testing
- `tests/post-upgrade-restore.sh`
- `tests/bridge-render.sh`
- `bash -n setup.sh upgrade.sh lib/skills.sh bridges/kimaki.sh bridges/kimaki/post-upgrade.sh lib/summary.sh tests/post-upgrade-restore.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the docs rename, ran targeted verification, and prepared the PR summary for Chris to review.