### PR TITLE
Fix Homeboy component attach status handling

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -176,8 +176,10 @@ sync_homeboy_project_components() {
     fi
 
     local attach_output attach_status
+    set +e
     attach_output="$(homeboy_run project components attach-path "$project_id" "$repo_path" 2>&1)"
     attach_status=$?
+    set -e
 
     # Trust Homeboy's JSON `.success` field over the raw exit code: the CLI
     # can print a success payload while still returning a non-zero status (or

--- a/tests/homeboy-components.sh
+++ b/tests/homeboy-components.sh
@@ -66,7 +66,11 @@ if [ "$1 $2 $3" = "project components remove" ]; then
 fi
 if [ "$1 $2 $3" = "project components attach-path" ]; then
   printf '%s|%s\n' "$4" "$5" >> "$HOMEBOY_ATTACH_LOG"
-  exit 0
+  if [ "${HOMEBOY_ATTACH_STATUS:-0}" = 0 ]; then
+    exit 0
+  fi
+  printf '{"success":true,"warning":"non-zero status with success payload"}\n'
+  exit "$HOMEBOY_ATTACH_STATUS"
 fi
 exit 2
 SH
@@ -108,8 +112,9 @@ HOMEBOY_ATTACH_LOG="$TMP/attached.log"
 HOMEBOY_REMOVE_LOG="$TMP/removed.log"
 HOMEBOY_PROJECT_SHOW_JSON="$TMP/project-show.json"
 HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON="$TMP/project-show-after-remove.json"
+HOMEBOY_ATTACH_STATUS=0
 HOMEBOY_REMOVE_STATUS=1
-export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG HOMEBOY_PROJECT_SHOW_JSON HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON HOMEBOY_REMOVE_STATUS
+export HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG HOMEBOY_PROJECT_SHOW_JSON HOMEBOY_PROJECT_SHOW_AFTER_REMOVE_JSON HOMEBOY_ATTACH_STATUS HOMEBOY_REMOVE_STATUS
 PATH="$FAKE_BIN:$PATH"
 
 write_project_show_json() {
@@ -164,6 +169,18 @@ assert_contains "pruned stale Homeboy component(s): alpha-feature no-metadata" "
 assert_contains "skipped alpha@feature: worktree skipped" "$TMP/output.log"
 assert_contains "skipped no-metadata: no homeboy.json" "$TMP/output.log"
 assert_contains "Homeboy component sync complete: 2 attached, 2 skipped, 0 failed" "$TMP/output.log"
+
+HOMEBOY_ATTACH_STATUS=4
+HOMEBOY_ATTACH_LOG="$TMP/nonzero-success-attached.log"
+HOMEBOY_REMOVE_LOG="$TMP/nonzero-success-removed.log"
+export HOMEBOY_ATTACH_STATUS HOMEBOY_ATTACH_LOG HOMEBOY_REMOVE_LOG
+sync_homeboy_project_components > "$TMP/nonzero-success-output.log"
+
+assert_contains "site-project|$DM_WORKSPACE_DIR/alpha" "$HOMEBOY_ATTACH_LOG"
+assert_contains "site-project|$DM_WORKSPACE_DIR/beta" "$HOMEBOY_ATTACH_LOG"
+assert_contains "Homeboy component sync complete: 2 attached, 2 skipped, 0 failed" "$TMP/nonzero-success-output.log"
+
+HOMEBOY_ATTACH_STATUS=0
 
 DRY_RUN=true
 HOMEBOY_ATTACH_LOG="$TMP/dry-run-attached.log"


### PR DESCRIPTION
## Summary
- Preserve Homeboy component attachment handling when `attach-path` exits non-zero but emits a successful JSON payload.
- Add regression coverage for the non-zero/success-payload path so upgrade does not exit during AGENTS.md regeneration.

## Tests
- `bash tests/homeboy-components.sh`
- `bash tests/kimaki-managed-plugin-rig.sh`
- `bash tests/post-upgrade-restore.sh`
- `node tests/effective-prompt/run.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the local upgrade failure, drafted the minimal shell fix and regression test, and ran targeted verification; Chris remains responsible for review and merge.