### PR TITLE
fix(kimaki): enforce managed skill surface

### DIFF
--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
-# post-upgrade.sh — Restore the wp-coding-agents upgrade skill and validate plugin state.
+# post-upgrade.sh — Enforce the managed Kimaki skill surface and validate plugin state.
 #
 # Two passes run against the npm-installed kimaki package and persistent
 # kimaki-config directory:
-#   1. RESTORE skill   — re-copy the upgrade skill from the persistent
-#                source dir (kimaki-config/skills/) into kimaki/skills/.
+#   1. SKILL surface   — remove package-local managed skill duplicates and,
+#                when a skills-enable-list.txt is present, remove bundled skills
+#                outside the allowlist from kimaki/skills/.
 #   2. VERIFY plugins  — confirm required wp-coding-agents opencode plugins
 #                exist at the persistent kimaki-config/plugins path loaded by
 #                opencode.json. Local installs no longer restore plugins into
 #                $(npm root -g)/kimaki/plugins because package-local files are
 #                wiped by `npm update -g kimaki`.
 #
-# `npm update -g kimaki` still wipes kimaki/skills/, so the upgrade skill is rehydrated
-# from persistent kimaki-config/ on every restart. Plugins are loaded directly
-# from persistent kimaki-config/plugins and only need validation here.
+# `npm update -g kimaki` can recreate bundled skills in kimaki/skills/. The
+# managed service starts Kimaki with --enable-skill, but post-upgrade also
+# enforces the package-local skill surface so recreated bundled skills and stale
+# wp-coding-agents duplicates do not leak or trigger duplicate discovery.
+# Plugins are loaded directly from persistent kimaki-config/plugins and only
+# need validation here.
 #
 # Invoked two ways:
 #   VPS:   ExecStartPre in kimaki.service (runs on every service start).
@@ -28,7 +32,7 @@
 #   1. KIMAKI_PLUGINS_DIR env var (explicit override)
 #   2. Persistent plugin source dir below (default for local and VPS)
 #
-# Persistent skill source dir resolution priority:
+# Persistent config dir resolution priority:
 #   1. KIMAKI_SKILL_SOURCE_DIR env var (explicit override)
 #   2. $KIMAKI_DATA_DIR/kimaki-config/skills/ if KIMAKI_DATA_DIR set and dir exists
 #   3. $HOME/.kimaki/kimaki-config/skills/ (local default)
@@ -74,10 +78,12 @@ is_wp_coding_agents_skill() {
 }
 
 # ----------------------------------------------------------------------------
-# Pass 1: RESTORE skill — re-copy the upgrade skill from the
-# persistent source dir into the npm-managed skills dir. Idempotent: `rm -rf`
-# before each `cp -r` so a stale copy always gets replaced by the current
-# source.
+# Pass 1: SKILL surface — keep persistent kimaki-config/skills/ as the durable
+# source and avoid copying it into Kimaki's package skills dir. OpenCode already
+# discovers project/user/runtime skills; package-local copies only create
+# duplicate skill warnings. If an allowlist exists, remove package-local skills
+# outside it so npm upgrades/restarts cannot recreate unwanted bundled skills
+# such as critique.
 # ----------------------------------------------------------------------------
 
 if [[ -n "${KIMAKI_SKILL_SOURCE_DIR:-}" ]]; then
@@ -90,27 +96,57 @@ else
   SKILL_SOURCE_DIR="/opt/kimaki-config/skills"
 fi
 
-skills_restored=0
+if [[ -n "${KIMAKI_SKILL_ENABLES_FILE:-}" ]]; then
+  SKILL_ENABLES_FILE="$KIMAKI_SKILL_ENABLES_FILE"
+elif [[ -n "${KIMAKI_DATA_DIR:-}" && -f "$KIMAKI_DATA_DIR/kimaki-config/skills-enable-list.txt" ]]; then
+  SKILL_ENABLES_FILE="$KIMAKI_DATA_DIR/kimaki-config/skills-enable-list.txt"
+elif [[ -f "$HOME/.kimaki/kimaki-config/skills-enable-list.txt" ]]; then
+  SKILL_ENABLES_FILE="$HOME/.kimaki/kimaki-config/skills-enable-list.txt"
+elif [[ -f "/opt/kimaki-config/skills-enable-list.txt" ]]; then
+  SKILL_ENABLES_FILE="/opt/kimaki-config/skills-enable-list.txt"
+else
+  SKILL_ENABLES_FILE=""
+fi
+
+skill_is_enabled() {
+  local candidate="$1"
+  [[ -n "$SKILL_ENABLES_FILE" && -f "$SKILL_ENABLES_FILE" ]] || return 1
+  local line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"
+    line="${line//[[:space:]]/}"
+    [[ -n "$line" ]] || continue
+    [[ "$line" == "$candidate" ]] && return 0
+  done < "$SKILL_ENABLES_FILE"
+  return 1
+}
+
+skills_removed=0
 if [[ ! -d "$SKILLS_DIR" ]]; then
