### PR TITLE
Fix Homeboy project resolution for local Studio upgrades

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -114,6 +114,101 @@ PY
         printf '%s\n' "$resolved"
         return 0
       fi
+
+      # Local Studio installs can surface a transient localhost URL while the
+      # registered Homeboy project keeps the stable Studio project id/domain.
+      # In that case, resolve by base_path before falling back to a slug.
+      if [ -n "${SITE_PATH:-}" ]; then
+        resolved="$(HOMEBOY_PROJECT_LIST="$project_list" HOMEBOY_SITE_PATH="$SITE_PATH" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+site_path = Path(os.environ.get("HOMEBOY_SITE_PATH", "")).expanduser()
+try:
+    site_path = site_path.resolve()
+except Exception:
+    site_path = site_path.absolute()
+
+try:
+    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_LIST", ""))
+except Exception:
+    payload = {}
+
+for project in payload.get("data", {}).get("projects", []):
+    base_path = project.get("base_path") or ""
+    if not base_path:
+        continue
+    candidate = Path(base_path).expanduser()
+    try:
+        candidate = candidate.resolve()
+    except Exception:
+        candidate = candidate.absolute()
+    if candidate == site_path and project.get("id"):
+        print(project["id"])
+        break
+PY
+)"
+        if [ -z "$resolved" ]; then
+          local project_id project_ids project_json
+          project_ids="$(HOMEBOY_PROJECT_LIST="$project_list" python3 <<'PY'
+import json
+import os
+
+try:
+    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_LIST", ""))
+except Exception:
+    payload = {}
+
+for project in payload.get("data", {}).get("projects", []):
+    project_id = project.get("id") or ""
+    if project_id:
+        print(project_id)
+PY
+)"
+          while IFS= read -r project_id; do
+            [ -n "$project_id" ] || continue
+            project_json="$(homeboy_run project show "$project_id" 2>/dev/null || true)"
+            [ -n "$project_json" ] || continue
+            resolved="$(HOMEBOY_PROJECT_JSON="$project_json" HOMEBOY_SITE_PATH="$SITE_PATH" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+site_path = Path(os.environ.get("HOMEBOY_SITE_PATH", "")).expanduser()
+try:
+    site_path = site_path.resolve()
+except Exception:
+    site_path = site_path.absolute()
+
+try:
+    payload = json.loads(os.environ.get("HOMEBOY_PROJECT_JSON", ""))
+except Exception:
+    payload = {}
+
+entity = payload.get("data", {}).get("entity", {})
+base_path = entity.get("base_path") or ""
+project_id = entity.get("id") or payload.get("data", {}).get("id") or ""
+if base_path and project_id:
+    candidate = Path(base_path).expanduser()
+    try:
+        candidate = candidate.resolve()
+    except Exception:
+        candidate = candidate.absolute()
+    if candidate == site_path:
+        print(project_id)
+PY
+)"
+            if [ -n "$resolved" ]; then
+              break
+            fi
+          done <<< "$project_ids"
+        fi
+        if [ -n "$resolved" ]; then
+          printf '%s\n' "$resolved"
+          return 0
+        fi
+      fi
     fi
   fi
 

--- a/tests/homeboy-project-id.sh
+++ b/tests/homeboy-project-id.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# tests/homeboy-project-id.sh — Homeboy project id resolution for local sites.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/homeboy.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SITE_PATH="$TMP/intelligence-chubes4"
+SITE_DOMAIN="localhost:8881"
+DRY_RUN=false
+LOCAL_MODE=true
+mkdir -p "$SITE_PATH"
+
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/homeboy" <<'SH'
+#!/bin/sh
+if [ "$1 $2" = "project list" ]; then
+  cat <<JSON
+{"success":true,"data":{"projects":[
+  {"domain":"intelligence-chubes4","id":"intelligence-chubes4"},
+  {"domain":"example.test","id":"example"}
+]}}
+JSON
+  exit 0
+fi
+if [ "$1 $2" = "project show" ]; then
+  case "$3" in
+    intelligence-chubes4)
+      printf '{"success":true,"data":{"id":"intelligence-chubes4","entity":{"base_path":"%s"}}}\n' "$SITE_PATH"
+      exit 0
+      ;;
+    example)
+      printf '{"success":true,"data":{"id":"example","entity":{"base_path":"%s"}}}\n' "$TMP/example"
+      exit 0
+      ;;
+  esac
+fi
+exit 2
+SH
+chmod +x "$FAKE_BIN/homeboy"
+PATH="$FAKE_BIN:$PATH"
+export SITE_PATH TMP
+
+resolved="$(homeboy_project_id)"
+if [ "$resolved" != "intelligence-chubes4" ]; then
+  echo "FAIL: expected base_path match to resolve intelligence-chubes4, got '$resolved'"
+  exit 1
+fi
+
+echo "OK: Homeboy project id resolves local Studio site by base_path"


### PR DESCRIPTION
## Summary
- Resolve registered Homeboy projects by `base_path` when the WordPress site URL is a transient local/Studio URL that does not match the Homeboy project domain.
- Add regression coverage for a `localhost:8881` Studio site resolving to the stable `intelligence-chubes4` Homeboy project id.
- Fixes #224.

## Verification
- `bash tests/homeboy-project-id.sh`
- `bash tests/homeboy-components.sh`
- `bash -n lib/homeboy.sh tests/homeboy-project-id.sh tests/homeboy-components.sh`
- `bash tests/kimaki-managed-plugin-rig.sh`
- `bash tests/post-upgrade-restore.sh`
- `node tests/effective-prompt/run.mjs`
- Local upgrade repro: `exit=0 failures=0 attached=41`; `Homeboy component sync complete: 41 attached, 367 skipped, 0 failed`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the local Studio/Homeboy project-id mismatch, drafted the resolver change and regression test, and ran targeted verification; Chris remains responsible for review and merge.