### PR TITLE
Fix Kimaki Data Machine command context

### DIFF
--- a/bridges/_dispatch.sh
+++ b/bridges/_dispatch.sh
@@ -310,7 +310,7 @@ _smart_update_systemd_unit() {
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would update $unit_file"
     echo -e "${BLUE}[dry-run]${NC} Diff:"
-    diff -u "$unit_file" <(echo "$new_unit") 2>/dev/null | head -30 | sed 's/^/    /' || true
+    diff -u "$unit_file" <(echo "$new_unit") 2>/dev/null | _redact_secret_diff | head -30 | sed 's/^/    /' || true
     echo -e "${BLUE}[dry-run]${NC} Would run: systemctl daemon-reload"
     return 0
   fi
@@ -319,11 +319,34 @@ _smart_update_systemd_unit() {
   echo "$new_unit" > "$unit_file"
   log "  Updated $unit_file (backup: ${unit_file}.backup.$TIMESTAMP)"
   log "  Diff:"
-  diff -u "${unit_file}.backup.$TIMESTAMP" "$unit_file" 2>/dev/null | head -30 | sed 's/^/    /' || true
+  diff -u "${unit_file}.backup.$TIMESTAMP" "$unit_file" 2>/dev/null | _redact_secret_diff | head -30 | sed 's/^/    /' || true
   systemctl daemon-reload
   log "  systemctl daemon-reload complete"
   log "  NOTE: $label NOT restarted — run the restart command in the summary when ready"
   UPDATED_ITEMS+=("$label (daemon-reloaded, not restarted)")
+}
+
+_redact_secret_diff() {
+  awk '
+    /Environment=.*TOKEN=/ {
+      sub(/=.*/, "=<redacted>")
+      print
+      redact_next_string = 0
+      next
+    }
+    /<key>.*TOKEN/ {
+      print
+      redact_next_string = 1
+      next
+    }
+    redact_next_string && /<string>.*<\/string>/ {
+      sub(/<string>.*<\/string>/, "<string><redacted></string>")
+      print
+      redact_next_string = 0
+      next
+    }
+    { print; redact_next_string = 0 }
+  '
 }
 
 # _plist_string_after_key <plist_path> <key>

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -320,11 +320,18 @@ _kimaki_install_systemd() {
   KIMAKI_BIN_DIR=$(dirname "$KIMAKI_BIN")
   NODE_BIN_DIR=$(_resolve_node_bin_dir "$KIMAKI_BIN")
   PATH_VALUE=$(_compose_path_value "$KIMAKI_BIN_DIR" "$NODE_BIN_DIR" /usr/local/bin /usr/bin /bin)
+  local DATAMACHINE_WP_CMD
+  DATAMACHINE_WP_CMD=$(_kimaki_datamachine_wp_cmd)
 
   local ENV_BLOCK="Environment=HOME=$SERVICE_HOME
 Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
-Environment=DATAMACHINE_SITE_PATH=$SITE_PATH"
+Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
+Environment=DATAMACHINE_WP_CMD=$DATAMACHINE_WP_CMD"
+  if [ -n "${AGENT_SLUG:-}" ]; then
+    ENV_BLOCK="$ENV_BLOCK
+Environment=DATAMACHINE_AGENT_SLUG=$AGENT_SLUG"
+  fi
   if [ -n "$KIMAKI_BOT_TOKEN" ]; then
     ENV_BLOCK="$ENV_BLOCK
 Environment=KIMAKI_BOT_TOKEN=$KIMAKI_BOT_TOKEN"
@@ -581,7 +588,12 @@ bridge_update_systemd() {
   local TEMPLATE_ENV="Environment=HOME=$SERVICE_HOME
 Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
-Environment=DATAMACHINE_SITE_PATH=$SITE_PATH"
+Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
+Environment=DATAMACHINE_WP_CMD=$(_kimaki_datamachine_wp_cmd)"
+  if [ -n "${AGENT_SLUG:-}" ]; then
+    TEMPLATE_ENV="$TEMPLATE_ENV
+Environment=DATAMACHINE_AGENT_SLUG=$AGENT_SLUG"
+  fi
 
   local MERGED_ENV
   MERGED_ENV=$(_merge_systemd_env_lines "$CURRENT_ENV" "$TEMPLATE_ENV")
@@ -626,7 +638,7 @@ bridge_update_launchd() {
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would update $plist"
     echo -e "${BLUE}[dry-run]${NC} Diff:"
-    diff -u "$plist" <(echo "$new_plist") 2>/dev/null | head -30 | sed 's/^/    /' || true
+    diff -u "$plist" <(echo "$new_plist") 2>/dev/null | _redact_secret_diff | head -30 | sed 's/^/    /' || true
     return 0
   fi
 
@@ -634,7 +646,7 @@ bridge_update_launchd() {
   echo "$new_plist" > "$plist"
   log "  Updated $plist (backup: ${plist}.backup.$TIMESTAMP)"
   log "  Diff:"
-  diff -u "${plist}.backup.$TIMESTAMP" "$plist" 2>/dev/null | head -30 | sed 's/^/    /' || true
+  diff -u "${plist}.backup.$TIMESTAMP" "$plist" 2>/dev/null | _redact_secret_diff | head -30 | sed 's/^/    /' || true
   log "  NOTE: com.wp.kimaki NOT restarted — run the restart command in the summary when ready"
   UPDATED_ITEMS+=("com.wp.kimaki.plist (not restarted)")
 }
@@ -690,6 +702,8 @@ bridge_render_launchd() {
   skill_filter_plist_args="$(_kimaki_skill_filter_args_plist)"
   local launchd_start
   launchd_start="${KIMAKI_DATA_DIR}/kimaki-config/launchd-start.sh"
+  local datamachine_wp_cmd
+  datamachine_wp_cmd=$(_kimaki_datamachine_wp_cmd)
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -724,13 +738,26 @@ $skill_filter_plist_args
         <key>KIMAKI_CONFIG_DIR</key>
         <string>${KIMAKI_DATA_DIR}/kimaki-config</string>
         <key>DATAMACHINE_SITE_PATH</key>
-        <string>$SITE_PATH</string>$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
+        <string>$SITE_PATH</string>
+        <key>DATAMACHINE_WP_CMD</key>
+        <string>$datamachine_wp_cmd</string>$(if [ -n "${AGENT_SLUG:-}" ]; then echo "
+        <key>DATAMACHINE_AGENT_SLUG</key>
+        <string>$AGENT_SLUG</string>"; fi)$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
         <key>KIMAKI_BOT_TOKEN</key>
         <string>$KIMAKI_BOT_TOKEN</string>"; fi)
     </dict>
 </dict>
 </plist>
 EOF
+}
+
+_kimaki_datamachine_wp_cmd() {
+  if [ "${IS_STUDIO:-false}" = true ]; then
+    printf '%s\n' "studio wp"
+    return 0
+  fi
+
+  printf '%s\n' "${WP_CMD:-wp}"
 }
 
 _kimaki_skill_filter_mode() {

--- a/bridges/kimaki/plugins/dm-agent-sync.ts
+++ b/bridges/kimaki/plugins/dm-agent-sync.ts
@@ -35,12 +35,13 @@ interface InjectableFile {
 const dmAgentSync: Plugin = async ({ $ }) => {
   return {
     config: async (input) => {
-      const wpAvailable = await $`command -v wp`.quiet().nothrow();
-      if (wpAvailable.exitCode !== 0) {
+      const wpCli = await resolveWpCli($);
+      if (!wpCli) {
         return;
       }
 
       const sitePath = getSitePath();
+      const agentSlug = getAgentSlug(input);
 
       // Refresh composable files before the session reads them.
       // DM SectionRegistry callbacks render live state (configured sources,
@@ -49,9 +50,7 @@ const dmAgentSync: Plugin = async ({ $ }) => {
       // edits, or other external processes would leave AGENTS.md stale.
       // Running compose here guarantees the file matches live state at the
       // moment OpenCode loads the session prompt.
-      const composeResult = sitePath
-        ? await $`wp --path=${sitePath} datamachine memory compose --allow-root`.quiet().nothrow()
-        : await $`wp datamachine memory compose --allow-root`.quiet().nothrow();
+      const composeResult = await runDatamachineCommand($, wpCli, sitePath, agentSlug, "compose");
       if (composeResult.exitCode !== 0) {
         // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
         console.warn(`[dm-agent-sync] memory compose failed (exit ${composeResult.exitCode}): ${await shellOutputText(composeResult)}`);
@@ -64,10 +63,42 @@ const dmAgentSync: Plugin = async ({ $ }) => {
       // files so it stays in sync with the registry. If DM is too old to
       // provide the command, or it returns nothing usable, leave whatever
       // static list opencode.json already has untouched (graceful no-op).
-      await syncInstructions(input, sitePath, $);
+      await syncInstructions(input, sitePath, $, wpCli, agentSlug);
     },
   };
 };
+
+type WpCli = string;
+
+async function resolveWpCli($: any): Promise<WpCli | null> {
+  const configured = process.env.DATAMACHINE_WP_CMD || process.env.WP_CMD || "";
+  if (configured) {
+    return configured;
+  }
+
+  const wpAvailable = await $`command -v wp`.quiet().nothrow();
+  if (wpAvailable.exitCode === 0) {
+    return "wp";
+  }
+
+  return null;
+}
+
+async function runDatamachineCommand($: any, wpCli: WpCli, sitePath: string, agentSlug: string, command: "compose" | "injectable-files"): Promise<any> {
+  const args = ["datamachine", "memory", command];
+  if (command === "injectable-files") {
+    args.push("--format=json");
+  }
+  if (agentSlug) {
+    args.push(`--agent=${agentSlug}`);
+  }
+  if (sitePath) {
+    args.push(`--path=${sitePath}`);
+  }
+  args.push("--allow-root");
+
+  return $`sh -lc ${[wpCli, ...args.map(shellQuote)].join(" ")}`.quiet().nothrow();
+}
 
 /**
  * Replace config.instructions with the absolute paths Data Machine reports as
@@ -79,10 +110,16 @@ async function syncInstructions(
   input: { instructions?: string[] },
   sitePath: string,
   $: any,
+  wpCli: WpCli,
+  agentSlug: string,
 ): Promise<void> {
-  const result = sitePath
-    ? await $`wp --path=${sitePath} datamachine memory injectable-files --format=json --allow-root`.quiet().nothrow()
-    : await $`wp datamachine memory injectable-files --format=json --allow-root`.quiet().nothrow();
+  if (!agentSlug) {
+    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+    console.warn("[dm-agent-sync] agent slug unavailable; leaving instructions unchanged");
+    return;
+  }
+
+  const result = await runDatamachineCommand($, wpCli, sitePath, agentSlug, "injectable-files");
 
   if (result.exitCode !== 0) {
     // DM predates the command, or the call failed — keep the existing list.
@@ -118,6 +155,27 @@ async function syncInstructions(
 
 function getSitePath(): string {
   return process.env.DATAMACHINE_SITE_PATH || process.env.SITE_PATH || process.env.PWD || "";
+}
+
+function getAgentSlug(input: { instructions?: string[] }): string {
+  const envSlug = process.env.DATAMACHINE_AGENT_SLUG || process.env.AGENT_SLUG || process.env.DATAMACHINE_AGENT || "";
+  if (envSlug) {
+    return envSlug;
+  }
+
+  const instructions = Array.isArray(input.instructions) ? input.instructions : [];
+  for (const instruction of instructions) {
+    const match = instruction.match(/(?:^|\/)agents\/([^/]+)\//);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return "";
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 async function shellOutputText(output: any): Promise<string> {

--- a/scripts/kimaki-managed-plugin-rig.mjs
+++ b/scripts/kimaki-managed-plugin-rig.mjs
@@ -162,6 +162,13 @@ async function recordLiveDriftEvidence() {
 
   const expectedSkillMode = fs.existsSync(path.join(repoKimakiDir, 'skills-enable-list.txt')) ? 'enable' : 'disable'
   const skillListName = expectedSkillMode === 'enable' ? 'skills-enable-list.txt' : 'skills-disable-list.txt'
+  const liveFreshnessFiles = [
+    path.join(livePluginsDir, 'dm-context-filter.ts'),
+    path.join(livePluginsDir, 'dm-agent-sync.ts'),
+    path.join(liveConfigDir, 'post-upgrade.sh'),
+    path.join(liveConfigDir, skillListName),
+    liveLaunchdPlist,
+  ].filter(Boolean)
   live.expected_skill_mode = expectedSkillMode
   live.expected_skills = skillNames(path.join(repoKimakiDir, skillListName))
   live.expected_managed_args = managedArgsFor(liveKimakiDataDir, path.join(repoKimakiDir, skillListName), expectedSkillMode)
@@ -225,6 +232,7 @@ async function recordLiveDriftEvidence() {
     liveConfigDir,
     livePluginsDir,
     liveLaunchdPlist,
+    liveFreshnessFiles,
     expectedSkillMode,
     skillListName,
   })
@@ -236,7 +244,7 @@ async function recordLiveDriftEvidence() {
   }
 }
 
-async function recordLiveRuntimeEvidence({ live, liveSiteDir, liveKimakiDataDir, liveConfigDir, livePluginsDir, liveLaunchdPlist, expectedSkillMode, skillListName }) {
+async function recordLiveRuntimeEvidence({ live, liveSiteDir, liveKimakiDataDir, liveConfigDir, livePluginsDir, liveLaunchdPlist, liveFreshnessFiles, expectedSkillMode, skillListName }) {
   const processes = listProcesses()
   live.processes = {
     kimaki: processes.filter(isKimakiProcess).map(enrichProcess),
@@ -283,6 +291,15 @@ async function recordLiveRuntimeEvidence({ live, liveSiteDir, liveKimakiDataDir,
     class: 'stale OpenCode server',
     liveSiteDir,
   })
+
+  const freshness = managedRuntimeFreshness(opencodeFromManagedKimaki, liveFreshnessFiles)
+  live.runtime_freshness = freshness
+  liveCheck(freshness.fresh, 'active OpenCode serve process started after managed Kimaki config files', live, {
+    class: 'stale OpenCode server',
+    newestManagedConfig: freshness.newestManagedConfig,
+    staleProcesses: freshness.staleProcesses,
+  })
+
   const staleOpenCodeServers = live.processes.opencode_serve.filter((processInfo) => !hasAncestor(processInfo, managedKimakiProcesses, processes))
   live.stale_opencode_serve = staleOpenCodeServers
   liveCheck(staleOpenCodeServers.length === 0, 'no stale OpenCode serve processes outside managed Kimaki ancestry', live, {
@@ -673,7 +690,40 @@ function isOpencodeServeProcess(processInfo) {
 }
 
 function enrichProcess(processInfo) {
-  return { ...processInfo, cwd: processCwd(processInfo.pid) }
+  return { ...processInfo, cwd: processCwd(processInfo.pid), started_at: processStartedAt(processInfo.pid) }
+}
+
+function managedRuntimeFreshness(opencodeProcesses, freshnessFiles) {
+  const newestManagedConfig = newestFileMtime(freshnessFiles)
+  const staleProcesses = opencodeProcesses
+    .filter((processInfo) => !processInfo.started_at || (newestManagedConfig?.mtimeMs && Date.parse(processInfo.started_at) < newestManagedConfig.mtimeMs))
+    .map((processInfo) => ({
+      pid: processInfo.pid,
+      started_at: processInfo.started_at,
+      command: processInfo.command,
+      cwd: processInfo.cwd,
+    }))
+
+  return {
+    fresh: !!newestManagedConfig && opencodeProcesses.length > 0 && staleProcesses.length === 0,
+    newestManagedConfig,
+    staleProcesses,
+  }
+}
+
+function newestFileMtime(files) {
+  let newest = null
+  for (const file of files) {
+    if (!file || !fs.existsSync(file)) {
+      continue
+    }
+    const stats = fs.statSync(file)
+    const record = { file, mtimeMs: stats.mtimeMs, mtime: stats.mtime.toISOString() }
+    if (!newest || record.mtimeMs > newest.mtimeMs) {
+      newest = record
+    }
+  }
+  return newest
 }
 
 function hasAncestor(processInfo, ancestorCandidates, processes) {
@@ -701,6 +751,46 @@ function processCwd(pid) {
     const stdout = execFileSync('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
     const line = stdout.split('\n').find((candidate) => candidate.startsWith('n'))
     return line ? line.slice(1) : null
+  } catch {
+    return null
+  }
+}
+
+function processStartedAt(pid) {
+  if (process.platform === 'linux') {
+    return linuxProcessStartedAt(pid)
+  }
+
+  try {
+    const stdout = execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+    const parsed = Date.parse(stdout)
+    return Number.isNaN(parsed) ? null : new Date(parsed).toISOString()
+  } catch {
+    return null
+  }
+}
+
+function linuxProcessStartedAt(pid) {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8')
+    const parts = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)
+    const startTicks = Number(parts[19])
+    const clockTicks = Number(execFileSync('getconf', ['CLK_TCK'], { encoding: 'utf8' }).trim()) || 100
+    const bootTime = linuxBootTimeMs()
+    if (!bootTime || !Number.isFinite(startTicks)) {
+      return null
+    }
+    return new Date(bootTime + (startTicks / clockTicks) * 1000).toISOString()
+  } catch {
+    return null
+  }
+}
+
+function linuxBootTimeMs() {
+  try {
+    const stat = fs.readFileSync('/proc/stat', 'utf8')
+    const match = stat.match(/^btime\s+(\d+)$/m)
+    return match ? Number(match[1]) * 1000 : null
   } catch {
     return null
   }

--- a/tests/__snapshots__/bridges/kimaki-launchd
+++ b/tests/__snapshots__/bridges/kimaki-launchd
@@ -33,6 +33,10 @@
         <string>/home/chubes/.kimaki/kimaki-config</string>
         <key>DATAMACHINE_SITE_PATH</key>
         <string>/var/www/site</string>
+        <key>DATAMACHINE_WP_CMD</key>
+        <string>wp</string>
+        <key>DATAMACHINE_AGENT_SLUG</key>
+        <string>intelligence-chubes4</string>
     </dict>
 </dict>
 </plist>

--- a/tests/__snapshots__/bridges/kimaki-systemd
+++ b/tests/__snapshots__/bridges/kimaki-systemd
@@ -10,6 +10,8 @@ Environment=HOME=/home/chubes
 Environment=PATH=/usr/bin:/usr/local/bin:/bin
 Environment=KIMAKI_DATA_DIR=/home/chubes/.kimaki
 Environment=DATAMACHINE_SITE_PATH=/var/www/site
+Environment=DATAMACHINE_WP_CMD=wp
+Environment=DATAMACHINE_AGENT_SLUG=intelligence-chubes4
 # Reap stray opencode-serve children left behind by the previous kimaki
 # process before starting a fresh one. Each kimaki session spawns its own
 # opencode-serve worker; if kimaki exits uncleanly (crash, OOM, manual

--- a/tests/bridge-render.sh
+++ b/tests/bridge-render.sh
@@ -54,6 +54,9 @@ export LOCAL_MODE=false
 export DRY_RUN=false
 export INSTALL_CHAT=true
 export RUN_AS_ROOT=false
+export IS_STUDIO=false
+export WP_CMD="wp"
+export AGENT_SLUG="intelligence-chubes4"
 
 # kimaki
 export KIMAKI_DATA_DIR="$SERVICE_HOME/.kimaki"
@@ -81,6 +84,12 @@ export OPENCODE_MODEL=""
 # ---------------------------------------------------------------------------
 source "$SCRIPT_DIR/bridges/_dispatch.sh"
 
+REDACTED_DIFF=$(printf '%s\n' ' Environment=KIMAKI_BOT_TOKEN=secret-token' '         <key>KIMAKI_BOT_TOKEN</key>' '         <string>secret-token</string>' | _redact_secret_diff)
+if echo "$REDACTED_DIFF" | grep -q 'secret-token'; then
+  echo "FAIL: bridge diff redaction leaked a token"
+  exit 1
+fi
+
 kimaki_env_block() {
   local kimaki_bin_dir node_bin_dir path_value
   kimaki_bin_dir=$(dirname "$KIMAKI_BIN")
@@ -89,7 +98,9 @@ kimaki_env_block() {
   local out="Environment=HOME=$SERVICE_HOME
 Environment=PATH=$path_value
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
-Environment=DATAMACHINE_SITE_PATH=$SITE_PATH"
+Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
+Environment=DATAMACHINE_WP_CMD=$WP_CMD
+Environment=DATAMACHINE_AGENT_SLUG=$AGENT_SLUG"
   if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then
     out="$out
 Environment=KIMAKI_BOT_TOKEN=$KIMAKI_BOT_TOKEN"

--- a/tests/dm-agent-sync.mjs
+++ b/tests/dm-agent-sync.mjs
@@ -49,9 +49,33 @@ async function runConfig(config, responses) {
   return warnings
 }
 
+async function withEnv(env, callback) {
+  const previous = {}
+  for (const key of Object.keys(env)) {
+    previous[key] = process.env[key]
+    if (env[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = env[key]
+    }
+  }
+
+  try {
+    return await callback()
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
 const commonResponses = [
   [/^command -v wp$/, output("/usr/local/bin/wp")],
-  [/^wp --path=\/tmp\/datamachine-site datamachine memory compose/, output("composed")],
+  [/^sh -lc wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
 ]
 
 {
@@ -99,10 +123,23 @@ const commonResponses = [
   const config = {}
   const warnings = await runConfig(config, [
     [/^command -v wp$/, output("/usr/local/bin/wp")],
-    [/^wp --path=\/tmp\/datamachine-site datamachine memory compose/, output("", 1, "db down")],
+    [/^sh -lc wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("", 1, "db down")],
   ])
   assert.ok(warnings.some((line) => line.includes("memory compose failed")))
   assert.equal(config.agent, undefined)
 }
+
+await withEnv({ DATAMACHINE_WP_CMD: "custom-wp", DATAMACHINE_AGENT_SLUG: "intelligence-chubes4" }, async () => {
+  const config = {}
+  const warnings = await runConfig(config, [
+    [/^sh -lc custom-wp 'datamachine' 'memory' 'compose' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
+    [/^sh -lc custom-wp 'datamachine' 'memory' 'injectable-files' '--format=json' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output(JSON.stringify([
+      { path: "/tmp/datamachine-site/AGENTS.md" },
+      { path: "/tmp/datamachine-site/MEMORY.md" },
+    ]))],
+  ])
+  assert.ok(warnings.some((line) => line.includes("recomposed Data Machine memory")))
+  assert.deepEqual(config.instructions, ["/tmp/datamachine-site/AGENTS.md", "/tmp/datamachine-site/MEMORY.md"])
+})
 
 console.log("OK: dm-agent-sync recomposes DM memory without mutating OpenCode agents")


### PR DESCRIPTION
## Summary
- Pass the resolved Data Machine WP-CLI command into Kimaki-managed OpenCode sessions via `DATAMACHINE_WP_CMD` instead of hardcoding command discovery in the plugin.
- Scope `dm-agent-sync` memory refreshes with an explicit/derived agent slug so multi-agent sites avoid ambiguous Data Machine memory resolution.
- Redact token values from service/plist upgrade diffs so future dry-runs and applies do not print bridge secrets.
- Extend the live Kimaki managed rig so it fails when active OpenCode serve processes predate managed config/plugin changes, catching stale runtimes that still expose Kimaki’s generic prompt surface.

## Testing
- `node tests/dm-agent-sync.mjs`
- `tests/bridge-render.sh`
- `bash tests/kimaki-managed-plugin-rig.sh`
- `node tests/effective-prompt/run.mjs`
- `git diff --check`

## Live evidence
- `node scripts/kimaki-managed-plugin-rig.mjs --check-live --live-site-dir /Users/chubes/Studio/intelligence-chubes4 --live-kimaki-data-dir /Users/chubes/.kimaki --artifact-dir /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/kimaki-managed-live-proof-pr227`
- Expected current-result: failed with `active OpenCode serve process started after managed Kimaki config files` and `no stale OpenCode serve processes outside managed Kimaki ancestry`.
- Artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/kimaki-managed-live-proof-pr227/live-drift.json`
- The failure shows the managed Kimaki process is present but its active OpenCode serve child started before the managed config/plugin files, so this rig now catches the stale live runtime case that previously made prompt replacement look fixed while sessions still saw Kimaki’s generic prompt guidance.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the Kimaki/Data Machine prompt and memory sync path, drafting the implementation, running local and live verification, and preparing this PR. Chris reviewed the behavior and directed the abstraction change away from hardcoded Studio handling.