### PR TITLE
Fix managed Kimaki prompt replacement

### DIFF
--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -44,11 +44,29 @@ const fleetContextFilter: Plugin = async () => {
     // Replace Kimaki's generic CLI/orchestration prompt with managed guidance.
     "experimental.chat.system.transform": async (_input, output) => {
       output.system = output.system.map((block) => {
-        if (isKimakiSystemPrompt(block)) {
-          return MANAGED_KIMAKI_SYSTEM_PROMPT;
-        }
-        return block;
+        return replaceKimakiSystemPrompt(block);
       });
+    },
+
+    // Kimaki passes its generated Discord prompt through promptAsync's per-call
+    // `system` field. Some OpenCode releases do not expose that field through
+    // the system transform hook before model dispatch, but the final message
+    // transform still sees text parts that are about to reach the model. Keep a
+    // second replacement pass here so managed installs do not depend on one
+    // experimental hook shape.
+    "experimental.chat.messages.transform": async (_input, output) => {
+      for (const message of output.messages) {
+        for (const part of message.parts) {
+          if (part.type !== "text") {
+            continue;
+          }
+          const text = (part as any).text;
+          if (typeof text !== "string") {
+            continue;
+          }
+          (part as any).text = replaceKimakiSystemPrompt(text);
+        }
+      }
     },
 
     // Filter out Kimaki's MEMORY.md injection and time-gap MEMORY.md reminders.
@@ -95,6 +113,13 @@ function isKimakiSystemPrompt(block: string): boolean {
     block.includes("## uploading files to discord") ||
     block.includes("Your current OpenCode session ID is:")
   );
+}
+
+function replaceKimakiSystemPrompt(block: string): string {
+  if (isKimakiSystemPrompt(block)) {
+    return MANAGED_KIMAKI_SYSTEM_PROMPT;
+  }
+  return block;
 }
 
 export default fleetContextFilter;

--- a/scripts/kimaki-managed-plugin-rig.mjs
+++ b/scripts/kimaki-managed-plugin-rig.mjs
@@ -267,6 +267,7 @@ async function runCycle({ name, simulatePackageWipe }) {
   assert(promptEvidence.rawStaleOrchestrationLeaks.length > 0, `${name}: raw Kimaki prompt contains stale orchestration sections`, cycle)
   assert(promptEvidence.filteredStaleOrchestrationLeaks.length === 0, `${name}: filtered prompt removes stale orchestration sections`, cycle)
   assert(promptEvidence.contextFilterExecuted, `${name}: dm-context-filter hook executed`, cycle)
+  assert(promptEvidence.systemAndMessageTransformsAgree, `${name}: system and message transforms agree`, cycle)
   assert(promptEvidence.agentSyncLoaded, `${name}: dm-agent-sync module loads`, cycle)
 }
 
