### PR TITLE
feat: write DATAMACHINE_COMPOSE_AGENTS_MD constant to wp-config during setup/upgrade

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -24,6 +24,33 @@ install_data_machine() {
   elif [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} $WP_CMD config set DATAMACHINE_WORKSPACE_PATH $DM_WORKSPACE_DIR --type=constant"
   fi
+
+  set_compose_agents_md_constant
+}
+
+# Write the DATAMACHINE_COMPOSE_AGENTS_MD gate to wp-config.php.
+#
+# This boolean constant turns ON core-owned AGENTS.md composition in Data
+# Machine (see data-machine#2640). wp-coding-agents is the rightful writer
+# because its presence is the signal that an external coding agent lives here —
+# installs without one stay default-OFF and emit zero AGENTS.md noise.
+#
+# Mirrors the DATAMACHINE_WORKSPACE_PATH block above: idempotent grep-guard,
+# respects DRY_RUN / IS_STUDIO / wp-config.php existence. Written as a raw
+# boolean (true) via --raw so the define is `define( ..., true )`, not the
+# string "true". Safe to (re-)run on both setup and upgrade; harmless even if
+# core does not yet read the constant.
+set_compose_agents_md_constant() {
+  if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/wp-config.php" ] && [ "$IS_STUDIO" = false ]; then
+    if ! grep -q 'DATAMACHINE_COMPOSE_AGENTS_MD' "$SITE_PATH/wp-config.php"; then
+      wp_cmd config set DATAMACHINE_COMPOSE_AGENTS_MD true --raw --type=constant
+      log "Set DATAMACHINE_COMPOSE_AGENTS_MD to true"
+    else
+      log "DATAMACHINE_COMPOSE_AGENTS_MD already defined in wp-config.php"
+    fi
+  elif [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} $WP_CMD config set DATAMACHINE_COMPOSE_AGENTS_MD true --raw --type=constant"
+  fi
 }
 
 upgrade_data_machine_plugins() {
@@ -35,6 +62,9 @@ upgrade_data_machine_plugins() {
   log "Phase 2: Updating Data Machine plugins to latest tagged releases..."
   update_plugin_to_latest_tag data-machine https://github.com/Extra-Chill/data-machine.git
   update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+
+  # Backfill the AGENTS.md composition gate on existing installs (idempotent).
+  set_compose_agents_md_constant
 }
 
 create_dm_agent() {

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -55,9 +55,12 @@ The user says something like:
    homeboy project show <project-id>
    homeboy project components list <project-id>
    wp option get datamachine_code_homeboy_available --path=/path/to/site
+   wp config get DATAMACHINE_COMPOSE_AGENTS_MD --path=/path/to/site
    wp datamachine memory compose AGENTS.md --path=/path/to/site
    ```
    For WordPress Studio installs, use `studio wp option get datamachine_code_homeboy_available` and `studio wp datamachine memory compose AGENTS.md`. Do not create `homeboy.json` in the site root to "fix" a missing project; that confuses a Homeboy project with a component.
+
+   Setup and upgrade write `define( 'DATAMACHINE_COMPOSE_AGENTS_MD', true )` to wp-config.php (idempotent grep-guard; skipped on Studio and dry-run). This is the gate that turns on core-owned AGENTS.md composition — `wp config get DATAMACHINE_COMPOSE_AGENTS_MD` should return `true` after either run.
 
 Run `./upgrade.sh --help` for scope flags (`--plugins-only`, `--skip-plugins`, `--kimaki-only`, `--skills-only`, `--agents-md-only`, `--repair-opencode-json`, etc.) and the full list of what the script touches and never touches.
 


### PR DESCRIPTION
Closes #234.

## Why

AGENTS.md composition is moving INTO Data Machine core, but **gated default-OFF behind the `DATAMACHINE_COMPOSE_AGENTS_MD` wp-config constant** so installs with no external coding agent emit zero AGENTS.md noise (see data-machine#2640). When the constant is undefined/false, core registers no composable AGENTS.md file and no sections (zero footprint); when `true`, the whole reflected section tree composes.

wp-coding-agents is the rightful writer of that gate: its presence is the signal that an external coding agent lives here.

## What changed

`lib/data-machine.sh` — new `set_compose_agents_md_constant()` helper that **mirrors the existing `DATAMACHINE_WORKSPACE_PATH` block exactly**:

- Idempotent grep-guard — only writes the define if `DATAMACHINE_COMPOSE_AGENTS_MD` is not already present in `wp-config.php`.
- Respects `DRY_RUN`, `IS_STUDIO`, and `wp-config.php` existence (no-op when missing or on Studio).
- Written as a **raw boolean** via `wp config set DATAMACHINE_COMPOSE_AGENTS_MD true --raw --type=constant`, producing `define( 'DATAMACHINE_COMPOSE_AGENTS_MD', true )` — not the string `"true"`.

Wired into **both** flows:

- `install_data_machine()` (setup) — sibling call right after the workspace-path block.
- `upgrade_data_machine_plugins()` (upgrade) — backfills the constant on existing installs on next upgrade.

`skills/upgrade-wp-coding-agents/SKILL.md` — adds the constant to the verify block (`wp config get DATAMACHINE_COMPOSE_AGENTS_MD`) and a note that setup/upgrade write it.

## Teardown

No site-level teardown/uninstall entrypoint exists in this repo (only per-bridge channel cleanup in `lib/cli-channel.sh`), so this is scoped to setup/upgrade only. If a de-provision path is added later, it should `wp config delete DATAMACHINE_COMPOSE_AGENTS_MD`.

## Verification

- `bash -n` clean on `lib/data-machine.sh`, `setup.sh`, `upgrade.sh`.
- Traced the function in isolation (stubbed `wp_cmd`/`log`):
  - DRY_RUN=true → prints the intended `wp config set ... --raw --type=constant`, executes nothing.
  - live + constant absent → executes the `--raw` write.
  - live + constant already present → grep-guard skips (idempotent re-run).
  - IS_STUDIO=true → no-op.
  - wp-config.php missing → no-op.
- Ran `tests/homeboy-components.sh`, `tests/homeboy-project-id.sh`, `tests/detect-site-domain.sh` (all exercise `lib/data-machine.sh`) — all pass, confirming clean sourcing.

## Constraints

- Coordinates with data-machine#2640 — the constant is inert until core reads it, but writing it early is harmless (core ignores an unknown constant). Safe to land independently.
- No CHANGELOG.md / version-string edits (homeboy owns both).

Part of #2613 (Extra-Chill/data-machine) AGENTS.md dynamic-CLI fleet.