### PR TITLE
fix: resolve kimaki binary against adopted service identity (#232)

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -273,7 +273,7 @@ _kimaki_install_launchd() {
   if [ "$DRY_RUN" = true ]; then
     KIMAKI_BIN="/opt/homebrew/bin/kimaki"
   else
-    KIMAKI_BIN=$(which kimaki 2>/dev/null || echo "/opt/homebrew/bin/kimaki")
+    KIMAKI_BIN=$(_kimaki_resolve_service_bin "/opt/homebrew/bin/kimaki")
   fi
 
   run_cmd mkdir -p "$KIMAKI_DATA_DIR"
@@ -305,6 +305,126 @@ _kimaki_install_launchd() {
   log "  Logs:   tail -f $KIMAKI_DATA_DIR/kimaki.log"
 }
 
+# _kimaki_resolve_service_bin
+#
+# Resolve the kimaki binary that goes into ExecStart / ProgramArguments using
+# the ADOPTED service identity (SERVICE_USER / SERVICE_HOME), never the
+# invoking shell's $PATH. This is the fix for #232: upgrade.sh runs as root,
+# but adopt_service_identity_from_units() (bridges/_dispatch.sh) may have
+# already re-derived SERVICE_USER=opencode / SERVICE_HOME=/home/opencode from
+# the existing unit. A bare `which kimaki` resolves against root's PATH and
+# leaks /root/.kimaki/bin/kimaki into a unit that runs as opencode and writes
+# HOME=/home/opencode — an internally inconsistent unit whose ExecStart the
+# service user cannot read, crashing the bridge on the next restart.
+#
+# Resolution order (issue option order — prefer a stable, identity-consistent
+# path over the invoking user's private home):
+#   1. A system-prefix binary (/usr/bin, /usr/local/bin, /opt/homebrew/bin):
+#      reachable by any service user, the npm-global symlink target the
+#      installer already prefers (see _kimaki_register_cli_channel, ~line 80).
+#   2. When SERVICE_USER differs from the invoking user, resolve UNDER the
+#      service user: `sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME"
+#      bash -lc 'command -v kimaki'` (mirrors lib/homeboy.sh:40). Guarded for
+#      sudo availability / non-zero exit.
+#   3. $SERVICE_HOME/.kimaki/bin/kimaki if that file exists (the canonical
+#      per-user install layout, derived from the adopted home — never /root).
+#   4. /usr/bin/kimaki as a last-resort stable default.
+#
+# Args: $1 = fallback system-prefix default (e.g. /usr/bin/kimaki on Linux,
+#            /opt/homebrew/bin/kimaki on macOS).
+_kimaki_resolve_service_bin() {
+  local default_bin="${1:-/usr/bin/kimaki}"
+  local candidate
+
+  # 1. Stable system-prefix binary — reachable by any service user. The list
+  #    is overridable (space-separated) only so tests can point it at a temp
+  #    prefix and exercise the service-user / SERVICE_HOME fallback paths
+  #    deterministically; production always uses the real system prefixes.
+  local system_bins="${KIMAKI_SYSTEM_PREFIX_BINS:-/usr/bin/kimaki /usr/local/bin/kimaki /opt/homebrew/bin/kimaki}"
+  for candidate in $system_bins; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  # 2. Resolve under the adopted service user when it differs from the
+  #    invoking user (the root-upgrade-against-opencode-unit case).
+  local invoking_user running_as_root=false
+  invoking_user="$(id -un 2>/dev/null || echo "")"
+  if [ "${WP_CODING_AGENTS_TEST_ASSUME_ROOT:-false}" = true ] || [ "$(id -u)" -eq 0 ]; then
+    running_as_root=true
+  fi
+  if [ "${LOCAL_MODE:-false}" != true ] \
+    && [ -n "${SERVICE_USER:-}" ] \
+    && [ "$SERVICE_USER" != "$invoking_user" ] \
+    && [ -n "${SERVICE_HOME:-}" ] \
+    && [ "$running_as_root" = true ] \
+    && command -v sudo >/dev/null 2>&1; then
+    candidate="$(sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" bash -lc 'command -v kimaki' 2>/dev/null || true)"
+    if [ -n "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+
+  # 3. Canonical per-user install layout under the ADOPTED home (not /root).
+  if [ -n "${SERVICE_HOME:-}" ] && [ -f "$SERVICE_HOME/.kimaki/bin/kimaki" ]; then
+    printf '%s\n' "$SERVICE_HOME/.kimaki/bin/kimaki"
+    return 0
+  fi
+
+  # 4. Last-resort stable default.
+  printf '%s\n' "$default_bin"
+}
+
+# _kimaki_assert_bin_identity <kimaki_bin> <path_value>
+#
+# Cheap guard requested by #232: after resolving KIMAKI_BIN / PATH_VALUE,
+# assert that the binary and any `.kimaki/bin` PATH segment live under the
+# adopted $SERVICE_HOME OR a system prefix. If either references a DIFFERENT
+# user's home, warn loudly rather than silently writing a mismatched unit.
+# Never fatal — the unit is still written, but the operator sees the warning
+# in the upgrade output and can intervene before the next restart.
+_kimaki_assert_bin_identity() {
+  local kimaki_bin="$1" path_value="$2"
+  local home="${SERVICE_HOME:-}"
+
+  _kimaki_path_under_allowed_home() {
+    local path="$1"
+    case "$path" in
+      /usr/bin/*|/usr/local/bin/*|/opt/homebrew/bin/*) return 0 ;;
+    esac
+    if [ -n "$home" ]; then
+      case "$path" in
+        "$home"/*) return 0 ;;
+      esac
+    fi
+    return 1
+  }
+
+  if ! _kimaki_path_under_allowed_home "$kimaki_bin"; then
+    warn "  kimaki binary '$kimaki_bin' is NOT under SERVICE_HOME ($home) or a system prefix"
+    warn "  the rendered unit runs as User=${SERVICE_USER:-?} and may not be able to read it (see #232)"
+  fi
+
+  # Inspect every PATH segment that points at a per-user .kimaki/bin: it must
+  # belong to the adopted home, not another user's (e.g. /root/.kimaki/bin).
+  local seg
+  local IFS=:
+  for seg in $path_value; do
+    case "$seg" in
+      */.kimaki/bin)
+        if ! _kimaki_path_under_allowed_home "$seg"; then
+          warn "  PATH segment '$seg' references a different user's home than SERVICE_HOME ($home) (see #232)"
+        fi
+        ;;
+    esac
+  done
+
+  unset -f _kimaki_path_under_allowed_home
+}
+
 _kimaki_install_systemd() {
   KIMAKI_CONFIG_DIR="/opt/kimaki-config"
   run_cmd cp -r "$SCRIPT_DIR/bridges/kimaki" "$KIMAKI_CONFIG_DIR"
@@ -313,13 +433,14 @@ _kimaki_install_systemd() {
   if [ "$DRY_RUN" = true ]; then
     KIMAKI_BIN="/usr/bin/kimaki"
   else
-    KIMAKI_BIN=$(which kimaki 2>/dev/null || echo "/usr/bin/kimaki")
+    KIMAKI_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
   fi
 
   local KIMAKI_BIN_DIR NODE_BIN_DIR PATH_VALUE
   KIMAKI_BIN_DIR=$(dirname "$KIMAKI_BIN")
   NODE_BIN_DIR=$(_resolve_node_bin_dir "$KIMAKI_BIN")
   PATH_VALUE=$(_compose_path_value "$KIMAKI_BIN_DIR" "$NODE_BIN_DIR" /usr/local/bin /usr/bin /bin)
+  _kimaki_assert_bin_identity "$KIMAKI_BIN" "$PATH_VALUE"
   local DATAMACHINE_WP_CMD
   DATAMACHINE_WP_CMD=$(_kimaki_datamachine_wp_cmd)
 
@@ -574,12 +695,13 @@ bridge_update_systemd() {
   CURRENT_ENV=$(grep '^Environment=' "$UNIT_FILE" || true)
 
   local KIMAKI_BIN
-  KIMAKI_BIN=$(which kimaki 2>/dev/null || echo "/usr/bin/kimaki")
+  KIMAKI_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
   local KIMAKI_CONFIG_DIR="/opt/kimaki-config"
   local KIMAKI_BIN_DIR NODE_BIN_DIR PATH_VALUE
   KIMAKI_BIN_DIR=$(dirname "$KIMAKI_BIN")
   NODE_BIN_DIR=$(_resolve_node_bin_dir "$KIMAKI_BIN")
   PATH_VALUE=$(_compose_path_value "$KIMAKI_BIN_DIR" "$NODE_BIN_DIR" /usr/local/bin /usr/bin /bin)
+  _kimaki_assert_bin_identity "$KIMAKI_BIN" "$PATH_VALUE"
   CURRENT_ENV=$(_ensure_systemd_path_contains "$CURRENT_ENV" "$KIMAKI_BIN_DIR")
   if [ -n "$NODE_BIN_DIR" ]; then
     CURRENT_ENV=$(_ensure_systemd_path_contains "$CURRENT_ENV" "$NODE_BIN_DIR")
@@ -612,7 +734,7 @@ bridge_update_launchd() {
   [ -f "$plist" ] || { warn "  $plist does not exist — skipping"; return 0; }
 
   local KIMAKI_BIN
-  KIMAKI_BIN=$(which kimaki 2>/dev/null || echo "/opt/homebrew/bin/kimaki")
+  KIMAKI_BIN=$(_kimaki_resolve_service_bin "/opt/homebrew/bin/kimaki")
 
   local previous_token="${KIMAKI_BOT_TOKEN:-}"
   local token_was_set=false

--- a/tests/service-identity-adoption.sh
+++ b/tests/service-identity-adoption.sh
@@ -174,6 +174,89 @@ assert "rendered unit keeps UMask=0002"        "$(echo "$RENDERED" | grep -q '^U
 assert "pkill scoped to adopted user"          "$(echo "$RENDERED" | grep -q 'pkill -TERM -u opencode'; echo $?)"
 
 # ---------------------------------------------------------------------------
+# Issue #232: KIMAKI_BIN / PATH must follow the ADOPTED service identity, not
+# the invoking shell. Reproduces the production trap: upgrade runs as root,
+# adoption flips SERVICE_USER to opencode, but `which kimaki` would resolve
+# /root/.kimaki/bin/kimaki — an ExecStart the opencode service user can't read.
+echo "==> #232: binary resolution follows adopted identity (root invoker + opencode unit)"
+
+# Adopt opencode from the unit (root defaults -> opencode), exactly as above.
+SERVICE_USER="root"
+SERVICE_HOME="/root"
+KIMAKI_DATA_DIR="/root/.kimaki"
+RUN_AS_ROOT=true
+adopt_service_identity_from_units
+
+# Sandbox so the resolver's system-prefix probe and SERVICE_HOME fallback are
+# deterministic and offline (no real /usr/bin/kimaki, no sudo). SERVICE_HOME
+# is redirected into the temp dir so the per-user fallback is writable.
+BIN232="$TMP/bin232"
+ADOPTED_HOME="$TMP/home-opencode"
+mkdir -p "$BIN232" "$ADOPTED_HOME/.kimaki/bin"
+SERVICE_HOME="$ADOPTED_HOME"
+KIMAKI_DATA_DIR="$ADOPTED_HOME/.kimaki"
+# Per-user install layout under the ADOPTED (non-root) home.
+printf '#!/bin/sh\n' > "$ADOPTED_HOME/.kimaki/bin/kimaki"
+chmod +x "$ADOPTED_HOME/.kimaki/bin/kimaki"
+
+# No system-prefix binary exists in this sandbox (yet).
+export KIMAKI_SYSTEM_PREFIX_BINS="$BIN232/usr-bin-kimaki $BIN232/usr-local-kimaki"
+# Force the "invoking user != service user, running as root" branch. Build a
+# clean PATH containing only the coreutils the test needs — crucially WITHOUT
+# `sudo` and WITHOUT `kimaki`, so resolver step 2 (sudo probe) is skipped and
+# resolution falls through to the SERVICE_HOME per-user binary, deterministic
+# and offline on any machine.
+CLEANBIN="$TMP/cleanbin"
+mkdir -p "$CLEANBIN"
+for tool in bash mkdir rm chmod grep cat dirname id printf env; do
+  tool_path="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$tool_path" ] && ln -sf "$tool_path" "$CLEANBIN/$tool"
+done
+export WP_CODING_AGENTS_TEST_ASSUME_ROOT=true
+LOCAL_MODE=false
+PATH_SAVE="$PATH"
+export PATH="$CLEANBIN"
+
+RESOLVED_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
+assert "resolved bin is under adopted SERVICE_HOME" \
+  "$([ "$RESOLVED_BIN" = "$ADOPTED_HOME/.kimaki/bin/kimaki" ]; echo $?)"
+assert "resolved bin is NOT under /root" \
+  "$(case "$RESOLVED_BIN" in /root/*) echo 1 ;; *) echo 0 ;; esac)"
+
+# A real system-prefix binary wins over the per-user home (issue option 1).
+printf '#!/bin/sh\n' > "$BIN232/usr-bin-kimaki"
+chmod +x "$BIN232/usr-bin-kimaki"
+RESOLVED_SYS=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
+assert "system-prefix binary preferred over per-user home" \
+  "$([ "$RESOLVED_SYS" = "$BIN232/usr-bin-kimaki" ]; echo $?)"
+
+export PATH="$PATH_SAVE"
+unset KIMAKI_SYSTEM_PREFIX_BINS WP_CODING_AGENTS_TEST_ASSUME_ROOT
+
+# Guard: _kimaki_assert_bin_identity warns when the binary / PATH segment
+# references a different user's home than the adopted SERVICE_HOME.
+echo "==> #232: identity guard warns on a /root binary under an opencode unit"
+SERVICE_USER="opencode"
+SERVICE_HOME="/home/opencode"
+GUARD_BAD=$(_kimaki_assert_bin_identity \
+  "/root/.kimaki/bin/kimaki" \
+  "/root/.kimaki/bin:/home/opencode/.kimaki/bin:/usr/bin:/bin" 2>&1)
+assert "guard warns on /root ExecStart binary" \
+  "$(echo "$GUARD_BAD" | grep -q 'NOT under SERVICE_HOME'; echo $?)"
+assert "guard warns on /root PATH segment" \
+  "$(echo "$GUARD_BAD" | grep -q "PATH segment '/root/.kimaki/bin'"; echo $?)"
+
+GUARD_OK=$(_kimaki_assert_bin_identity \
+  "/home/opencode/.kimaki/bin/kimaki" \
+  "/home/opencode/.kimaki/bin:/usr/bin:/bin" 2>&1)
+assert "guard silent on consistent opencode identity" \
+  "$([ -z "$GUARD_OK" ]; echo $?)"
+
+GUARD_SYS=$(_kimaki_assert_bin_identity "/usr/bin/kimaki" "/usr/bin:/bin" 2>&1)
+assert "guard silent on system-prefix binary" \
+  "$([ -z "$GUARD_SYS" ]; echo $?)"
+
+# ---------------------------------------------------------------------------
 echo ""
 if [ "$FAIL" -gt 0 ]; then
   echo "FAIL: $FAIL assertion(s):$fail_list"


### PR DESCRIPTION
## Root cause

`bridges/kimaki.sh` resolved the kimaki binary with `which kimaki` against the **invoking shell's `$PATH`** in two places — `_kimaki_install_systemd()` and `bridge_update_systemd()`. On a VPS upgrade, `upgrade.sh` runs as **root**, but `adopt_service_identity_from_units()` (`bridges/_dispatch.sh:255`) may have already re-derived `SERVICE_USER=opencode` / `SERVICE_HOME=/home/opencode` / `KIMAKI_DATA_DIR=/home/opencode/.kimaki` from the existing unit.

`HOME` / `KIMAKI_DATA_DIR` followed the adopted identity, but `KIMAKI_BIN` / `PATH` followed the invoking root identity — an internal split that only manifests when invoking-user != service-user (the normal VPS upgrade path). The written unit's `ExecStart=/root/.kimaki/bin/kimaki` is unreadable by the `opencode` service user, so the **next** `systemctl restart kimaki` would take the chat bridge down.

## Fix

New `_kimaki_resolve_service_bin()` resolves from one consistent identity, in issue option order:

1. A **system-prefix** binary (`/usr/bin`, `/usr/local/bin`, `/opt/homebrew/bin`) — reachable by any service user (the npm-global symlink the installer already prefers).
2. Else, when `SERVICE_USER` differs from the invoking user and we're root, resolve **under the service user**: `sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" bash -lc 'command -v kimaki'` (mirrors `lib/homeboy.sh:40`), guarded for sudo availability / failure.
3. Else `$SERVICE_HOME/.kimaki/bin/kimaki` (canonical per-user layout under the **adopted** home, never `/root`).
4. Else `/usr/bin/kimaki`.

New `_kimaki_assert_bin_identity()` guard `warn`s loudly if `KIMAKI_BIN` or any `.kimaki/bin` PATH segment references a home other than the adopted `SERVICE_HOME` (or a system prefix) — no more silently writing a mismatched unit. Both systemd paths and both launchd paths now use the resolver.

## Before / after — adopted-opencode-as-root rendered unit

```diff
-Environment=PATH=/root/.kimaki/bin:/home/opencode/.kimaki/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/home/opencode/.kimaki/bin:/usr/local/bin:/usr/bin:/bin
-ExecStart=/root/.kimaki/bin/kimaki --data-dir /home/opencode/.kimaki ...
+ExecStart=/home/opencode/.kimaki/bin/kimaki --data-dir /home/opencode/.kimaki ...
```

(`Environment=DATAMACHINE_WP_CMD=wp` from #230 is preserved.)

## Files changed

- `bridges/kimaki.sh` — `_kimaki_resolve_service_bin()` + `_kimaki_assert_bin_identity()`; wired into `_kimaki_install_systemd`, `bridge_update_systemd`, `_kimaki_install_launchd`, `bridge_update_launchd`.
- `tests/service-identity-adoption.sh` — 7 new assertions for the root-invoker + adopted-opencode scenario.

## Tests run

- `bash tests/service-identity-adoption.sh` → **OK: all 22 assertions passed** (incl. 7 new #232 assertions: binary resolves under `SERVICE_HOME` not `/root`, system-prefix wins, guard fires on the trap, guard silent on consistent identity).
- `bash tests/path-helpers.sh` → **OK: 11/11**.
- `bash tests/bridge-render.sh` → the `kimaki-launchd` snapshot drifts, but **this drift is pre-existing on clean `main`** (verified via `git stash`): it's caused by this host having `node` at `/usr/bin/node` where the committed snapshot was generated without node on PATH. **Not introduced by this change** — the launchd PATH-composition path is untouched by the resolver. All other snapshots pass.
- Static render check under the adopted-opencode-as-root scenario confirms `ExecStart` and `PATH` resolve under `SERVICE_HOME`, never `/root`, and the guard stays silent.

Closes #232