### PR TITLE
fix(homeboy): prune stale worktree components

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -139,6 +139,8 @@ sync_homeboy_project_components() {
 
   log "Attaching Homeboy components from DMC workspace: $DM_WORKSPACE_DIR"
 
+  prune_homeboy_project_components "$project_id"
+
   local attached=0
   local skipped=0
   local failed=0
@@ -195,6 +197,80 @@ sync_homeboy_project_components() {
   shopt -u nullglob
 
   log "Homeboy component sync complete: $attached attached, $skipped skipped, $failed failed"
+}
+
+prune_homeboy_project_components() {
+  local project_id="$1"
+
+  [ -n "$project_id" ] || return 0
+  [ -n "${DM_WORKSPACE_DIR:-}" ] || return 0
+
+  local project_json
+  project_json="$(homeboy_run project show "$project_id" 2>/dev/null || true)"
+  [ -n "$project_json" ] || return 0
+
+  local component_ids
+  component_ids="$(HOMEBOY_PROJECT_JSON="$project_json" HOMEBOY_DM_WORKSPACE_DIR="$DM_WORKSPACE_DIR" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+try:
+    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_JSON", ""))
+except Exception:
+    raise SystemExit(0)
+
+workspace = Path(os.environ.get("HOMEBOY_DM_WORKSPACE_DIR", "")).resolve()
+components = payload.get("data", {}).get("entity", {}).get("components", [])
+for component in components:
+    component_id = component.get("id") or ""
+    local_path = component.get("local_path") or ""
+    if not component_id or not local_path:
+        continue
+
+    path = Path(local_path).expanduser()
+    try:
+        resolved = path.resolve()
+    except Exception:
+        resolved = path.absolute()
+
+    try:
+        resolved.relative_to(workspace)
+    except ValueError:
+        continue
+
+    if "@" in path.name or not (resolved / "homeboy.json").is_file():
+        print(component_id)
+PY
+)"
+
+  [ -n "$component_ids" ] || return 0
+
+  local remove_ids=()
+  local component_id
+  while IFS= read -r component_id; do
+    [ -n "$component_id" ] || continue
+    remove_ids+=("$component_id")
+  done <<< "$component_ids"
+
+  [ ${#remove_ids[@]} -gt 0 ] || return 0
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} homeboy project components remove $project_id ${remove_ids[*]}"
+    return 0
+  fi
+
+  local remove_output remove_status
+  remove_output="$(homeboy_run project components remove "$project_id" "${remove_ids[@]}" 2>&1)"
+  remove_status=$?
+  if homeboy_attach_succeeded "$remove_output" "$remove_status"; then
+    log "  pruned stale Homeboy component(s): ${remove_ids[*]}"
+  else
+    warn "  failed to prune stale Homeboy component(s): ${remove_ids[*]}"
+    if [ -n "$remove_output" ]; then
+      warn "    $(printf '%s' "$remove_output" | head -n 3 | tr '\n' ' ')"
+    fi
+  fi
 }
 
 # Decide whether a `homeboy ... attach-path` invocation succeeded. Prefers the

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -44,6 +44,18 @@ FAKE_BIN="$TMP/bin"
 mkdir -p "$FAKE_BIN"
 cat > "$FAKE_BIN/homeboy" <<'SH'
 #!/bin/sh
+if [ "$1 $2" = "project show" ]; then
+  cat "$HOMEBOY_PROJECT_SHOW_JSON"
+  exit 0
+fi
+if [ "$1 $2 $3" = "project components remove" ]; then
+  shift 3
+  project_id="$1"
+  shift
+  printf '%s|%s\n' "$project_id" "$*" >> "$HOMEBOY_REMOVE_LOG"
+  printf '{"success":true}\n'
+  exit 0
+fi
 if [ "$1 $2 $3" = "project components attach-path" ]; then
   printf '%s|%s\n' "$4" "$5" >> "$HOMEBOY_ATTACH_LOG"
   exit 0
@@ -85,8 +97,24 @@ SH
 chmod +x "$FAKE_BIN/sudo"
 
 HOMEBOY_ATTACH_LOG="$TMP/attached.log"
-export HOMEBOY_ATTACH_LOG
+HOMEBOY_REMOVE_LOG="$TMP/removed.log"
+HOMEBOY_PROJECT_SHOW_JSON="$TMP/project-show.json"
+export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG HOMEBOY_PROJECT_SHOW_JSON
 PATH="$FAKE_BIN:$PATH"
+
+write_project_show_json() {
+  cat > "$HOMEBOY_PROJECT_SHOW_JSON" <<JSON
+{"success":true,"data":{"entity":{"components":[
+  {"id":"alpha","local_path":"$DM_WORKSPACE_DIR/alpha"},
+  {"id":"beta","local_path":"$DM_WORKSPACE_DIR/beta"},
+  {"id":"alpha-feature","local_path":"$DM_WORKSPACE_DIR/alpha@feature"},
+  {"id":"no-metadata","local_path":"$DM_WORKSPACE_DIR/no-metadata"},
+  {"id":"external","local_path":"$TMP/external@repo"}
+]}}}
+JSON
+}
+
+write_project_show_json
 
 assert_contains() {
   local needle="$1" file="$2"
@@ -112,14 +140,18 @@ assert_contains "site-project|$DM_WORKSPACE_DIR/alpha" "$HOMEBOY_ATTACH_LOG"
 assert_contains "site-project|$DM_WORKSPACE_DIR/beta" "$HOMEBOY_ATTACH_LOG"
 assert_not_contains "alpha@feature" "$HOMEBOY_ATTACH_LOG"
 assert_not_contains "no-metadata" "$HOMEBOY_ATTACH_LOG"
+assert_contains "site-project|alpha-feature no-metadata" "$HOMEBOY_REMOVE_LOG"
+assert_not_contains "external" "$HOMEBOY_REMOVE_LOG"
 
+assert_contains "pruned stale Homeboy component(s): alpha-feature no-metadata" "$TMP/output.log"
 assert_contains "skipped alpha@feature: worktree skipped" "$TMP/output.log"
 assert_contains "skipped no-metadata: no homeboy.json" "$TMP/output.log"
 assert_contains "Homeboy component sync complete: 2 attached, 2 skipped, 0 failed" "$TMP/output.log"
 
 DRY_RUN=true
 HOMEBOY_ATTACH_LOG="$TMP/dry-run-attached.log"
-export HOMEBOY_ATTACH_LOG
+HOMEBOY_REMOVE_LOG="$TMP/dry-run-removed.log"
+export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG
 sync_homeboy_project_components > "$TMP/dry-run-output.log"
 
 if [ -f "$HOMEBOY_ATTACH_LOG" ]; then
@@ -129,13 +161,20 @@ if [ -f "$HOMEBOY_ATTACH_LOG" ]; then
 fi
 assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/alpha" "$TMP/dry-run-output.log"
 assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/beta" "$TMP/dry-run-output.log"
+assert_contains "homeboy project components remove site-project alpha-feature no-metadata" "$TMP/dry-run-output.log"
+if [ -f "$HOMEBOY_REMOVE_LOG" ]; then
+  echo "FAIL: dry-run should not call homeboy components remove"
+  cat "$HOMEBOY_REMOVE_LOG"
+  exit 1
+fi
 
 cat > "$SITE_PATH/homeboy.json" <<'JSON'
 {}
 JSON
 DRY_RUN=false
 HOMEBOY_ATTACH_LOG="$TMP/empty-id-attached.log"
-export HOMEBOY_ATTACH_LOG
+HOMEBOY_REMOVE_LOG="$TMP/empty-id-removed.log"
+export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG
 sync_homeboy_project_components > "$TMP/empty-id-output.log"
 
 if [ -f "$HOMEBOY_ATTACH_LOG" ]; then
@@ -153,15 +192,18 @@ SERVICE_USER="opencode"
 SERVICE_HOME="$TMP/opencode-home"
 WP_CODING_AGENTS_TEST_ASSUME_ROOT=true
 HOMEBOY_ATTACH_LOG="$TMP/service-user-attached.log"
+HOMEBOY_REMOVE_LOG="$TMP/service-user-removed.log"
 SUDO_LOG="$TMP/sudo.log"
-export HOMEBOY_ATTACH_LOG SUDO_LOG SERVICE_USER SERVICE_HOME WP_CODING_AGENTS_TEST_ASSUME_ROOT
+export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG SUDO_LOG SERVICE_USER SERVICE_HOME WP_CODING_AGENTS_TEST_ASSUME_ROOT
 
 sync_homeboy_project_components > "$TMP/service-user-output.log"
 
+assert_contains "site-project|alpha-feature no-metadata" "$HOMEBOY_REMOVE_LOG"
 assert_contains "site-project|$DM_WORKSPACE_DIR/alpha" "$HOMEBOY_ATTACH_LOG"
 assert_contains "site-project|$DM_WORKSPACE_DIR/beta" "$HOMEBOY_ATTACH_LOG"
 assert_contains "-n -H -u opencode env HOME=$SERVICE_HOME" "$SUDO_LOG"
 assert_contains "PATH=" "$SUDO_LOG"
+assert_contains "homeboy project components remove site-project alpha-feature no-metadata" "$SUDO_LOG"
 assert_contains "homeboy project components attach-path site-project $DM_WORKSPACE_DIR/alpha" "$SUDO_LOG"
 
-echo "OK: Homeboy component attachment skips worktrees and metadata-less repos"
+echo "OK: Homeboy component attachment prunes stale worktrees and skips metadata-less repos"


### PR DESCRIPTION
## Summary
- Prune stale Homeboy project components under the DMC workspace before attaching current primary repos.
- Remove existing `repo@slug` worktree components and metadata-less workspace entries through `homeboy project components remove`.
- Extend the Homeboy component test to cover stale component pruning, dry-run output, and service-user execution.

## Verification
- `bash tests/homeboy-components.sh`
- `bash -n lib/data-machine.sh tests/homeboy-components.sh upgrade.sh`
- `bash tests/kimaki-managed-plugin-rig.sh`
- `./upgrade.sh --dry-run --wp-path /Users/chubes/Studio/intelligence-chubes4`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the upgrade-time Homeboy component validation failure, drafted the prune fix and tests, and ran targeted verification; Chris remains responsible for review and merge.