### PR TITLE
Fix Kimaki launchd stale OpenCode cleanup

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -9,11 +9,12 @@
 # Install layout:
 #   VPS:   /opt/kimaki-config/{plugins,post-upgrade.sh,skills-enable-list.txt}
 #          + /etc/systemd/system/kimaki.service (ExecStartPre runs post-upgrade.sh)
-#   Local: $KIMAKI_DATA_DIR/kimaki-config/ for plugins, post-upgrade.sh +
-#          skill filters (executed inline at upgrade time — no launchd
-#          ExecStartPre hook). opencode.json loads plugins directly from this
-#          durable data-dir copy because `npm update -g kimaki` wipes package-
-#          local files.
+#   Local: $KIMAKI_DATA_DIR/kimaki-config/ for plugins, post-upgrade.sh,
+#          launchd-start.sh, and skill filters. launchd-start.sh gives macOS
+#          the same pre-start cleanup/post-upgrade hook that systemd gets from
+#          ExecStartPre. opencode.json loads plugins directly from this durable
+#          data-dir copy because `npm update -g kimaki` wipes package-local
+#          files.
 #          + $HOME/Library/LaunchAgents/com.wp.kimaki.plist on macOS.
 
 # ============================================================================
@@ -278,6 +279,13 @@ _kimaki_install_launchd() {
   run_cmd mkdir -p "$KIMAKI_DATA_DIR"
   run_cmd mkdir -p "$KIMAKI_PLIST_DIR"
 
+  local KIMAKI_CONFIG_DIR="${KIMAKI_DATA_DIR}/kimaki-config"
+  if [ "$DRY_RUN" = false ] && [ -f "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" ]; then
+    mkdir -p "$KIMAKI_CONFIG_DIR"
+    cp "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" "$KIMAKI_CONFIG_DIR/launchd-start.sh"
+    chmod +x "$KIMAKI_CONFIG_DIR/launchd-start.sh"
+  fi
+
   write_file "$KIMAKI_PLIST" "$(bridge_render_launchd "$KIMAKI_PLIST_LABEL")"
 
   if [ "$DRY_RUN" = false ] && [ -n "$KIMAKI_BOT_TOKEN" ]; then
@@ -416,7 +424,7 @@ bridge_sync_config() {
     done
   fi
 
-  # Stage post-upgrade.sh and skills-enable-list.txt in KIMAKI_CONFIG_DIR.
+  # Stage post-upgrade.sh, launchd-start.sh, and skills-enable-list.txt in KIMAKI_CONFIG_DIR.
   # On VPS this is read by ExecStartPre. On local we execute it inline below.
   if [ "$DRY_RUN" = false ]; then
     mkdir -p "$KIMAKI_CONFIG_DIR" 2>/dev/null || true
@@ -433,6 +441,21 @@ bridge_sync_config() {
         chmod +x "$KIMAKI_CONFIG_DIR/post-upgrade.sh"
         log "  Updated $KIMAKI_CONFIG_DIR/post-upgrade.sh"
         UPDATED_ITEMS+=("kimaki-config/post-upgrade.sh")
+      fi
+    fi
+  fi
+
+  if [ -f "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" "$KIMAKI_CONFIG_DIR/launchd-start.sh" 2>/dev/null; then
+        echo -e "${BLUE}[dry-run]${NC} Would update $KIMAKI_CONFIG_DIR/launchd-start.sh"
+      fi
+    else
+      if ! cmp -s "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" "$KIMAKI_CONFIG_DIR/launchd-start.sh" 2>/dev/null; then
+        cp "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" "$KIMAKI_CONFIG_DIR/launchd-start.sh"
+        chmod +x "$KIMAKI_CONFIG_DIR/launchd-start.sh"
+        log "  Updated $KIMAKI_CONFIG_DIR/launchd-start.sh"
+        UPDATED_ITEMS+=("kimaki-config/launchd-start.sh")
       fi
     fi
   fi
@@ -665,6 +688,8 @@ bridge_render_launchd() {
   path_value="$(_compose_path_value "$HOME/.local/bin" "$kimaki_bin_dir" "$node_bin_dir" "$HOME/.opencode/bin" "$HOME/.bun/bin" /opt/homebrew/bin /usr/local/bin /usr/bin /bin /usr/sbin /sbin)"
   local skill_filter_plist_args
   skill_filter_plist_args="$(_kimaki_skill_filter_args_plist)"
+  local launchd_start
+  launchd_start="${KIMAKI_DATA_DIR}/kimaki-config/launchd-start.sh"
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -674,6 +699,7 @@ bridge_render_launchd() {
     <string>$label</string>
     <key>ProgramArguments</key>
     <array>
+        <string>$launchd_start</string>
         <string>$KIMAKI_BIN</string>
         <string>--data-dir</string>
         <string>$KIMAKI_DATA_DIR</string>
@@ -695,6 +721,8 @@ $skill_filter_plist_args
         <string>$path_value</string>
         <key>KIMAKI_DATA_DIR</key>
         <string>$KIMAKI_DATA_DIR</string>
+        <key>KIMAKI_CONFIG_DIR</key>
+        <string>${KIMAKI_DATA_DIR}/kimaki-config</string>
         <key>DATAMACHINE_SITE_PATH</key>
         <string>$SITE_PATH</string>$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
         <key>KIMAKI_BOT_TOKEN</key>

--- a/bridges/kimaki/launchd-start.sh
+++ b/bridges/kimaki/launchd-start.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# wp-coding-agents-owned launchd entrypoint for the managed Kimaki bridge.
+# launchd has no ExecStartPre equivalent, so keep macOS parity with the
+# systemd unit by running preflight cleanup here before execing Kimaki.
+set -eu
+
+if command -v pkill >/dev/null 2>&1; then
+  pkill -TERM -f "opencode-ai/bin/.*serve" >/dev/null 2>&1 || true
+fi
+
+config_dir="${KIMAKI_CONFIG_DIR:-${KIMAKI_DATA_DIR:-$HOME/.kimaki}/kimaki-config}"
+if [ -x "$config_dir/post-upgrade.sh" ]; then
+  "$config_dir/post-upgrade.sh" || true
+fi
+
+exec "$@"

--- a/scripts/kimaki-managed-plugin-rig.mjs
+++ b/scripts/kimaki-managed-plugin-rig.mjs
@@ -283,6 +283,12 @@ async function recordLiveRuntimeEvidence({ live, liveSiteDir, liveKimakiDataDir,
     class: 'stale OpenCode server',
     liveSiteDir,
   })
+  const staleOpenCodeServers = live.processes.opencode_serve.filter((processInfo) => !hasAncestor(processInfo, managedKimakiProcesses, processes))
+  live.stale_opencode_serve = staleOpenCodeServers
+  liveCheck(staleOpenCodeServers.length === 0, 'no stale OpenCode serve processes outside managed Kimaki ancestry', live, {
+    class: 'stale OpenCode server',
+    stale: staleOpenCodeServers,
+  })
 
   const livePromptEvidence = await renderLivePromptEvidence({ liveConfigDir, livePluginsDir })
   live.prompt = livePromptEvidence.summary
@@ -811,6 +817,18 @@ function runArgSelfTest() {
   if (parsed['live-site-dir'] !== '/tmp/site') failures.push('--live-site-dir should consume /tmp/site')
   if (parsed.keep !== true) failures.push('--keep should parse as boolean true')
   if (parsed['artifact-dir'] !== '/tmp/artifacts') failures.push('--artifact-dir=value should parse inline value')
+  const processFixtures = [
+    { pid: 10, ppid: 1, command: 'node /bin/kimaki --data-dir /tmp/kimaki --auto-restart --no-critique' },
+    { pid: 11, ppid: 10, command: 'node /bin/opencode serve --port 12345' },
+    { pid: 12, ppid: 1, command: 'node /bin/opencode serve --port 23456' },
+  ]
+  const managedKimakiFixtures = [processFixtures[0]]
+  const staleOpenCodeFixtures = processFixtures
+    .filter(isOpencodeServeProcess)
+    .filter((processInfo) => !hasAncestor(processInfo, managedKimakiFixtures, processFixtures))
+  if (staleOpenCodeFixtures.length !== 1 || staleOpenCodeFixtures[0].pid !== 12) {
+    failures.push('stale OpenCode process detector should flag orphaned serve process')
+  }
   if (failures.length > 0) {
     throw new Error(`argument parser self-test failed: ${failures.join('; ')}`)
   }

--- a/tests/__snapshots__/bridges/kimaki-launchd
+++ b/tests/__snapshots__/bridges/kimaki-launchd
@@ -6,6 +6,7 @@
     <string>com.wp.kimaki</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/home/chubes/.kimaki/kimaki-config/launchd-start.sh</string>
         <string>/opt/homebrew/bin/kimaki</string>
         <string>--data-dir</string>
         <string>/home/chubes/.kimaki</string>
@@ -28,6 +29,8 @@
         <string>/home/chubes/.local/bin:/opt/homebrew/bin:/home/chubes/.opencode/bin:/home/chubes/.bun/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>KIMAKI_DATA_DIR</key>
         <string>/home/chubes/.kimaki</string>
+        <key>KIMAKI_CONFIG_DIR</key>
+        <string>/home/chubes/.kimaki/kimaki-config</string>
         <key>DATAMACHINE_SITE_PATH</key>
         <string>/var/www/site</string>
     </dict>

--- a/tests/kimaki-launchd-start.sh
+++ b/tests/kimaki-launchd-start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# tests/kimaki-launchd-start.sh — verifies the managed launchd entrypoint
+# runs wp-coding-agents preflight hooks without touching real processes.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/bin" "$TMP/data/kimaki-config"
+
+cat > "$TMP/bin/pkill" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" > "$TEST_TMP/pkill.log"
+exit 0
+SH
+chmod +x "$TMP/bin/pkill"
+
+cat > "$TMP/data/kimaki-config/post-upgrade.sh" <<'SH'
+#!/bin/sh
+printf 'post-upgrade\n' > "$TEST_TMP/post-upgrade.log"
+exit 17
+SH
+chmod +x "$TMP/data/kimaki-config/post-upgrade.sh"
+
+cat > "$TMP/bin/kimaki" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" > "$TEST_TMP/kimaki.log"
+SH
+chmod +x "$TMP/bin/kimaki"
+
+TEST_TMP="$TMP" \
+PATH="$TMP/bin:/usr/bin:/bin" \
+KIMAKI_DATA_DIR="$TMP/data" \
+  "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" "$TMP/bin/kimaki" --data-dir "$TMP/data" --auto-restart
+
+if ! grep -q -- '-TERM -f opencode-ai/bin/.*serve' "$TMP/pkill.log"; then
+  echo "FAIL: launchd-start did not reap stale opencode serve processes"
+  cat "$TMP/pkill.log" 2>/dev/null || true
+  exit 1
+fi
+
+if ! grep -q '^post-upgrade$' "$TMP/post-upgrade.log"; then
+  echo "FAIL: launchd-start did not run post-upgrade.sh"
+  exit 1
+fi
+
+if ! grep -q -- "--data-dir $TMP/data --auto-restart" "$TMP/kimaki.log"; then
+  echo "FAIL: launchd-start did not exec kimaki with original arguments"
+  cat "$TMP/kimaki.log" 2>/dev/null || true
+  exit 1
+fi
+
+echo "PASS: tests/kimaki-launchd-start.sh"


### PR DESCRIPTION
## Summary
- Add a wp-coding-agents-owned launchd entrypoint for managed Kimaki so macOS gets the same stale `opencode serve` cleanup and post-upgrade preflight as systemd.
- Sync the launchd wrapper into durable `kimaki-config` during install/upgrade and render launchd plists through it.
- Tighten the managed Kimaki live rig to fail when OpenCode serve processes exist outside managed Kimaki ancestry.

## Tests
- `tests/bridge-render.sh`
- `tests/kimaki-launchd-start.sh`
- `bash tests/kimaki-managed-plugin-rig.sh`
- `node tests/effective-prompt/run.mjs`
- `bash tests/post-upgrade-restore.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the launchd wrapper, bridge integration, rig assertion, and targeted test coverage; Chris directed the repository boundary and wp-coding-agents-only fix.