### PR TITLE
Fix Homeboy upgrade service-user context

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -174,7 +174,7 @@ sync_homeboy_project_components() {
     fi
 
     local attach_output attach_status
-    attach_output="$(homeboy project components attach-path "$project_id" "$repo_path" 2>&1)"
+    attach_output="$(homeboy_run project components attach-path "$project_id" "$repo_path" 2>&1)"
     attach_status=$?
 
     # Trust Homeboy's JSON `.success` field over the raw exit code: the CLI

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -30,6 +30,20 @@ homeboy_project_json() {
   printf '}'
 }
 
+homeboy_run() {
+  if [ "${LOCAL_MODE:-false}" != true ] && \
+     [ -n "${SERVICE_USER:-}" ] && \
+     [ "$SERVICE_USER" != "root" ] && \
+     [ -n "${SERVICE_HOME:-}" ] && \
+     { [ "${WP_CODING_AGENTS_TEST_ASSUME_ROOT:-false}" = true ] || [ "$(id -u)" -eq 0 ]; } && \
+     command -v sudo >/dev/null 2>&1; then
+    sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" PATH="$PATH" homeboy "$@"
+    return $?
+  fi
+
+  homeboy "$@"
+}
+
 homeboy_server_json() {
   local user port
   user="$(homeboy_json_escape "$1")"
@@ -73,7 +87,7 @@ PY
   # "extrachill-site"), not a domain-slug guess.
   if [ -n "${SITE_DOMAIN:-}" ] && command -v homeboy >/dev/null 2>&1; then
     local project_list resolved
-    project_list="$(homeboy project list 2>/dev/null)"
+    project_list="$(homeboy_run project list 2>/dev/null)"
     if [ -n "$project_list" ]; then
       # Pass the JSON via env var (not stdin) so it does not collide with the
       # heredoc that supplies the python source on stdin.
@@ -130,7 +144,7 @@ homeboy_server_id() {
     return 0
   fi
 
-  if [ "$DRY_RUN" = false ] && homeboy server show "$SITE_DOMAIN" >/dev/null 2>&1; then
+  if [ "$DRY_RUN" = false ] && homeboy_run server show "$SITE_DOMAIN" >/dev/null 2>&1; then
     printf '%s' "$SITE_DOMAIN"
   fi
 
@@ -158,7 +172,7 @@ homeboy_wordpress_extension_ready() {
   command -v homeboy >/dev/null 2>&1 || return 1
 
   local list_json
-  list_json=$(homeboy extension list 2>/dev/null) || return 1
+  list_json=$(homeboy_run extension list 2>/dev/null) || return 1
 
   printf '%s' "$list_json" | python3 -c '
 import json, sys
@@ -180,7 +194,7 @@ homeboy_wordpress_extension_linked() {
   command -v homeboy >/dev/null 2>&1 || return 1
 
   local show_json
-  show_json=$(homeboy extension show wordpress 2>/dev/null) || return 1
+  show_json=$(homeboy_run extension show wordpress 2>/dev/null) || return 1
 
   printf '%s' "$show_json" | python3 -c '
 import json, sys

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -52,13 +52,45 @@ exit 2
 SH
 chmod +x "$FAKE_BIN/homeboy"
 
+cat > "$FAKE_BIN/sudo" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >> "$SUDO_LOG"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -n|-H)
+      shift
+      ;;
+    -u)
+      shift 2
+      ;;
+    env)
+      shift
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          *=*) export "$1"; shift ;;
+          *) break ;;
+        esac
+      done
+      exec "$@"
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+exit 2
+SH
+chmod +x "$FAKE_BIN/sudo"
+
 HOMEBOY_ATTACH_LOG="$TMP/attached.log"
 export HOMEBOY_ATTACH_LOG
 PATH="$FAKE_BIN:$PATH"
 
 assert_contains() {
   local needle="$1" file="$2"
-  if ! grep -qF "$needle" "$file"; then
+  if ! grep -qF -- "$needle" "$file"; then
     echo "FAIL: expected '$needle' in $file"
     cat "$file"
     exit 1
@@ -67,7 +99,7 @@ assert_contains() {
 
 assert_not_contains() {
   local needle="$1" file="$2"
-  if grep -qF "$needle" "$file"; then
+  if grep -qF -- "$needle" "$file"; then
     echo "FAIL: unexpected '$needle' in $file"
     cat "$file"
     exit 1
@@ -112,5 +144,24 @@ if [ -f "$HOMEBOY_ATTACH_LOG" ]; then
   exit 1
 fi
 assert_contains "Homeboy project config not found at site root — skipping DMC component attachment" "$TMP/empty-id-output.log"
+
+cat > "$SITE_PATH/homeboy.json" <<'JSON'
+{"id":"site-project"}
+JSON
+DRY_RUN=false
+SERVICE_USER="opencode"
+SERVICE_HOME="$TMP/opencode-home"
+WP_CODING_AGENTS_TEST_ASSUME_ROOT=true
+HOMEBOY_ATTACH_LOG="$TMP/service-user-attached.log"
+SUDO_LOG="$TMP/sudo.log"
+export HOMEBOY_ATTACH_LOG SUDO_LOG SERVICE_USER SERVICE_HOME WP_CODING_AGENTS_TEST_ASSUME_ROOT
+
+sync_homeboy_project_components > "$TMP/service-user-output.log"
+
+assert_contains "site-project|$DM_WORKSPACE_DIR/alpha" "$HOMEBOY_ATTACH_LOG"
+assert_contains "site-project|$DM_WORKSPACE_DIR/beta" "$HOMEBOY_ATTACH_LOG"
+assert_contains "-n -H -u opencode env HOME=$SERVICE_HOME" "$SUDO_LOG"
+assert_contains "PATH=" "$SUDO_LOG"
+assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/alpha" "$SUDO_LOG"
 
 echo "OK: Homeboy component attachment skips worktrees and metadata-less repos"


### PR DESCRIPTION
## Summary
- Run Homeboy project discovery and component attachment through the adopted service user during VPS upgrades.
- Keep root-run upgrades aligned with the Homeboy config used by the Kimaki service user.
- Cover the service-user attach path in the Homeboy component sync test.

## Testing
- `tests/homeboy-components.sh`
- `tests/service-identity-adoption.sh`
- `tests/agents-md-guidance.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Extra Chill upgrade hang, drafted the shell wrapper/test changes, and ran focused verification; Chris remains responsible for review and acceptance.