### PR TITLE
fix(upgrade): adopt service identity from existing unit instead of assuming root

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -81,3 +81,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests/wp-codebox-subtree.sh
         run: ./tests/wp-codebox-subtree.sh
+
+  service-identity-adoption:
+    name: Service identity adoption regression (#204)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/service-identity-adoption.sh
+        run: ./tests/service-identity-adoption.sh

--- a/bridges/_dispatch.sh
+++ b/bridges/_dispatch.sh
@@ -197,6 +197,96 @@ _ensure_systemd_path_contains() {
   ' <<< "$current_env"
 }
 
+# _systemd_unit_user <unit_file>
+#
+# Print the User= value from an existing systemd unit. Empty output +
+# return 1 when the file is missing or has no User= directive.
+_systemd_unit_user() {
+  local unit_file="$1"
+  [ -f "$unit_file" ] || return 1
+  local user
+  user=$(sed -n 's/^User=\(.*\)$/\1/p' "$unit_file" | head -1)
+  [ -n "$user" ] || return 1
+  printf '%s' "$user"
+}
+
+# _preserve_systemd_umask <unit_file> <env_block>
+#
+# Carry the existing unit's UMask= directive into a re-rendered unit.
+# The bridge templates do not render UMask, but non-root installs rely on
+# it (e.g. UMask=0002 for group-write with www-data). Without this, every
+# Phase 5 refresh silently dropped the directive. Appends the existing
+# UMask= line to the env block (both land in [Service]); no-op when the
+# existing unit has none.
+_preserve_systemd_umask() {
+  local unit_file="$1" env_block="$2"
+  local umask_line=""
+  if [ -f "$unit_file" ]; then
+    umask_line=$(grep '^UMask=' "$unit_file" | head -1 || true)
+  fi
+  if [ -z "$umask_line" ]; then
+    printf '%s' "$env_block"
+    return 0
+  fi
+  if [ -n "$env_block" ]; then
+    printf '%s\n%s' "$env_block" "$umask_line"
+  else
+    printf '%s' "$umask_line"
+  fi
+}
+
+# adopt_service_identity_from_units
+#
+# On upgrade, the EXISTING installed unit is the source of truth for the
+# service identity — not the script's default. upgrade.sh historically
+# hardcoded RUN_AS_ROOT=true, so on a non-root install (User=opencode)
+# Phase 5 re-rendered the unit with User=root: a silent service-identity
+# flip that creates root-owned state files, breaks the next non-root
+# start, and re-introduces the root-homed-path trap (#198/#93). See #204.
+#
+# Walks the loaded bridge's systemd units, reads User= from the first one
+# that exists, and re-derives SERVICE_USER / SERVICE_HOME /
+# KIMAKI_DATA_DIR / RUN_AS_ROOT to match. Skipped in local mode (no
+# systemd), when no bridge is loaded, or when the operator forced an
+# identity explicitly via --root / --non-root (SERVICE_USER_FORCED=true).
+#
+# SYSTEMD_UNIT_DIR is overridable for tests (defaults to
+# /etc/systemd/system).
+adopt_service_identity_from_units() {
+  [ "${LOCAL_MODE:-false}" = true ] && return 0
+  [ "${SERVICE_USER_FORCED:-false}" = true ] && return 0
+  declare -F bridge_systemd_units >/dev/null 2>&1 || return 0
+
+  local unit_dir="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+  local unit unit_user unit_home
+  for unit in $(bridge_systemd_units); do
+    [ -f "$unit_dir/$unit" ] || continue
+    unit_user=$(_systemd_unit_user "$unit_dir/$unit") || continue
+
+    if [ "$unit_user" != "$SERVICE_USER" ]; then
+      unit_home=$(getent passwd "$unit_user" 2>/dev/null | cut -d: -f6)
+      if [ -z "$unit_home" ]; then
+        if [ "$unit_user" = "root" ]; then
+          unit_home="/root"
+        else
+          unit_home="/home/$unit_user"
+        fi
+      fi
+      log "  Adopting service identity from $unit: User=$unit_user (script default was $SERVICE_USER)"
+      SERVICE_USER="$unit_user"
+      SERVICE_HOME="$unit_home"
+      KIMAKI_DATA_DIR="$unit_home/.kimaki"
+      if [ "$unit_user" = "root" ]; then
+        RUN_AS_ROOT=true
+      else
+        RUN_AS_ROOT=false
+      fi
+    fi
+    return 0
+  done
+  return 0
+}
+
 # _smart_update_systemd_unit <unit_file> <new_unit> [<label>]
 #
 # Diff + write + daemon-reload a single systemd unit. Records the change in

--- a/bridges/cc-connect.sh
+++ b/bridges/cc-connect.sh
@@ -200,6 +200,7 @@ Environment=PATH=/usr/local/bin:/usr/bin:/bin"
 
   local MERGED_ENV
   MERGED_ENV=$(_merge_systemd_env_lines "$CURRENT_ENV" "$TEMPLATE_ENV")
+  MERGED_ENV=$(_preserve_systemd_umask "$UNIT_FILE" "$MERGED_ENV")
 
   local NEW_UNIT
   NEW_UNIT=$(bridge_render_systemd cc-connect.service "$MERGED_ENV")

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -552,6 +552,7 @@ Environment=DATAMACHINE_SITE_PATH=$SITE_PATH"
 
   local MERGED_ENV
   MERGED_ENV=$(_merge_systemd_env_lines "$CURRENT_ENV" "$TEMPLATE_ENV")
+  MERGED_ENV=$(_preserve_systemd_umask "$UNIT_FILE" "$MERGED_ENV")
 
   local NEW_UNIT
   NEW_UNIT=$(bridge_render_systemd kimaki.service "$MERGED_ENV")

--- a/bridges/telegram.sh
+++ b/bridges/telegram.sh
@@ -261,6 +261,7 @@ Environment=PATH=/usr/local/bin:/usr/bin:/bin"
     local SERVE_CURRENT_ENV SERVE_MERGED_ENV SERVE_NEW
     SERVE_CURRENT_ENV=$(grep '^Environment=' "$SERVE_UNIT" || true)
     SERVE_MERGED_ENV=$(_merge_systemd_env_lines "$SERVE_CURRENT_ENV" "$TEMPLATE_ENV")
+    SERVE_MERGED_ENV=$(_preserve_systemd_umask "$SERVE_UNIT" "$SERVE_MERGED_ENV")
     SERVE_NEW=$(bridge_render_systemd opencode-serve.service "$SERVE_MERGED_ENV")
     _smart_update_systemd_unit "$SERVE_UNIT" "$SERVE_NEW" "opencode-serve.service"
   else
@@ -272,6 +273,7 @@ Environment=PATH=/usr/local/bin:/usr/bin:/bin"
     local TG_CURRENT_ENV TG_MERGED_ENV TG_NEW
     TG_CURRENT_ENV=$(grep '^Environment=' "$TG_UNIT" || true)
     TG_MERGED_ENV=$(_merge_systemd_env_lines "$TG_CURRENT_ENV" "$TEMPLATE_ENV")
+    TG_MERGED_ENV=$(_preserve_systemd_umask "$TG_UNIT" "$TG_MERGED_ENV")
     TG_NEW=$(bridge_render_systemd opencode-telegram.service "$TG_MERGED_ENV")
     _smart_update_systemd_unit "$TG_UNIT" "$TG_NEW" "opencode-telegram.service"
   else

--- a/tests/service-identity-adoption.sh
+++ b/tests/service-identity-adoption.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# tests/service-identity-adoption.sh — Regression coverage for issue #204.
+#
+# upgrade.sh hardcodes RUN_AS_ROOT=true. On a non-root install
+# (kimaki.service has User=opencode) Phase 5 re-rendered the unit with
+# User=root — a silent service-identity flip that creates root-owned state
+# files, breaks the next non-root start, and re-introduces the
+# root-homed-path dispatch trap (#198/#93). It also dropped the existing
+# unit's UMask= directive on every refresh.
+#
+# Asserts:
+#   1. adopt_service_identity_from_units reads User= from the existing unit
+#      and re-derives SERVICE_USER / SERVICE_HOME / KIMAKI_DATA_DIR /
+#      RUN_AS_ROOT to match (root-default script + opencode unit → opencode).
+#   2. Adoption is a no-op when the unit already matches the script default.
+#   3. Adoption is skipped when SERVICE_USER_FORCED=true (--root/--non-root).
+#   4. Adoption is skipped in LOCAL_MODE (no systemd).
+#   5. _preserve_systemd_umask carries an existing UMask= line into the
+#      re-rendered env block, and is a no-op when the unit has none.
+#   6. End-to-end: a re-render after adoption keeps User=opencode and
+#      UMask=0002 — the exact production diff from #204 must NOT appear.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+fail_list=""
+
+assert() {
+  local label="$1" ok="$2"
+  if [ "$ok" = "0" ]; then
+    echo "  ok   $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $label"
+    FAIL=$((FAIL + 1))
+    fail_list="$fail_list
+  - $label"
+  fi
+}
+
+# Minimal env so bridges/_dispatch.sh sources cleanly.
+export DRY_RUN=false
+export PLATFORM="linux"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/bridges/_dispatch.sh"
+
+# Mock unit dir with a non-root kimaki unit (the #204 production shape).
+UNIT_DIR="$TMP/systemd"
+mkdir -p "$UNIT_DIR"
+cat > "$UNIT_DIR/kimaki.service" <<'EOF'
+[Unit]
+Description=Kimaki Discord Bot (wp-coding-agents)
+After=network.target
+
+[Service]
+Type=simple
+User=opencode
+WorkingDirectory=/var/www/site
+UMask=0002
+Environment=HOME=/home/opencode
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/kimaki
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+export SYSTEMD_UNIT_DIR="$UNIT_DIR"
+
+# Stand-in for the loaded bridge's unit list.
+bridge_systemd_units() { echo "kimaki.service"; }
+
+# ---------------------------------------------------------------------------
+echo "==> adoption: root default + opencode unit -> opencode"
+LOCAL_MODE=false
+SERVICE_USER_FORCED=false
+SERVICE_USER="root"
+SERVICE_HOME="/root"
+KIMAKI_DATA_DIR="/root/.kimaki"
+RUN_AS_ROOT=true
+
+adopt_service_identity_from_units
+
+assert "SERVICE_USER adopted from unit"        "$([ "$SERVICE_USER" = "opencode" ]; echo $?)"
+assert "RUN_AS_ROOT flipped to false"          "$([ "$RUN_AS_ROOT" = "false" ]; echo $?)"
+assert "SERVICE_HOME re-derived"               "$([ "$SERVICE_HOME" != "/root" ]; echo $?)"
+assert "KIMAKI_DATA_DIR re-derived"            "$([ "$KIMAKI_DATA_DIR" != "/root/.kimaki" ]; echo $?)"
+
+# ---------------------------------------------------------------------------
+echo "==> adoption: no-op when unit matches script default"
+SERVICE_USER="opencode"
+SERVICE_HOME="/home/opencode"
+KIMAKI_DATA_DIR="/home/opencode/.kimaki"
+RUN_AS_ROOT=false
+
+adopt_service_identity_from_units
+
+assert "matching user unchanged"               "$([ "$SERVICE_USER" = "opencode" ]; echo $?)"
+assert "matching home unchanged"               "$([ "$SERVICE_HOME" = "/home/opencode" ]; echo $?)"
+
+# ---------------------------------------------------------------------------
+echo "==> adoption: skipped when SERVICE_USER_FORCED=true"
+SERVICE_USER_FORCED=true
+SERVICE_USER="root"
+SERVICE_HOME="/root"
+KIMAKI_DATA_DIR="/root/.kimaki"
+RUN_AS_ROOT=true
+
+adopt_service_identity_from_units
+
+assert "forced identity not overridden"        "$([ "$SERVICE_USER" = "root" ]; echo $?)"
+SERVICE_USER_FORCED=false
+
+# ---------------------------------------------------------------------------
+echo "==> adoption: skipped in LOCAL_MODE"
+LOCAL_MODE=true
+SERVICE_USER="someuser"
+
+adopt_service_identity_from_units
+
+assert "local mode untouched"                  "$([ "$SERVICE_USER" = "someuser" ]; echo $?)"
+LOCAL_MODE=false
+
+# ---------------------------------------------------------------------------
+echo "==> umask preservation"
+ENV_BLOCK="Environment=HOME=/home/opencode
+Environment=PATH=/usr/local/bin:/usr/bin:/bin"
+
+PRESERVED=$(_preserve_systemd_umask "$UNIT_DIR/kimaki.service" "$ENV_BLOCK")
+assert "UMask carried into env block"          "$(echo "$PRESERVED" | grep -q '^UMask=0002$'; echo $?)"
+assert "env lines retained alongside UMask"    "$(echo "$PRESERVED" | grep -q '^Environment=HOME=/home/opencode$'; echo $?)"
+
+cat > "$UNIT_DIR/no-umask.service" <<'EOF'
+[Service]
+User=opencode
+Environment=HOME=/home/opencode
+EOF
+UNCHANGED=$(_preserve_systemd_umask "$UNIT_DIR/no-umask.service" "$ENV_BLOCK")
+assert "no UMask -> env block unchanged"       "$([ "$UNCHANGED" = "$ENV_BLOCK" ]; echo $?)"
+
+# ---------------------------------------------------------------------------
+echo "==> end-to-end: re-render after adoption keeps User=opencode + UMask"
+# Simulate the upgrade flow: root defaults, adoption, then render the kimaki
+# unit the way bridge_update_systemd does and assert the #204 diff is gone.
+SERVICE_USER="root"
+SERVICE_HOME="/root"
+KIMAKI_DATA_DIR="/root/.kimaki"
+RUN_AS_ROOT=true
+adopt_service_identity_from_units
+
+export SITE_PATH="/var/www/site"
+export KIMAKI_CONFIG_DIR="/opt/kimaki-config"
+export KIMAKI_BIN="/usr/bin/kimaki"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/bridges/kimaki.sh"
+
+CURRENT_ENV=$(grep '^Environment=' "$UNIT_DIR/kimaki.service" || true)
+MERGED_ENV=$(_preserve_systemd_umask "$UNIT_DIR/kimaki.service" "$CURRENT_ENV")
+RENDERED=$(bridge_render_systemd kimaki.service "$MERGED_ENV")
+
+assert "rendered unit keeps User=opencode"     "$(echo "$RENDERED" | grep -q '^User=opencode$'; echo $?)"
+assert "rendered unit does NOT flip to root"   "$(echo "$RENDERED" | grep -q '^User=root$'; echo $((1 - $?)))"
+assert "rendered unit keeps UMask=0002"        "$(echo "$RENDERED" | grep -q '^UMask=0002$'; echo $?)"
+assert "pkill scoped to adopted user"          "$(echo "$RENDERED" | grep -q 'pkill -TERM -u opencode'; echo $?)"
+
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAIL: $FAIL assertion(s):$fail_list"
+  exit 1
+fi
+echo "OK: all $PASS service-identity adoption assertions passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -111,6 +111,9 @@ RUNTIME=""
 DETECTED_RUNTIMES=()
 IS_STUDIO=false
 CHAT_BRIDGE=""
+# True when the operator forced the identity via --root / --non-root.
+# Suppresses adopt_service_identity_from_units (existing-unit adoption).
+SERVICE_USER_FORCED=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -124,6 +127,8 @@ while [[ $# -gt 0 ]]; do
     --runtime)       RUNTIME="$2"; shift 2 ;;
     --wp-path)       EXISTING_WP="$2"; shift 2 ;;
     --local)         LOCAL_MODE=true; RUN_AS_ROOT=false; shift ;;
