### PR TITLE
fix: register a web-traversable kimaki binary for CLI dispatch (#198)

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Run tests/kimaki-agent-fallback.sh
         run: ./tests/kimaki-agent-fallback.sh
 
+  cli-channel-binary-path:
+    name: CLI channel binary-path web-reachability regression (#198)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/cli-channel-binary-path.sh
+        run: ./tests/cli-channel-binary-path.sh
+
   wp-codebox-subtree:
     name: WP Codebox subtree updater
     runs-on: ubuntu-latest

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -66,9 +66,24 @@ bridge_install() {
 # Register the native Kimaki binary. Kimaki 0.13 validates requested agents and
 # falls back to the default/build agent when a requested agent is unavailable,
 # so wp-coding-agents must not rewrite `--agent` itself.
+#
+# The command we register here is shelled by the Data Machine Code CLI transport
+# from the `agents/dispatch-message` ability, which runs inside PHP-FPM as the
+# WordPress web user (www-data) on WP-cron / Action Scheduler fires — NOT as the
+# kimaki.service user. On a RUN_AS_ROOT install the kimaki binary resolves under
+# /root/.kimaki/bin (and the data dir under /root, mode 0700); www-data cannot
+# traverse 0700 /root, so proc_open fails with EACCES and every scheduled
+# dispatch dies as datamachine_code_cli_dispatch_spawn_failed. The opencode
+# service-user home (/home/opencode, mode 0750) is the same trap. We therefore
+# only register a path whose ancestor directories are world-traversable
+# (`o+x`), preferring a system-prefix binary (e.g. /usr/bin/kimaki, the
+# npm-global symlink) over any private-home wrapper. See #198 / #93.
 _kimaki_register_cli_channel() {
   local cmd
-  if [ -n "${KIMAKI_BIN:-}" ] && [ -x "$KIMAKI_BIN" ] && ! _kimaki_is_legacy_adapter_file "$KIMAKI_BIN"; then
+  if [ -n "${KIMAKI_BIN:-}" ] \
+    && [ -x "$KIMAKI_BIN" ] \
+    && ! _kimaki_is_legacy_adapter_file "$KIMAKI_BIN" \
+    && _kimaki_path_is_web_traversable "$KIMAKI_BIN"; then
     cmd="$KIMAKI_BIN"
   else
     cmd="$(_kimaki_find_native_binary)"
@@ -87,8 +102,66 @@ _kimaki_is_legacy_adapter_file() {
   [ -e "$file" ] && grep -q 'wp-coding-agents datamachine-kimaki adapter' "$file" 2>/dev/null
 }
 
+# _kimaki_path_is_web_traversable <path>
+#
+# Return 0 if every ancestor directory of <path> carries the world-execute
+# bit (`o+x`), i.e. an unrelated user (the PHP-FPM web user that runs the
+# CLI-dispatch transport) can traverse to it. Return 1 if any ancestor is
+# missing `o+x` (e.g. /root at 0700, /home/opencode at 0750) — such a path is
+# unreachable by www-data and must not be registered as the dispatch command.
+#
+# Symlinks are resolved first (via realpath when available) so the real
+# target's ancestors are checked, not the link's. If the path cannot be
+# resolved or stat'd, err on the side of "not traversable" (return 1) so the
+# caller falls back to PATH resolution.
+_kimaki_path_is_web_traversable() {
+  local path="$1"
+  [ -n "$path" ] || return 1
+
+  local resolved
+  if command -v realpath >/dev/null 2>&1; then
+    resolved="$(realpath -e "$path" 2>/dev/null)" || return 1
+  elif command -v readlink >/dev/null 2>&1; then
+    resolved="$(readlink -f "$path" 2>/dev/null)" || return 1
+  else
+    resolved="$path"
+  fi
+  [ -n "$resolved" ] || return 1
+
+  # Walk every ancestor directory from the binary up to /, asserting o+x.
+  local dir="${resolved%/*}"
+  [ -n "$dir" ] || dir="/"
+  while :; do
+    local perms
+    perms="$(stat -c '%a' "$dir" 2>/dev/null)" || perms="$(stat -f '%Lp' "$dir" 2>/dev/null)" || return 1
+    # Last octal digit is the "other" triad; its execute bit is value 1.
+    local other="${perms: -1}"
+    case "$other" in
+      1|3|5|7) ;;            # o+x present
+      *) return 1 ;;          # o+x missing — not traversable by www-data
+    esac
+    [ "$dir" = "/" ] && break
+    dir="${dir%/*}"
+    [ -n "$dir" ] || dir="/"
+  done
+
+  return 0
+}
+
+# _kimaki_find_native_binary
+#
+# Resolve the kimaki binary to register as the CLI-dispatch command. Walks
+# $PATH and returns the first candidate that is (a) executable, (b) not the
+# legacy adapter shim, and (c) web-traversable (every ancestor dir is `o+x`,
+# so the www-data CLI-dispatch transport can reach it — see #198).
+#
+# A candidate that is executable but trapped under a private home
+# (/root/.kimaki/bin, /home/opencode/.kimaki/bin) is skipped in favor of a
+# later, reachable candidate (typically the /usr/bin npm-global symlink). If
+# nothing on $PATH is reachable, fall back to the bare name "kimaki" and let
+# the runtime resolve it via its own PATH at dispatch time.
 _kimaki_find_native_binary() {
-  local dir candidate
+  local dir candidate first_unreachable=""
   IFS=: read -r -a path_entries <<< "${PATH:-}"
   for dir in "${path_entries[@]}"; do
     [ -n "$dir" ] || continue
@@ -97,9 +170,21 @@ _kimaki_find_native_binary() {
     if _kimaki_is_legacy_adapter_file "$candidate"; then
       continue
     fi
+    if ! _kimaki_path_is_web_traversable "$candidate"; then
+      # Remember the first executable-but-unreachable candidate as a
+      # last-resort over the bare name, but keep looking for a reachable one.
+      [ -n "$first_unreachable" ] || first_unreachable="$candidate"
+      continue
+    fi
     printf '%s\n' "$candidate"
     return 0
   done
+
+  if [ -n "$first_unreachable" ]; then
+    printf '%s\n' "$first_unreachable"
+    return 0
+  fi
+
   printf '%s\n' "kimaki"
 }
 

--- a/tests/cli-channel-binary-path.sh
+++ b/tests/cli-channel-binary-path.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# tests/cli-channel-binary-path.sh — Regression coverage for issue #198.
+#
+# The command registered for the kimaki CLI channel is shelled by the Data
+# Machine Code CLI transport from `agents/dispatch-message`, which runs inside
+# PHP-FPM as the WordPress web user (www-data) on WP-cron / Action Scheduler
+# fires. That user is NOT the kimaki.service user.
+#
+# On a RUN_AS_ROOT install the kimaki binary resolves under /root/.kimaki/bin
+# (and the data dir under /root, mode 0700). www-data cannot traverse 0700
+# /root, so proc_open fails with EACCES and every scheduled dispatch dies as
+# `datamachine_code_cli_dispatch_spawn_failed`. The opencode service-user home
+# (/home/opencode, mode 0750) is the same trap.
+#
+# The resolver (_kimaki_find_native_binary) and the KIMAKI_BIN short-circuit in
+# _kimaki_register_cli_channel must therefore only register a binary whose
+# ancestor directories are world-traversable (`o+x`), preferring a reachable
+# system-prefix path over any private-home wrapper.
+#
+# Asserts:
+#   1. _kimaki_path_is_web_traversable accepts a 0755-ancestor path and
+#      rejects a 0700- and a 0750-ancestor path (the /root and /home/opencode
+#      traps).
+#   2. _kimaki_find_native_binary skips an executable-but-unreachable PATH
+#      entry (private-home wrapper) in favor of a later reachable one.
+#   3. _kimaki_register_cli_channel ignores a KIMAKI_BIN that is executable but
+#      trapped under a non-traversable home, falling back to the reachable
+#      PATH binary.
+#   4. The registered command is never a path under a non-traversable home.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'chmod -R u+rwx "$TMP" 2>/dev/null || true; rm -rf "$TMP"' EXIT
+
+# mktemp -d creates the dir at 0700 by design. This test simulates a WEB-
+# REACHABLE install prefix, so make the temp root world-traversable; the
+# individual "trap" dirs below re-tighten their own permissions to 0700/0750.
+# (/tmp itself is 1777, and the temp root's parent chain is world-traversable
+# in CI, so this gives us a clean 0755 base to build reachable paths under.)
+chmod 0755 "$TMP"
+
+# Silence helper logs; capture cli_channel_register args for assertions.
+log() { :; }
+warn() { printf 'WARN: %s\n' "$1" >&2; }
+cli_channel_register() {
+  printf '%s\0' "$@" > "$TMP/cli-channel.args"
+}
+
+DRY_RUN=false
+UPDATED_ITEMS=()
+
+# shellcheck disable=SC1091
+source "$ROOT/bridges/kimaki.sh"
+
+FAILED=0
+fail() { echo "  FAIL $1"; FAILED=$((FAILED + 1)); }
+ok()   { echo "  ok   $1"; }
+
+# A fake kimaki binary the resolver can find.
+make_kimaki() {
+  local dir="$1"
+  mkdir -p "$dir"
+  printf '#!/bin/sh\nexit 0\n' > "$dir/kimaki"
+  chmod 0755 "$dir/kimaki"
+}
+
+# Read the command (2nd arg) that _kimaki_register_cli_channel passed through.
+registered_command() {
+  python3 - "$TMP/cli-channel.args" <<'PY'
+import sys
+with open(sys.argv[1], 'rb') as handle:
+    parts = [p.decode() for p in handle.read().split(b'\0') if p]
+# cli_channel_register "kimaki" "<command>" "<args_json>" "<detach>" "<timeout>"
+print(parts[1] if len(parts) > 1 else '')
+PY
+}
+
+# --- 1. _kimaki_path_is_web_traversable on hostile vs friendly ancestors ----
+echo "==> _kimaki_path_is_web_traversable ancestor checks"
+
+reachable_dir="$TMP/reachable/bin"        # all ancestors 0755 by default
+make_kimaki "$reachable_dir"
+if _kimaki_path_is_web_traversable "$reachable_dir/kimaki"; then
+  ok "accepts 0755-ancestor path"
+else
+  fail "should accept 0755-ancestor path"
+fi
+
+# Simulate /root (0700) trap.
+root_trap="$TMP/roothome"                 # stands in for /root
+mkdir -p "$root_trap/.kimaki/bin"
+make_kimaki "$root_trap/.kimaki/bin"
+chmod 0700 "$root_trap"
+if _kimaki_path_is_web_traversable "$root_trap/.kimaki/bin/kimaki"; then
+  fail "should REJECT 0700-ancestor (/root) path"
+else
+  ok "rejects 0700-ancestor (/root) path"
+fi
+
+# Simulate /home/opencode (0750) trap.
+home_trap="$TMP/opencodehome"             # stands in for /home/opencode
+mkdir -p "$home_trap/.kimaki/bin"
+make_kimaki "$home_trap/.kimaki/bin"
+chmod 0750 "$home_trap"
+if _kimaki_path_is_web_traversable "$home_trap/.kimaki/bin/kimaki"; then
+  fail "should REJECT 0750-ancestor (/home/opencode) path"
+else
+  ok "rejects 0750-ancestor (/home/opencode) path"
+fi
+
+# --- 2. resolver skips unreachable PATH entry for a reachable one -----------
+echo "==> _kimaki_find_native_binary prefers reachable PATH entry"
+
+# PATH puts the 0700-trapped wrapper FIRST (mirrors root's $PATH ordering),
+# then a reachable system-style dir.
+unset KIMAKI_BIN || true
+resolved="$(PATH="$root_trap/.kimaki/bin:$reachable_dir:/usr/bin:/bin" _kimaki_find_native_binary)"
+if [ "$resolved" = "$reachable_dir/kimaki" ]; then
+  ok "skips 0700 wrapper, returns reachable binary"
+else
+  fail "expected $reachable_dir/kimaki, got '$resolved'"
+fi
+
+# --- 3. register ignores trapped KIMAKI_BIN, falls back to reachable PATH ----
+echo "==> _kimaki_register_cli_channel ignores trapped KIMAKI_BIN"
+
+rm -f "$TMP/cli-channel.args"
+KIMAKI_BIN="$root_trap/.kimaki/bin/kimaki"   # executable but trapped under 0700
+PATH="$reachable_dir:/usr/bin:/bin" _kimaki_register_cli_channel
+got="$(registered_command)"
+if [ "$got" = "$reachable_dir/kimaki" ]; then
+  ok "trapped KIMAKI_BIN ignored; registered reachable $got"
+else
+  fail "expected reachable $reachable_dir/kimaki, got '$got'"
+fi
+
+# --- 4. registered command is never under a non-traversable home ------------
+echo "==> registered command is web-traversable"
+
+if _kimaki_path_is_web_traversable "$got"; then
+  ok "registered command '$got' is web-traversable"
+else
+  fail "registered command '$got' is NOT web-traversable"
+fi
+
+# Sanity: a reachable KIMAKI_BIN is still honored (no regression).
+rm -f "$TMP/cli-channel.args"
+reachable_bin_dir="$TMP/reachable2/bin"
+make_kimaki "$reachable_bin_dir"
+KIMAKI_BIN="$reachable_bin_dir/kimaki"
+PATH="/usr/bin:/bin" _kimaki_register_cli_channel
+got2="$(registered_command)"
+if [ "$got2" = "$reachable_bin_dir/kimaki" ]; then
+  ok "reachable KIMAKI_BIN still honored (no regression)"
+else
+  fail "expected $reachable_bin_dir/kimaki, got '$got2'"
+fi
+
+echo
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAILED: $FAILED assertion(s)"
+  exit 1
+fi
+echo "OK: all cli-channel binary-path assertions passed"

--- a/tests/kimaki-agent-fallback.sh
+++ b/tests/kimaki-agent-fallback.sh
@@ -5,6 +5,13 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# mktemp -d creates the dir at 0700. The CLI-channel resolver now refuses to
+# register a binary whose ancestor dirs are not world-traversable (the #198
+# fix: a /root- or /home/opencode-trapped binary is unreachable by the
+# www-data CLI-dispatch transport). These fixtures simulate normally-installed,
+# web-reachable binaries, so make the temp root 0755 to match that reality.
+chmod 0755 "$TMP"
+
 if [ -e "$ROOT/bridges/kimaki/bin/datamachine-kimaki" ]; then
   echo "FAIL: datamachine-kimaki adapter should not be shipped"
   exit 1


### PR DESCRIPTION
## Summary

Fixes #198. On a `RUN_AS_ROOT` install, the kimaki CLI-channel `command` was registered as `/root/.kimaki/bin/kimaki`. That command is shelled by the Data Machine Code CLI transport from `agents/dispatch-message`, which runs inside PHP-FPM as **www-data** on WP-cron / Action Scheduler fires — not as the `kimaki.service` user. `www-data` cannot traverse `0700 /root`, so `proc_open` fails with `EACCES` and **every scheduled dispatch dies** as `datamachine_code_cli_dispatch_spawn_failed`, while manual-as-root runs succeed. The `opencode` service-user home (`/home/opencode`, `0750`) is the same trap.

This patch makes the registered command **web-traversable regardless of service user**, by refusing any binary whose ancestor directories lack the world-execute bit (`o+x`) and preferring a reachable system-prefix binary (e.g. `/usr/bin/kimaki`, the npm-global symlink).

## Changes

- **`bridges/kimaki.sh`**
  - New `_kimaki_path_is_web_traversable()` — returns success only if every ancestor dir of a candidate binary carries `o+x` (resolves symlinks first via `realpath`/`readlink`).
  - `_kimaki_register_cli_channel()` now ignores a `KIMAKI_BIN` that is executable but trapped under a non-traversable home, falling back to PATH resolution.
  - `_kimaki_find_native_binary()` now skips executable-but-unreachable `$PATH` entries in favor of a later reachable candidate; only falls back to a trapped path (then the bare name) as a last resort.
- **`tests/cli-channel-binary-path.sh`** (new) + CI job — covers 0700/0750 ancestor rejection, reachable-preference on a root-style `$PATH`, trapped-`KIMAKI_BIN` fallback, and a no-regression check that a reachable `KIMAKI_BIN` is still honored.
- **`tests/kimaki-agent-fallback.sh`** — `mktemp -d` defaults to `0700`; its fixtures now `chmod 0755` the temp root to simulate a normally-installed, web-reachable binary (otherwise the new, correct reachability check would reject them).

## Verification against the live production scenario

With root's actual `$PATH` ordering (`/root/.kimaki/bin` first), the fixed resolver now returns the reachable binary:

```
$ PATH="/root/.kimaki/bin:/usr/bin:/bin" _kimaki_find_native_binary
/usr/bin/kimaki                      # was /root/.kimaki/bin/kimaki

$ _kimaki_path_is_web_traversable /root/.kimaki/bin/kimaki  ; echo $?
1                                    # correctly rejected (/root is 0700)
$ _kimaki_path_is_web_traversable /usr/bin/kimaki           ; echo $?
0                                    # accepted (/usr/bin is 0755)
```

`/usr/bin/kimaki` is confirmed `www-data`-executable on the affected host, so this un-breaks the scheduled `EC Agent Progress Ping` flow (flow_id 4).

## Test results

```
tests/cli-channel-binary-path.sh   OK: all assertions passed (7)
tests/kimaki-agent-fallback.sh     OK
tests/cli-channel-perms.sh         OK
bash -n on all changed scripts     OK
```

> `tests/bridge-render.sh` shows a pre-existing, host-dependent launchd-PATH snapshot drift that reproduces on clean `main` (unrelated to this change) — not touched here.

## Scope / relationship to the durable fix

This is the **targeted stopgap**. The durable fix is migrating off `RUN_AS_ROOT` to the `opencode` service user (#93, live remediation scoped in #199). Because `/home/opencode` (0750) is *also* non-traversable by www-data, making the registered command web-reachable regardless of service user is a **prerequisite** for that migration, not a duplicate of it.

Closes #198.