### PR TITLE
fix(homeboy): tolerate partial component pruning

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -261,9 +261,12 @@ PY
   fi
 
   local remove_output remove_status
+  set +e
   remove_output="$(homeboy_run project components remove "$project_id" "${remove_ids[@]}" 2>&1)"
   remove_status=$?
-  if homeboy_attach_succeeded "$remove_output" "$remove_status"; then
+  set -e
+
+  if homeboy_attach_succeeded "$remove_output" "$remove_status" || homeboy_components_absent "$project_id" "${remove_ids[@]}"; then
     log "  pruned stale Homeboy component(s): ${remove_ids[*]}"
   else
     warn "  failed to prune stale Homeboy component(s): ${remove_ids[*]}"
@@ -271,6 +274,42 @@ PY
       warn "    $(printf '%s' "$remove_output" | head -n 3 | tr '\n' ' ')"
     fi
   fi
+}
+
+homeboy_components_absent() {
+  local project_id="$1"
+  shift
+  [ -n "$project_id" ] || return 1
+  [ "$#" -gt 0 ] || return 0
+
+  local project_json
+  project_json="$(homeboy_run project show "$project_id" 2>/dev/null || true)"
+  [ -n "$project_json" ] || return 1
+
+  local remaining
+  remaining="$(HOMEBOY_PROJECT_JSON="$project_json" python3 - "$@" <<'PY'
+import json
+import os
+import sys
+
+try:
+    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_JSON", ""))
+except Exception:
+    raise SystemExit(1)
+
+expected_absent = set(sys.argv[1:])
+components = payload.get("data", {}).get("entity", {}).get("components", [])
+present = {
+    component.get("id")
+    for component in components
+    if component.get("id")
+}
+for component_id in sorted(expected_absent & present):
+    print(component_id)
+PY
+)"
+
+  [ -z "$remaining" ]
 }
 
 # Decide whether a `homeboy ... attach-path` invocation succeeded. Prefers the

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -45,6 +45,10 @@ mkdir -p "$FAKE_BIN"
 cat > "$FAKE_BIN/homeboy" <<'SH'
 #!/bin/sh
 if [ "$1 $2" = "project show" ]; then
+  if [ -n "${HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON:-}" ] && [ -f "${HOMEBOY_REMOVE_LOG:-}" ]; then
+    cat "$HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON"
+    exit 0
+  fi
   cat "$HOMEBOY_PROJECT_SHOW_JSON"
   exit 0
 fi
@@ -53,8 +57,12 @@ if [ "$1 $2 $3" = "project components remove" ]; then
   project_id="$1"
   shift
   printf '%s|%s\n' "$project_id" "$*" >> "$HOMEBOY_REMOVE_LOG"
-  printf '{"success":true}\n'
-  exit 0
+  if [ "${HOMEBOY_REMOVE_STATUS:-0}" = 0 ]; then
+    printf '{"success":true}\n'
+    exit 0
+  fi
+  printf '{"success":false,"error":{"message":"validation failed after partial mutation"}}\n'
+  exit "$HOMEBOY_REMOVE_STATUS"
 fi
 if [ "$1 $2 $3" = "project components attach-path" ]; then
   printf '%s|%s\n' "$4" "$5" >> "$HOMEBOY_ATTACH_LOG"
@@ -99,7 +107,9 @@ chmod +x "$FAKE_BIN/sudo"
 HOMEBOY_ATTACH_LOG="$TMP/attached.log"
 HOMEBOY_REMOVE_LOG="$TMP/removed.log"
 HOMEBOY_PROJECT_SHOW_JSON="$TMP/project-show.json"
-export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG HOMEBOY_PROJECT_SHOW_JSON
+HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON="$TMP/project-show-after-remove.json"
+HOMEBOY_REMOVE_STATUS=1
+export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG HOMEBOY_PROJECT_SHOW_JSON HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON HOMEBOY_REMOVE_STATUS
 PATH="$FAKE_BIN:$PATH"
 
 write_project_show_json() {
@@ -115,6 +125,13 @@ JSON
 }
 
 write_project_show_json
+cat > "$HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON" <<JSON
+{"success":true,"data":{"entity":{"components":[
+  {"id":"alpha","local_path":"$DM_WORKSPACE_DIR/alpha"},
+  {"id":"beta","local_path":"$DM_WORKSPACE_DIR/beta"},
+  {"id":"external","local_path":"$TMP/external@repo"}
+]}}}
+JSON
 
 assert_contains() {
   local needle="$1" file="$2"


### PR DESCRIPTION
## Summary
- Prevent `set -e` from aborting upgrade when `homeboy project components remove` returns non-zero after mutating project config.
- Verify stale component IDs are absent with `project show` before treating a non-zero remove as failure.
- Extend Homeboy component tests to cover partial-mutation remove behavior.

## Verification
- `bash tests/homeboy-components.sh`
- `bash -n lib/data-machine.sh tests/homeboy-components.sh upgrade.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed Homeboy remove partial-mutation behavior, drafted the tolerance fix and regression test, and ran targeted verification; Chris remains responsible for review and merge.