-  echo "kimaki-config: skills dir not found at $SKILLS_DIR, skipping upgrade skill restore"
-elif [[ -d "$SKILL_SOURCE_DIR" ]]; then
-  for skill_dir in "$SKILL_SOURCE_DIR"/*/; do
+  echo "kimaki-config: skills dir not found at $SKILLS_DIR, skipping package skill surface enforcement"
+else
+  for skill_dir in "$SKILLS_DIR"/*/; do
     [[ -d "$skill_dir" ]] || continue
     skill_name="$(basename "$skill_dir")"
-    if ! is_wp_coding_agents_skill "$skill_name"; then
-      echo "kimaki-config: skipped unmanaged skill $skill_name"
+    if is_wp_coding_agents_skill "$skill_name"; then
+      rm -rf "$skill_dir"
+      echo "kimaki-config: removed package-local duplicate skill $skill_name"
+      skills_removed=$((skills_removed + 1))
       continue
     fi
-    if [[ -f "$skill_dir/SKILL.md" ]]; then
-      target="$SKILLS_DIR/$skill_name"
-      rm -rf "$target"
-      cp -r "$skill_dir" "$target"
-      echo "kimaki-config: restored upgrade skill $skill_name"
-      skills_restored=$((skills_restored + 1))
+
+    if [[ -n "$SKILL_ENABLES_FILE" && -f "$SKILL_ENABLES_FILE" ]] && ! skill_is_enabled "$skill_name"; then
+      rm -rf "$skill_dir"
+      echo "kimaki-config: removed package-local skill outside allowlist $skill_name"
+      skills_removed=$((skills_removed + 1))
     fi
   done
+fi
+
+if [[ -d "$SKILL_SOURCE_DIR" ]]; then
+  echo "kimaki-config: persistent skill source available at $SKILL_SOURCE_DIR"
 else
-  echo "kimaki-config: persistent skill source dir not found at $SKILL_SOURCE_DIR, skipping upgrade skill restore"
+  echo "kimaki-config: persistent skill source dir not found at $SKILL_SOURCE_DIR"
 fi
 
 # ----------------------------------------------------------------------------
@@ -177,4 +213,4 @@ else
   done
 fi
 
-echo "kimaki-config: done ($skills_restored skills restored, $plugins_restored plugins restored, $missing_required_plugins required plugins missing)"
+echo "kimaki-config: done ($skills_removed package skills removed, $plugins_restored plugins restored, $missing_required_plugins required plugins missing)"