+    --root)          RUN_AS_ROOT=true;  SERVICE_USER_FORCED=true; shift ;;
+    --non-root)      RUN_AS_ROOT=false; SERVICE_USER_FORCED=true; shift ;;
     --help|-h)       SHOW_HELP=true; shift ;;
     *)               shift ;;
   esac
@@ -158,6 +163,15 @@ USAGE:
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
   ./upgrade.sh --wp-path <path> Override detected WordPress path
   ./upgrade.sh --local          Local mode (no systemd; auto-on on macOS)
+  ./upgrade.sh --root           Force root service identity (skips adoption
+                                of the existing unit's User=)
+  ./upgrade.sh --non-root       Force non-root service identity (User=opencode)
+
+SERVICE IDENTITY:
+  By default the upgrade adopts the service user from the EXISTING
+  installed systemd unit (its User= line) rather than assuming root.
+  The upgrade never changes the service identity implicitly; use
+  --root / --non-root to change it deliberately.
 
 SUPPORTED CHAT BRIDGES:
   kimaki, cc-connect, telegram  (auto-detected per environment)
@@ -274,6 +288,14 @@ fi
 if [ -n "$CHAT_BRIDGE" ] && bridge_file "$CHAT_BRIDGE" >/dev/null 2>&1; then
   bridge_load "$CHAT_BRIDGE"
 fi
+
+# On upgrade, the installed unit's User= is the source of truth for the
+# service identity. upgrade.sh defaults RUN_AS_ROOT=true, which on a
+# non-root install (User=opencode) made Phase 5 silently rewrite the unit
+# to User=root — root-owned state files, broken next non-root start, and
+# the root-homed-path dispatch trap (#198/#93) all over again. See #204.
+# --root / --non-root force an explicit identity and skip adoption.
+adopt_service_identity_from_units
 
 log "Runtime:     $RUNTIME"
 log "Chat bridge: ${CHAT_BRIDGE:-none detected}"


### PR DESCRIPTION
## Summary
- `upgrade.sh` hardcodes `RUN_AS_ROOT=true` with no override flags, so on a non-root install (`kimaki.service` `User=opencode`) the Phase 5 systemd refresh proposed rewriting the unit to `User=root` — a silent service-identity flip caught in `--dry-run` on extrachill.com. It also dropped `UMask=0002` on every refresh.
- New `adopt_service_identity_from_units` (bridges/_dispatch.sh): on upgrade, the **existing installed unit's `User=` is the source of truth**. Reads it, re-derives `SERVICE_USER` / `SERVICE_HOME` / `KIMAKI_DATA_DIR` / `RUN_AS_ROOT`. Upgrades never change service identity implicitly.
- New `_preserve_systemd_umask`: carries the existing unit's `UMask=` through re-renders the same way `Environment=` lines are preserved. Wired into kimaki, cc-connect, and telegram `bridge_update_systemd`.
- `upgrade.sh` gains explicit `--root` / `--non-root` flags (parity with setup.sh) that force an identity and skip adoption — identity changes become deliberate operator actions.

## Why it matters
Root-run kimaki creates root-owned state files (breaking the next non-root start with EACCES on 0700 root-owned paths), the rendered `pkill -u root -f opencode.*serve` would kill any root opencode process on the host, and the flip re-introduces the root-homed-path dispatch trap already documented in bridges/kimaki.sh (#198/#93).

## Verification
- `tests/service-identity-adoption.sh` — 15 new assertions: adoption (root default + opencode unit → opencode), no-op when matching, forced-identity skip, local-mode skip, UMask preservation, and the end-to-end #204 production diff (re-render keeps `User=opencode` + `UMask=0002`, pkill scoped to adopted user). Added to CI.
- `bash -n` on all touched scripts.
- Full existing suite passes: cli-transport-install, smoke-cli-transport (17/17), cli-channel-perms, opencode-wrapper-removal, kimaki-agent-fallback (12/12), cli-channel-binary-path, wp-codebox-subtree.
- `tests/bridge-render.sh` kimaki-launchd snapshot drift is pre-existing on unmodified main (env-dependent PATH ordering on this host, `/usr/bin/node`) — not introduced here; renders are byte-identical between main and this branch.

Fixes #204

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Extra Chill Bot)
- **Used for:** Root-cause analysis from the production dry-run diff, implementation, regression test, and PR body. Chris reviews and merges.