### PR TITLE
Fix Kimaki final system prompt stripping

### DIFF
--- a/bridges/kimaki/plugins/dm-context-filter.ts
+++ b/bridges/kimaki/plugins/dm-context-filter.ts
@@ -116,10 +116,30 @@ function isKimakiSystemPrompt(block: string): boolean {
 }
 
 function replaceKimakiSystemPrompt(block: string): string {
-  if (isKimakiSystemPrompt(block)) {
-    return MANAGED_KIMAKI_SYSTEM_PROMPT;
+  const kimakiStart = kimakiSystemPromptStart(block);
+  if (kimakiStart === -1) {
+    return block;
   }
-  return block;
+
+  const prefix = block.slice(0, kimakiStart).trimEnd();
+  return [prefix, MANAGED_KIMAKI_SYSTEM_PROMPT].filter(Boolean).join("\n\n");
+}
+
+function kimakiSystemPromptStart(block: string): number {
+  const markers = [
+    "The user is reading your messages from inside Discord, via kimaki.dev",
+    "Your current OpenCode session ID is:",
+    "## debugging kimaki issues",
+    "## uploading files to discord",
+  ];
+
+  return markers.reduce((earliest, marker) => {
+    const index = block.indexOf(marker);
+    if (index === -1) {
+      return earliest;
+    }
+    return earliest === -1 ? index : Math.min(earliest, index);
+  }, -1);
 }
 
 export default fleetContextFilter;

--- a/scripts/kimaki-managed-plugin-rig.mjs
+++ b/scripts/kimaki-managed-plugin-rig.mjs
@@ -317,6 +317,11 @@ async function recordLiveRuntimeEvidence({ live, liveSiteDir, liveKimakiDataDir,
   }
   liveCheck(livePromptEvidence.contextFilterExecuted, 'live dm-context-filter transform executes', live, { class: 'plugin not loaded' })
   liveCheck(livePromptEvidence.managedPromptActive, 'live effective prompt uses managed bridge prompt', live, { class: 'plugin match predicate failed' })
+  liveCheck(livePromptEvidence.joinedSystemPrefixPreserved, 'live final system transform preserves non-Kimaki prefix', live, { class: 'plugin overmatched final system block' })
+  liveCheck(livePromptEvidence.joinedSystemStaleOrchestrationLeaks.length === 0, 'live final system transform strips Kimaki promptAsync system field', live, {
+    class: 'plugin match predicate failed',
+    leaks: livePromptEvidence.joinedSystemStaleOrchestrationLeaks,
+  })
   liveCheck(livePromptEvidence.filteredStaleOrchestrationLeaks.length === 0, 'live effective prompt has no non-allowlisted Kimaki prompt surface', live, {
     class: 'plugin match predicate failed',
     leaks: livePromptEvidence.filteredStaleOrchestrationLeaks,
@@ -348,8 +353,10 @@ async function renderLivePromptEvidence({ liveConfigDir, livePluginsDir }) {
       filteredPath: fs.existsSync(filteredPath) ? filteredPath : null,
       rawStaleOrchestrationLeaks: [],
       filteredStaleOrchestrationLeaks: [{ line: 0, text: error instanceof Error ? error.message : String(error) }],
+      joinedSystemStaleOrchestrationLeaks: [{ line: 0, text: error instanceof Error ? error.message : String(error) }],
       contextFilterExecuted: false,
       managedPromptActive: false,
+      joinedSystemPrefixPreserved: false,
       summary: { ...summary, error: error instanceof Error ? error.message : String(error) },
     }
   }
@@ -413,6 +420,8 @@ async function runCycle({ name, simulatePackageWipe }) {
   assert(promptEvidence.rawStaleOrchestrationLeaks.length > 0, `${name}: raw Kimaki prompt contains stale orchestration sections`, cycle)
   assert(promptEvidence.filteredStaleOrchestrationLeaks.length === 0, `${name}: filtered prompt removes stale orchestration sections`, cycle)
   assert(promptEvidence.contextFilterExecuted, `${name}: dm-context-filter hook executed`, cycle)
+  assert(promptEvidence.joinedSystemPrefixPreserved, `${name}: final system transform preserves non-Kimaki prefix`, cycle)
+  assert(promptEvidence.joinedSystemStaleOrchestrationLeaks.length === 0, `${name}: final system transform strips Kimaki promptAsync system field`, cycle)
   assert(promptEvidence.systemAndMessageTransformsAgree, `${name}: system and message transforms agree`, cycle)
   assert(promptEvidence.agentSyncLoaded, `${name}: dm-agent-sync module loads`, cycle)
 }
@@ -491,6 +500,10 @@ async function renderPromptWithPlugin({ name, kimakiDistDir, pluginsDir, rawPath
   const systemOutput = { system: [raw] }
   await systemTransform({}, systemOutput)
   const systemFiltered = systemOutput.system.join('\n')
+  const joinedSystemPrefix = '## Sentinel Joined System Prefix\n\nThis block represents composed Data Machine AGENTS guidance.'
+  const joinedSystemOutput = { system: [`${joinedSystemPrefix}\n\n${raw}`] }
+  await systemTransform({}, joinedSystemOutput)
+  const joinedSystemFiltered = joinedSystemOutput.system.join('\n')
 
   const messageTransform = contextPlugin['experimental.chat.messages.transform']
   if (typeof messageTransform !== 'function') {
@@ -511,6 +524,7 @@ async function renderPromptWithPlugin({ name, kimakiDistDir, pluginsDir, rawPath
   const agentSyncPlugin = await agentSyncModule.default({ $: fakeShell })
   const rawStaleOrchestrationLeaks = findStaleOrchestrationLeaks(raw)
   const filteredStaleOrchestrationLeaks = findStaleOrchestrationLeaks(filtered)
+  const joinedSystemStaleOrchestrationLeaks = findStaleOrchestrationLeaks(joinedSystemFiltered)
 
   mkdirp(path.join(artifactRoot, 'prompts'))
   fs.writeFileSync(rawPath, normalizeHome(raw), 'utf8')
@@ -523,8 +537,10 @@ async function renderPromptWithPlugin({ name, kimakiDistDir, pluginsDir, rawPath
     filteredIncludesTunnel: filtered.includes('## running dev servers with tunnel access'),
     rawStaleOrchestrationLeaks,
     filteredStaleOrchestrationLeaks,
+    joinedSystemStaleOrchestrationLeaks,
     contextFilterExecuted: systemOutput.system[0] !== raw && filtered !== raw,
     managedPromptActive: filtered.includes('## Kimaki Discord Bridge') && filtered.includes('## Managed Coding Runtime'),
+    joinedSystemPrefixPreserved: joinedSystemFiltered.includes(joinedSystemPrefix) && joinedSystemFiltered.includes('## Kimaki Discord Bridge'),
     systemAndMessageTransformsAgree: systemFiltered === filtered,
     agentSyncLoaded: !!agentSyncPlugin && typeof agentSyncPlugin === 'object',
     summary: {
@@ -535,6 +551,7 @@ async function renderPromptWithPlugin({ name, kimakiDistDir, pluginsDir, rawPath
       stripped_chars: raw.length - filtered.length,
       raw_stale_orchestration_leaks: rawStaleOrchestrationLeaks.length,
       filtered_stale_orchestration_leaks: filteredStaleOrchestrationLeaks.length,
+      joined_system_stale_orchestration_leaks: joinedSystemStaleOrchestrationLeaks.length,
     },
   }
 }

--- a/tests/dm-agent-sync.mjs
+++ b/tests/dm-agent-sync.mjs
@@ -5,6 +5,9 @@ import dmAgentSync from "../bridges/kimaki/plugins/dm-agent-sync.ts"
 
 const sitePath = "/tmp/datamachine-site"
 process.env.DATAMACHINE_SITE_PATH = sitePath
+delete process.env.DATAMACHINE_WP_CMD
+delete process.env.WP_CMD
+delete process.env.DATAMACHINE_AGENT_SLUG
 
 function output(stdout = "", exitCode = 0, stderr = "") {
   return {

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -326,6 +326,21 @@ async function runScenario(name, scenario) {
       failures.push(`current filter returned ${transformedBlocks.length} system blocks for a two-block input`)
     }
 
+    const joinedSystemPrefix = "## Sentinel Joined System Prefix\n\nThis block represents composed Data Machine AGENTS guidance."
+    const joinedSystemInput = `${joinedSystemPrefix}\n\n${raw}`
+    const joinedSystemBlocks = await currentFilterSystemBlocks([joinedSystemInput])
+    const joinedSystemOut = joinedSystemBlocks.join("\n")
+    const joinedSystemLeaks = detectLeaks(joinedSystemOut, scenario.triggers, scenario.allowLeakInSection)
+    if (!joinedSystemOut.includes(joinedSystemPrefix)) {
+      failures.push("current filter dropped the non-Kimaki prefix from a joined final system block")
+    }
+    if (!joinedSystemOut.includes("## Kimaki Discord Bridge")) {
+      failures.push("current filter did not insert the managed bridge prompt into a joined final system block")
+    }
+    if (joinedSystemLeaks.length > 0) {
+      failures.push(`current joined final system transform has ${joinedSystemLeaks.length} trigger leaks (expected 0)`)
+    }
+
     const transformedMessageText = await currentFilterMessageText(raw)
     const messageLeaks = detectLeaks(transformedMessageText, scenario.triggers, scenario.allowLeakInSection)
     if (messageLeaks.length > 0) {


### PR DESCRIPTION
## Summary
- Strip Kimaki's generated prompt from OpenCode's final joined LLM system block without dropping the non-Kimaki prefix.
- Add regression coverage for the actual OpenCode shape: composed system prefix plus Kimaki `promptAsync.system` in one block.
- Make the dm-agent-sync test hermetic against live `DATAMACHINE_WP_CMD` environment leakage.

## Testing
- `node tests/effective-prompt/run.mjs`
- `bash tests/kimaki-managed-plugin-rig.sh`
- `node tests/dm-agent-sync.mjs`
- `tests/bridge-render.sh`
- `git diff --check`
- Live: `node scripts/kimaki-managed-plugin-rig.mjs --check-live --live-site-dir /Users/chubes/Studio/intelligence-chubes4 --live-kimaki-data-dir /Users/chubes/.kimaki --artifact-dir /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/kimaki-managed-live-proof-final-system`

## Live evidence
- Applied to `/Users/chubes/.kimaki/kimaki-config/plugins/dm-context-filter.ts` via `./upgrade.sh --wp-path /Users/chubes/Studio/intelligence-chubes4`.
- Restarted Kimaki via launchd.
- Live rig passed with the final joined-system proof.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the latest OpenCode LLM request assembly, implementing the managed plugin fix, adding regression coverage, applying the live update, and running verification.