--- a/scripts/kimaki-managed-plugin-rig.mjs
+++ b/scripts/kimaki-managed-plugin-rig.mjs
@@ -247,15 +247,24 @@ async function runCycle({ name, simulatePackageWipe }) {
   artifacts.cycles.push(cycle)
 
   if (simulatePackageWipe) {
-    fs.rmSync(path.join(npmSkillsDir, 'upgrade-wp-coding-agents'), { recursive: true, force: true })
+    fs.rmSync(npmSkillsDir, { recursive: true, force: true })
+    mkdirp(npmSkillsDir)
+    seedPackageSkill('critique')
+    seedPackageSkill('upgrade-wp-coding-agents')
   }
 
   const postUpgrade = runPostUpgrade(name)
   cycle.post_upgrade = postUpgrade
   assert(postUpgrade.status === 0, `${name}: post-upgrade exits 0`, cycle)
-  assert(fs.existsSync(path.join(npmSkillsDir, 'upgrade-wp-coding-agents', 'SKILL.md')), `${name}: upgrade skill restored to npm skills dir`, cycle)
+  assert(!fs.existsSync(path.join(npmSkillsDir, 'critique', 'SKILL.md')), `${name}: bundled critique skill removed from npm skills dir`, cycle)
+  assert(!fs.existsSync(path.join(npmSkillsDir, 'upgrade-wp-coding-agents', 'SKILL.md')), `${name}: package-local upgrade skill duplicate removed`, cycle)
+  assert(fs.existsSync(path.join(stagedSkillsDir, 'upgrade-wp-coding-agents', 'SKILL.md')), `${name}: persistent upgrade skill source remains present`, cycle)
   assert(fs.existsSync(path.join(stagedPluginsDir, 'dm-context-filter.ts')), `${name}: context filter present after restart`, cycle)
   assert(fs.existsSync(path.join(stagedPluginsDir, 'dm-agent-sync.ts')), `${name}: agent sync present after restart`, cycle)
+
+  const permission = expectedSkillPermission()
+  assert(permission?.['*'] === 'deny', `${name}: generated skill permission denies unlisted skills`, cycle)
+  assert(permission?.['upgrade-wp-coding-agents'] === 'allow', `${name}: generated skill permission allows upgrade skill`, cycle)
 
   const promptEvidence = await renderAndFilterPrompt(name)
   cycle.prompt = promptEvidence.summary
@@ -277,6 +286,7 @@ function runPostUpgrade(name) {
     KIMAKI_DATA_DIR: kimakiDataDir,
     KIMAKI_SKILLS_DIR: npmSkillsDir,
     KIMAKI_SKILL_SOURCE_DIR: stagedSkillsDir,
+    KIMAKI_SKILL_ENABLES_FILE: path.join(kimakiConfigDir, 'skills-enable-list.txt'),
     KIMAKI_PLUGIN_SOURCE_DIR: stagedPluginsDir,
     KIMAKI_PLUGINS_DIR: stagedPluginsDir,
   }
@@ -290,6 +300,27 @@ function runPostUpgrade(name) {
     fs.writeFileSync(outPath, stdout, 'utf8')
     return { status: error.status || 1, log: path.relative(artifactRoot, outPath), stdout }
   }
+}
+
+function seedPackageSkill(name) {
+  const skillDir = path.join(npmSkillsDir, name)
+  mkdirp(skillDir)
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${name} package fixture\n`, 'utf8')
+}
+
+function expectedSkillPermission() {
+  const enableList = path.join(kimakiConfigDir, 'skills-enable-list.txt')
+  const disableList = path.join(kimakiConfigDir, 'skills-disable-list.txt')
+  if (fs.existsSync(enableList)) {
+    return Object.fromEntries([
+      ['*', 'deny'],
+      ...skillNames(enableList).map((skill) => [skill, 'allow']),
+    ])
+  }
+  if (fs.existsSync(disableList)) {
+    return Object.fromEntries(skillNames(disableList).map((skill) => [skill, 'deny']))
+  }
+  return undefined
 }
 
 async function renderAndFilterPrompt(name) {

--- a/tests/kimaki-managed-plugin-rig.sh
+++ b/tests/kimaki-managed-plugin-rig.sh
@@ -94,6 +94,11 @@ for (const cycle of manifest.cycles) {
     `${cycle.name}: filtered prompt removes tunnel section`,
     `${cycle.name}: raw Kimaki prompt contains stale orchestration sections`,
     `${cycle.name}: filtered prompt removes stale orchestration sections`,
+    `${cycle.name}: bundled critique skill removed from npm skills dir`,
+    `${cycle.name}: package-local upgrade skill duplicate removed`,
+    `${cycle.name}: persistent upgrade skill source remains present`,
+    `${cycle.name}: generated skill permission denies unlisted skills`,
+    `${cycle.name}: generated skill permission allows upgrade skill`,
     `${cycle.name}: dm-context-filter hook executed`,
     `${cycle.name}: dm-agent-sync module loads`,
   ]) {

--- a/tests/post-upgrade-restore.sh
+++ b/tests/post-upgrade-restore.sh
@@ -6,9 +6,10 @@
 # user config.
 #
 # What we cover:
-#   1. Bundled Kimaki skills are left untouched; filtering happens at startup.
-#   2. Skill restore pass copies wp-coding-agents SKILL.md trees from the
-#      persistent source back into the (wiped) skills dir.
+#   1. Bundled Kimaki skills outside the allowlist are removed from the package
+#      skills dir because npm upgrades can recreate them.
+#   2. Package-local wp-coding-agents SKILL.md duplicates are removed; the
+#      persistent source remains authoritative.
 #   3. Default plugin pass is a no-op because opencode loads the persistent
 #      source dir directly.
 #   4. Explicit KIMAKI_PLUGINS_DIR compatibility override still copies *.ts
@@ -49,11 +50,15 @@ mkdir -p "$LIVE_SKILLS" "$SRC_SKILLS" "$SRC_PLUGINS"
 # Note: deliberately NOT creating LIVE_PLUGINS — explicit override mode must
 # still mkdir it.
 
-# Seed bundled skills that post-upgrade must not remove. Managed Kimaki service
-# startup now filters these with --disable-skill instead of mutating package
-# directories.
-mkdir -p "$LIVE_SKILLS/blacklisted-skill"
-echo "stub" > "$LIVE_SKILLS/blacklisted-skill/SKILL.md"
+# Seed package-local skills that post-upgrade must remove in allowlist mode.
+mkdir -p "$LIVE_SKILLS/critique" "$LIVE_SKILLS/upgrade-wp-coding-agents"
+echo "stub" > "$LIVE_SKILLS/critique/SKILL.md"
+echo "stale" > "$LIVE_SKILLS/upgrade-wp-coding-agents/SKILL.md"
+
+SKILL_ENABLES="$TMP/config/skills-enable-list.txt"
+cat > "$SKILL_ENABLES" <<'EOF'
+upgrade-wp-coding-agents
+EOF
 
 # Seed a wp-coding-agents skill in the persistent source that should be restored.
 mkdir -p "$SRC_SKILLS/upgrade-wp-coding-agents"
@@ -94,6 +99,7 @@ chmod +x "$TEST_SCRIPT_DIR/post-upgrade.sh"
 # npm install or user config.
 KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
 KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_SKILL_ENABLES_FILE="$SKILL_ENABLES" \
 KIMAKI_PLUGIN_SOURCE_DIR="$SRC_PLUGINS" \
   "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run1.log" 2>&1
 
@@ -131,14 +137,14 @@ assert_log_contains_file() {
   fi
 }
 
-# Pass 1: bundled Kimaki skills are not removed by post-upgrade.
-assert_present "$LIVE_SKILLS/blacklisted-skill/SKILL.md"
-
-# Pass 2: skill restore copied the allowed SKILL.md tree and skipped unmanaged skills.
-assert_present "$LIVE_SKILLS/upgrade-wp-coding-agents/SKILL.md"
-assert_log_contains "restored upgrade skill upgrade-wp-coding-agents"
+# Pass 1: package-local skills are scrubbed; persistent source remains.
+assert_missing "$LIVE_SKILLS/critique/SKILL.md"
+assert_missing "$LIVE_SKILLS/upgrade-wp-coding-agents/SKILL.md"
+assert_present "$SRC_SKILLS/upgrade-wp-coding-agents/SKILL.md"
+assert_log_contains "removed package-local skill outside allowlist critique"
+assert_log_contains "removed package-local duplicate skill upgrade-wp-coding-agents"
 assert_missing "$LIVE_SKILLS/unmanaged-skill/SKILL.md"
-assert_log_contains "skipped unmanaged skill unmanaged-skill"
+assert_log_contains "persistent skill source available at $SRC_SKILLS"
 
 # Pass 3: default plugin restore is a no-op because opencode loads the
 # persistent source directly.
@@ -149,6 +155,7 @@ assert_log_contains "plugin restore not needed; opencode loads persistent plugin
 KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
 KIMAKI_PLUGINS_DIR="$LIVE_PLUGINS" \
 KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_SKILL_ENABLES_FILE="$SKILL_ENABLES" \
 KIMAKI_PLUGIN_SOURCE_DIR="$SRC_PLUGINS" \
   "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run-override.log" 2>&1
 
@@ -161,6 +168,7 @@ assert_log_contains_file "$TMP/run-override.log" "restored plugin dm-agent-sync.
 KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
 KIMAKI_PLUGINS_DIR="$LIVE_PLUGINS" \
 KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_SKILL_ENABLES_FILE="$SKILL_ENABLES" \
 KIMAKI_PLUGIN_SOURCE_DIR="$SRC_PLUGINS" \
   "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run2.log" 2>&1
 
@@ -181,6 +189,7 @@ rm -rf "$LIVE_PLUGINS"
 KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
 KIMAKI_PLUGINS_DIR="$LIVE_PLUGINS" \
 KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_SKILL_ENABLES_FILE="$SKILL_ENABLES" \
 KIMAKI_PLUGIN_SOURCE_DIR="$SRC_PLUGINS" \
   "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run3.log" 2>&1
 
@@ -207,6 +216,9 @@ mkdir -p \
   "$FALLBACK_HOME/.kimaki/kimaki-config/skills/upgrade-wp-coding-agents" \
   "$FALLBACK_HOME/.kimaki/kimaki-config/plugins" \
   "$FALLBACK_LIVE_SKILLS"
+cat > "$FALLBACK_HOME/.kimaki/kimaki-config/skills-enable-list.txt" <<'EOF'
+upgrade-wp-coding-agents
+EOF
 cat > "$FALLBACK_HOME/.kimaki/kimaki-config/skills/upgrade-wp-coding-agents/SKILL.md" <<'EOF'
 ---
 name: upgrade-wp-coding-agents
@@ -224,8 +236,8 @@ KIMAKI_DATA_DIR="$FALLBACK_DATA" \
 KIMAKI_SKILLS_DIR="$FALLBACK_LIVE_SKILLS" \
   "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/run4.log" 2>&1
 
-if [[ ! -f "$FALLBACK_LIVE_SKILLS/upgrade-wp-coding-agents/SKILL.md" ]]; then
-  echo "FAIL: missing KIMAKI_DATA_DIR skills source should fall through to HOME source"
+if [[ -f "$FALLBACK_LIVE_SKILLS/upgrade-wp-coding-agents/SKILL.md" ]]; then
+  echo "FAIL: fallback run should not copy HOME-backed skill into package skills dir"
   cat "$TMP/run4.log"
   exit 1
 fi
@@ -234,8 +246,8 @@ if [[ -e "$FALLBACK_LIVE_PLUGINS" ]]; then
   cat "$TMP/run4.log"
   exit 1
 fi
-if ! grep -q "restored upgrade skill upgrade-wp-coding-agents" "$TMP/run4.log"; then
-  echo "FAIL: fallback run should restore the HOME-backed skill"
+if ! grep -q "persistent skill source available at $FALLBACK_HOME/.kimaki/kimaki-config/skills" "$TMP/run4.log"; then
+  echo "FAIL: fallback run should find the HOME-backed skill source"
   cat "$TMP/run4.log"
   exit 1
 fi
@@ -252,6 +264,7 @@ MISSING_LIVE_PLUGINS="$TMP/missing-live/plugins"
 KIMAKI_SKILLS_DIR="$LIVE_SKILLS" \
 KIMAKI_PLUGINS_DIR="$MISSING_LIVE_PLUGINS" \
 KIMAKI_SKILL_SOURCE_DIR="$SRC_SKILLS" \
+KIMAKI_SKILL_ENABLES_FILE="$SKILL_ENABLES" \
 KIMAKI_PLUGIN_SOURCE_DIR="$MISSING_SRC" \
   "$TEST_SCRIPT_DIR/post-upgrade.sh" > "$TMP/missing.log" 2>&1
 


### PR DESCRIPTION
## Summary
- Stop restoring wp-coding-agents managed skills into Kimaki's package-local skills directory.
- Scrub package-local managed duplicates and bundled skills outside the managed allowlist after Kimaki/npm upgrades.
- Extend deterministic Kimaki rigs to fail when `critique` or stale package-local `upgrade-wp-coding-agents` survives restart enforcement.

## Tests
- `bash tests/kimaki-managed-plugin-rig.sh && bash tests/post-upgrade-restore.sh`
- `node tests/effective-prompt/run.mjs --verbose`
- `for test in tests/*.sh; do bash "$test"; done` *(existing unrelated failures in `tests/cli-channel-binary-path.sh` on macOS temp-directory traversability)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigation, code changes, deterministic rig updates, and test execution; Chris reviewed the direction during the debugging session.