@@ -319,13 +320,28 @@ async function renderAndFilterPrompt(name) {
 
   const contextPluginModule = await import(pathToFileURL(path.join(stagedPluginsDir, 'dm-context-filter.ts')).href)
   const contextPlugin = await contextPluginModule.default({})
-  const transform = contextPlugin['experimental.chat.system.transform']
-  if (typeof transform !== 'function') {
+  const systemTransform = contextPlugin['experimental.chat.system.transform']
+  if (typeof systemTransform !== 'function') {
     throw new Error('dm-context-filter did not expose experimental.chat.system.transform')
   }
-  const output = { system: [raw] }
-  await transform({}, output)
-  const filtered = output.system.join('\n')
+  const systemOutput = { system: [raw] }
+  await systemTransform({}, systemOutput)
+  const systemFiltered = systemOutput.system.join('\n')
+
+  const messageTransform = contextPlugin['experimental.chat.messages.transform']
+  if (typeof messageTransform !== 'function') {
+    throw new Error('dm-context-filter did not expose experimental.chat.messages.transform')
+  }
+  const messageOutput = {
+    messages: [
+      {
+        info: { id: `msg_${name}` },
+        parts: [{ type: 'text', text: raw }],
+      },
+    ],
+  }
+  await messageTransform({}, messageOutput)
+  const filtered = messageOutput.messages[0].parts[0].text
 
   const agentSyncModule = await import(pathToFileURL(path.join(stagedPluginsDir, 'dm-agent-sync.ts')).href)
   const agentSyncPlugin = await agentSyncModule.default({ $: fakeShell })
@@ -341,7 +357,8 @@ async function renderAndFilterPrompt(name) {
     filteredIncludesTunnel: filtered.includes('## running dev servers with tunnel access'),
     rawStaleOrchestrationLeaks,
     filteredStaleOrchestrationLeaks,
-    contextFilterExecuted: output.system[0] !== raw,
+    contextFilterExecuted: systemOutput.system[0] !== raw && filtered !== raw,
+    systemAndMessageTransformsAgree: systemFiltered === filtered,
     agentSyncLoaded: !!agentSyncPlugin && typeof agentSyncPlugin === 'object',
     summary: {
       kimaki_dist_dir: kimakiDistDir,

--- a/tests/effective-prompt/filters.mjs
+++ b/tests/effective-prompt/filters.mjs
@@ -76,6 +76,26 @@ async function currentFilter(block) {
   return blocks.join("\n")
 }
 
+export async function currentFilterMessageText(block) {
+  const pluginModule = await import(pathToFileURL(PLUGIN_PATH).href)
+  const plugin = await pluginModule.default({})
+  const transform = plugin["experimental.chat.messages.transform"]
+  if (typeof transform !== "function") {
+    throw new Error(`dm-context-filter plugin is missing experimental.chat.messages.transform: ${PLUGIN_PATH}`)
+  }
+
+  const output = {
+    messages: [
+      {
+        info: { id: "msg_effective_prompt_test" },
+        parts: [{ type: "text", text: block }],
+      },
+    ],
+  }
+  await transform({}, output)
+  return output.messages[0].parts[0].text
+}
+
 export async function currentFilterSystemBlocks(blocks) {
   const pluginModule = await import(pathToFileURL(PLUGIN_PATH).href)
   const plugin = await pluginModule.default({})

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -48,7 +48,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 import { homedir } from "node:os"
 
-import { currentFilterSystemBlocks, filters } from "./filters.mjs"
+import { currentFilterMessageText, currentFilterSystemBlocks, filters } from "./filters.mjs"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -97,10 +97,10 @@ const DEFAULT_TRIGGERS = [
   { name: "dmc-hardcode",       pattern: "\\bData Machine Code\\b"                 },
   { name: "global-tunnel-url",  pattern: "\\bdev\\.chubes\\.net\\b"                },
   { name: "helper-fanout",      pattern: "spawn(?:ed)? .*helper sessions"           },
-  { name: "critique-section",   pattern: "^## (?:showing diffs|about critique)$"    },
-  { name: "critique-command",   pattern: "\\b(?:bunx )?critique\\b"               },
-  { name: "critique-url",       pattern: "\\bcritique\\.work\\b"                  },
-  { name: "critique-skill",     pattern: "<name>critique</name>"                    },
+  { name: "kimaki-generic-section", pattern: "^## (?:showing diffs|uploading files to discord|requesting files from the user|archiving the current thread|aborting a session|discord user mentions|generating audio from text|markdown formatting|Callouts in Kimaki Discord)$" },
+  { name: "kimaki-command",         pattern: "\\bkimaki (?:send|session|project|tunnel|upload-to-discord|tts|task)\\b" },
+  { name: "generic-skill-entry",    pattern: "<available_skills>|<skill>|</skill>|<name>(?!upgrade-wp-coding-agents</name>)" },
+  { name: "external-diff-surface",  pattern: "\\b(?:critique\\.work|(?:bunx )?critique)\\b" },
 ]
 
 // The current filter replaces Kimaki's generated bridge prompt and preserves
@@ -324,6 +324,19 @@ async function runScenario(name, scenario) {
     }
     if (transformedBlocks.length !== 2) {
       failures.push(`current filter returned ${transformedBlocks.length} system blocks for a two-block input`)
+    }
+
+    const transformedMessageText = await currentFilterMessageText(raw)
+    const messageLeaks = detectLeaks(transformedMessageText, scenario.triggers, scenario.allowLeakInSection)
+    if (messageLeaks.length > 0) {
+      failures.push(`current message transform has ${messageLeaks.length} trigger leaks (expected 0)`)
+    }
+    if (transformedMessageText !== filteredOut) {
+      failures.push("current system and message transforms disagree for the Kimaki prompt")
+    }
+    const sentinelMessageText = await currentFilterMessageText(sentinelBlock)
+    if (sentinelMessageText !== sentinelBlock) {
+      failures.push("current message transform changed a non-Kimaki text part")
     }
   }
 

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -97,6 +97,10 @@ const DEFAULT_TRIGGERS = [
   { name: "dmc-hardcode",       pattern: "\\bData Machine Code\\b"                 },
   { name: "global-tunnel-url",  pattern: "\\bdev\\.chubes\\.net\\b"                },
   { name: "helper-fanout",      pattern: "spawn(?:ed)? .*helper sessions"           },
+  { name: "critique-section",   pattern: "^## (?:showing diffs|about critique)$"    },
+  { name: "critique-command",   pattern: "\\b(?:bunx )?critique\\b"               },
+  { name: "critique-url",       pattern: "\\bcritique\\.work\\b"                  },
+  { name: "critique-skill",     pattern: "<name>critique</name>"                    },
 ]
 
 // The current filter replaces Kimaki's generated bridge prompt and preserves

--- a/tests/kimaki-managed-plugin-rig.sh
+++ b/tests/kimaki-managed-plugin-rig.sh
@@ -64,6 +64,21 @@ kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <curren
 
 cross-session discovery text that should be stripped
 
+## showing diffs
+
+Always run bunx critique --web and upload diffs to critique.work.
+
+## about critique
+
+critique is an external diff viewer that must not leak into managed context.
+
+<available_skills>
+  <skill>
+    <name>critique</name>
+    <description>Diff viewer skill that must not leak into managed context.</description>
+  </skill>
+</available_skills>
+
 ## markdown formatting
 
 Keep this section.
@@ -111,6 +126,11 @@ fi
 
 if grep -Eq '^## (starting new sessions from CLI|creating worktrees|cross-project commands|waiting for a session to finish)$|kimaki send|kimaki project list|Homeboy|Data Machine Code|dev\.chubes\.net' "$ARTIFACTS/prompts/initial-start.filtered.txt"; then
   echo "FAIL: filtered prompt leaked stale Kimaki orchestration guidance"
+  exit 1
+fi
+
+if grep -Eiq '^## (showing diffs|about critique)$|\b(bunx )?critique\b|critique\.work|<name>critique</name>' "$ARTIFACTS/prompts/initial-start.filtered.txt"; then
+  echo "FAIL: filtered prompt leaked critique guidance"
   exit 1
 fi
 

--- a/tests/kimaki-managed-plugin-rig.sh
+++ b/tests/kimaki-managed-plugin-rig.sh
@@ -64,6 +64,22 @@ kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <curren
 
 cross-session discovery text that should be stripped
 
+## uploading files to discord
+
+kimaki upload-to-discord --session ses_example artifact.txt
+
+## requesting files from the user
+
+Use the native file picker.
+
+## archiving the current thread
+
+kimaki session archive --session ses_example
+
+## generating audio from text
+
+kimaki tts 'summary' -o /tmp/summary.mp3
+
 ## showing diffs
 
 Always run bunx critique --web and upload diffs to critique.work.
@@ -76,6 +92,10 @@ critique is an external diff viewer that must not leak into managed context.
   <skill>
     <name>critique</name>
     <description>Diff viewer skill that must not leak into managed context.</description>
+  </skill>
+  <skill>
+    <name>playwriter</name>
+    <description>Browser automation skill that must not leak unless explicitly allowlisted.</description>
   </skill>
 </available_skills>
 
@@ -110,6 +130,7 @@ for (const cycle of manifest.cycles) {
     `${cycle.name}: raw Kimaki prompt contains stale orchestration sections`,
     `${cycle.name}: filtered prompt removes stale orchestration sections`,
     `${cycle.name}: dm-context-filter hook executed`,
+    `${cycle.name}: system and message transforms agree`,
     `${cycle.name}: dm-agent-sync module loads`,
   ]) {
     if (!labels.includes(expected)) {
@@ -129,8 +150,8 @@ if grep -Eq '^## (starting new sessions from CLI|creating worktrees|cross-projec
   exit 1
 fi
 
-if grep -Eiq '^## (showing diffs|about critique)$|\b(bunx )?critique\b|critique\.work|<name>critique</name>' "$ARTIFACTS/prompts/initial-start.filtered.txt"; then
-  echo "FAIL: filtered prompt leaked critique guidance"
+if grep -Eiq '^## (showing diffs|about critique|uploading files to discord|requesting files from the user|archiving the current thread|generating audio from text)$|\bkimaki (send|session|project|tunnel|upload-to-discord|tts|task)\b|<available_skills>|<skill>|</skill>|<name>(critique|playwriter)</name>|critique\.work|\b(bunx )?critique\b' "$ARTIFACTS/prompts/initial-start.filtered.txt"; then
+  echo "FAIL: filtered prompt leaked generic Kimaki guidance or non-allowlisted skills"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Replace the Kimaki-generated Discord system prompt through both the system transform hook and the final message transform hook.
- Extend the effective-prompt harness so it verifies the message-transform path, not just an idealized system-block transform.
- Update the managed Kimaki rig to prove both hook paths agree and to fail on generic Kimaki command/skill guidance leaks.

## Root cause
Kimaki sends its generated Discord instructions through `session.promptAsync({ system: ... })`. The previous `dm-context-filter` only tested and handled `experimental.chat.system.transform`, but the live session showed that per-call `system` content could still reach the model unchanged. The rig repeated the same false assumption by directly invoking only the system transform.

This change adds a defensive `experimental.chat.messages.transform` replacement pass so the managed prompt is enforced on the final text parts that are about to reach the model.

## Verification
- `node tests/effective-prompt/run.mjs`
- `bash tests/kimaki-managed-plugin-rig.sh`
- `node scripts/kimaki-managed-plugin-rig.mjs --check-live --live-site-dir '/Users/chubes/Studio/intelligence-chubes4' --live-kimaki-data-dir '/Users/chubes/.kimaki'`
- `./upgrade.sh --kimaki-only --wp-path '/Users/chubes/Studio/intelligence-chubes4'`

## Live install note
Synced the patched filter into the local Studio install with `./upgrade.sh --kimaki-only --wp-path '/Users/chubes/Studio/intelligence-chubes4'`. The live drift rig now passes. Kimaki still needs a restart before already-running/new bot-spawned sessions use the updated plugin process.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live managed Kimaki prompt leak, implemented the prompt replacement fallback, updated regression/rig coverage, and ran focused verification for Chris to review.