### PR TITLE
fix: pin writable HOME for CLI dispatch so scheduled kimaki sends survive WP-cron (#228)

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -90,12 +90,31 @@ _kimaki_register_cli_channel() {
     cmd="$(_kimaki_find_native_binary)"
   fi
 
+  # Stamp the spawned kimaki's HOME + data-dir into the channel block so the
+  # CLI transport pins them at dispatch time instead of inheriting the caller's
+  # env. The transport is shelled from PHP-FPM / WP-cron (running as www-data,
+  # HOME=/var/www which is root-owned and unwritable), so an inherited HOME
+  # makes kimaki die with `EACCES mkdir /var/www/.kimaki`. This is the
+  # dispatch-config twin of the systemd unit's Environment=HOME/KIMAKI_DATA_DIR
+  # (see _kimaki_install_systemd). Derive from the already-resolved adopted
+  # service identity (SERVICE_HOME / KIMAKI_DATA_DIR), never a hardcoded path,
+  # so a RUN_AS_ROOT install pins /root and a non-root install pins the service
+  # user's home. See #228.
+  local service_home="${SERVICE_HOME:-}"
+  local data_dir="${KIMAKI_DATA_DIR:-}"
+  local env_json=""
+  if [ -n "$service_home" ]; then
+    [ -n "$data_dir" ] || data_dir="$service_home/.kimaki"
+    env_json="{\"HOME\":\"${service_home}\",\"KIMAKI_DATA_DIR\":\"${data_dir}\"}"
+  fi
+
   cli_channel_register \
     "kimaki" \
     "$cmd" \
     '["send","--channel","{recipient}","--prompt","{message}"]' \
     "true" \
-    "600"
+    "600" \
+    "$env_json"
 }
 
 _kimaki_is_legacy_adapter_file() {

--- a/lib/cli-channel.sh
+++ b/lib/cli-channel.sh
@@ -40,13 +40,23 @@
 #   cli_channel_mu_plugin_path                 — echo resolved file path
 #   cli_channel_ensure_mu_plugin_file          — create stub if missing
 #   cli_channel_register <name> <command> \
-#       <args_json> [detach] [timeout]         — upsert a bridge's block
+#       <args_json> [detach] [timeout] \
+#       [env_json]                             — upsert a bridge's block
 #   cli_channel_unregister <name>              — remove a bridge's block
 #
 # `args_json` is a JSON array literal (e.g. '["send","--channel","{recipient}",
 # "--prompt","{message}"]'). Substitution tokens supported by the transport:
 #   {recipient}  — the bridge-specific target identifier (see per-bridge docs)
 #   {message}    — the message body to deliver
+#
+# `env_json` (optional) is a JSON object literal of environment variables to
+# stamp onto the spawned CLI's process env (e.g. '{"HOME":"/home/opencode"}').
+# The transport overlays these on top of the inherited env, so a bridge can
+# pin a writable HOME / data-dir regardless of the caller's environment. This
+# is the seam that fixes scheduled (WP-cron / PHP-FPM) dispatch, where the
+# caller HOME (www-data → /var/www) is not writable by the spawned CLI. Vendor-
+# specific paths live here in installer-written config, never in the generic
+# transport (layer purity).
 #
 # Honors DRY_RUN (logs intent, makes no changes).
 
@@ -123,12 +133,17 @@ cli_channel_ensure_mu_plugin_file() {
  *       'args'    => [ 'send', '--channel', '{recipient}', '--prompt', '{message}' ],
  *       'detach'  => true,
  *       'timeout' => 600,
+ *       'env'     => [ 'HOME' => '/home/<service-user>' ], // optional
  *   ];
  *   // END bridge:<name>
  *
  * Substitution tokens are resolved by the CLI transport at dispatch time:
  *   {recipient} — bridge-specific target identifier (see bridge docs).
  *   {message}   — the message body delivered by agents/dispatch-message.
+ *
+ * The optional 'env' map is overlaid onto the spawned CLI's process env by the
+ * transport, so a bridge can pin a writable HOME / data-dir independent of the
+ * caller (e.g. WP-cron running as www-data with HOME=/var/www, unwritable).
  *
  * New filter contract: wp_coding_agents_cli_channels.
  * Legacy migration filter: datamachine_code_cli_channels.
@@ -167,16 +182,20 @@ PHP
 # Block render
 # ---------------------------------------------------------------------------
 
-# _cli_channel_render_block <name> <command> <args_json> <detach> <timeout>
+# _cli_channel_render_block <name> <command> <args_json> <detach> <timeout> [env_json]
 #
 # Print the marker-delimited PHP block for a single bridge, including
 # surrounding BEGIN/END markers, indented to match the scaffold's filter
 # body. Strings are escaped for PHP single-quoted literals (backslash, single
 # quote); args_json is emitted verbatim because it is a literal JSON array
 # the caller has already constructed.
+#
+# When env_json is a non-empty JSON object, an 'env' => [ ... ] line is added
+# after 'timeout'. Omitting it (empty arg) keeps the block byte-identical to
+# the historical four-key form, so existing channels without env are unchanged.
 _cli_channel_render_block() {
-  local name="$1" command="$2" args_json="$3" detach="$4" timeout="$5"
-  local esc_name esc_command esc_args
+  local name="$1" command="$2" args_json="$3" detach="$4" timeout="$5" env_json="${6:-}"
+  local esc_name esc_command esc_args env_line=""
   esc_name=$(_cli_channel_php_escape "$name")
   esc_command=$(_cli_channel_php_escape "$command")
   # Convert JSON array to PHP array literal: [...] is valid in both. Single
@@ -185,13 +204,20 @@ _cli_channel_render_block() {
   # PHP strings via sed (no embedded quotes expected in real argv tokens).
   esc_args=$(_cli_channel_json_to_php_array "$args_json")
 
+  if [ -n "$env_json" ] && [ "$env_json" != "{}" ]; then
+    local esc_env
+    esc_env=$(_cli_channel_json_object_to_php_array "$env_json")
+    env_line="
+        'env'     => ${esc_env},"
+  fi
+
   cat <<PHP
     // BEGIN bridge:${esc_name}
     \$channels['${esc_name}'] = [
         'command' => '${esc_command}',
         'args'    => ${esc_args},
         'detach'  => ${detach},
-        'timeout' => ${timeout},
+        'timeout' => ${timeout},${env_line}
     ];
     // END bridge:${esc_name}
 PHP
@@ -238,11 +264,42 @@ PY
   printf '%s' "$out"
 }
 
+# _cli_channel_json_object_to_php_array <json_object_literal>
+#
+# Convert a JSON object of string=>string pairs like {"HOME":"/home/opencode"}
+# into a PHP associative-array literal [ 'HOME' => '/home/opencode' ]. Uses
+# python3 when available (handles escaping properly); falls back to a naive
+# transform for the simple case (no embedded quotes), which is all we ship —
+# env values here are filesystem paths in installer-controlled config.
+_cli_channel_json_object_to_php_array() {
+  local json="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$json" <<'PY'
+import json, sys
+obj = json.loads(sys.argv[1])
+def esc(s):
+    return str(s).replace("\\", "\\\\").replace("'", "\\'")
+parts = ", ".join("'" + esc(k) + "' => '" + esc(v) + "'" for k, v in obj.items())
+print("[ " + parts + " ]")
+PY
+    return $?
+  fi
+  # Fallback: naive substitution. Works for plain ASCII keys/paths with no
+  # embedded single quotes — the only shape any bridge emits.
+  local out="$json"
+  out="${out//\":\"/\' => \'}"
+  out="${out//\",\"/\', \'}"
+  out="${out//\"/\'}"
+  out="${out//\{/[ }"
+  out="${out//\}/ ]}"
+  printf '%s' "$out"
+}
+
 # ---------------------------------------------------------------------------
 # Register / unregister
 # ---------------------------------------------------------------------------
 
-# cli_channel_register <name> <command> <args_json> [detach] [timeout]
+# cli_channel_register <name> <command> <args_json> [detach] [timeout] [env_json]
 #
 # Upsert <name>'s block in the mu-plugin file. Idempotent: re-running with the
 # same arguments leaves the file unchanged; re-running with different
@@ -251,10 +308,12 @@ PY
 # Defaults:
 #   detach   — "true"  (CLI bridges dispatch fire-and-forget by default)
 #   timeout  — "600"   (10 minutes; matches DMC's default per #412)
+#   env_json — ""      (no 'env' key emitted; the four-key block is unchanged)
 cli_channel_register() {
   local name="$1" command="$2" args_json="$3"
   local detach="${4:-true}"
   local timeout="${5:-600}"
+  local env_json="${6:-}"
 
   if [ -z "$name" ] || [ -z "$command" ] || [ -z "$args_json" ]; then
     warn "  cli_channel_register: missing required args (name=$name command=$command args=$args_json)"
@@ -270,7 +329,7 @@ cli_channel_register() {
   cli_channel_ensure_mu_plugin_file || return 1
 
   local new_block
-  new_block=$(_cli_channel_render_block "$name" "$command" "$args_json" "$detach" "$timeout")
+  new_block=$(_cli_channel_render_block "$name" "$command" "$args_json" "$detach" "$timeout" "$env_json")
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would register CLI channel '$name' in $file"

--- a/templates/wp-coding-agents-cli-transport.php
+++ b/templates/wp-coding-agents-cli-transport.php
@@ -479,11 +479,36 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 		}
 
 		/**
+		 * Build the child process environment for a dispatched CLI.
+		 *
+		 * The base is the inherited parent env (with PATH special-cased so a
+		 * stripped-down FPM/cron env still resolves binaries), then the
+		 * channel-configured `env` map is overlaid on top — that overlay is
+		 * where a channel pins vendor-specific values such as a writable HOME
+		 * / data-dir (see the CLI-channel registry installer).
+		 *
+		 * Generic HOME guard (defense-in-depth, layer-pure — no vendor names,
+		 * no hardcoded paths): this transport is shelled from PHP-FPM / WP-cron,
+		 * which often run as a web user whose HOME points at a non-writable,
+		 * root-owned directory (e.g. /var/www). Many CLIs create a per-user
+		 * data dir under $HOME at startup and die with EACCES on such a HOME.
+		 * If the resolved env does not carry an explicit, writable HOME (either
+		 * inherited or channel-configured), we UNSET HOME entirely rather than
+		 * pass a poisoned value through — proc_open then leaves HOME to the
+		 * system/account default instead of a guaranteed-unwritable path. The
+		 * correct positive HOME value, when one is required, comes from the
+		 * channel config (installer-written), keeping vendor specifics out of
+		 * this generic layer.
+		 *
 		 * @param array<string, string> $configured Configured env map.
 		 * @return array<string, string>|null
 		 */
 		private static function build_env_map( array $configured ): ?array {
-			if ( empty( $configured ) ) {
+			$home_configured = array_key_exists( 'HOME', $configured );
+
+			// Fast path: no channel config AND the inherited HOME is sane —
+			// nothing to normalize, inherit the full parent env as before.
+			if ( empty( $configured ) && self::inherited_home_is_writable() ) {
 				return null;
 			}
 
@@ -501,7 +526,38 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 				$env[ $key ] = $value;
 			}
 
+			// If HOME wasn't pinned by the channel and the effective HOME is
+			// empty or unwritable, drop it rather than hand the child a
+			// poisoned path. The concrete writable HOME, when needed, is the
+			// channel config's job — not this generic transport's.
+			if ( ! $home_configured && ! self::home_value_is_writable( $env['HOME'] ?? null ) ) {
+				unset( $env['HOME'] );
+			}
+
 			return $env;
+		}
+
+		/**
+		 * Whether the inherited (process) HOME is set and writable by us.
+		 *
+		 * @return bool
+		 */
+		private static function inherited_home_is_writable(): bool {
+			$home = getenv( 'HOME' );
+			return self::home_value_is_writable( is_string( $home ) ? $home : null );
+		}
+
+		/**
+		 * Whether a HOME value is a non-empty, existing, writable directory.
+		 *
+		 * @param string|null $home Candidate HOME path.
+		 * @return bool
+		 */
+		private static function home_value_is_writable( ?string $home ): bool {
+			if ( null === $home || '' === $home ) {
+				return false;
+			}
+			return is_dir( $home ) && is_writable( $home );
 		}
 
 		private static function truncate_output( string $output ): string {

--- a/tests/smoke-cli-transport.php
+++ b/tests/smoke-cli-transport.php
@@ -226,6 +226,24 @@ $wp_coding_agents_test_options = array(
 				'WP_CODING_AGENTS_CONFIGURED_ENV' => 'configured-ok',
 			),
 		),
+		// #228: a channel with no configured HOME must not have a poisoned
+		// (unwritable) inherited HOME leak through to the child.
+		'guard-home'    => array(
+			'command' => $env_bin,
+			'args'    => array(),
+			'detach'  => false,
+			'timeout' => 5,
+		),
+		// #228: a channel that pins a writable HOME keeps it verbatim.
+		'pinned-home'   => array(
+			'command' => $env_bin,
+			'args'    => array(),
+			'detach'  => false,
+			'timeout' => 5,
+			'env'     => array(
+				'HOME' => sys_get_temp_dir(),
+			),
+		),
 	),
 );
 
@@ -271,6 +289,31 @@ $configured = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' =>
 $configured_stdout = is_array( $configured ) ? (string) ( $configured['metadata']['stdout'] ?? '' ) : '';
 $assert( 'configured channel env keeps parent env', str_contains( $configured_stdout, 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' ) );
 $assert( 'configured channel env adds configured env', str_contains( $configured_stdout, 'WP_CODING_AGENTS_CONFIGURED_ENV=configured-ok' ) );
+
+// #228 regression: when the caller's HOME is unwritable (PHP-FPM/WP-cron as
+// www-data with HOME=/var/www) and the channel does not pin HOME, the
+// transport must NOT pass the poisoned HOME through to the child — it drops
+// it so the CLI falls back to a system default instead of dying with EACCES.
+$poisoned_home = sys_get_temp_dir() . '/wpca-unwritable-home-' . getmypid();
+$prev_home     = getenv( 'HOME' );
+// A non-existent directory is, by definition, not a writable HOME.
+putenv( 'HOME=' . $poisoned_home );
+$guarded = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'guard-home', 'recipient' => 'r', 'message' => 'm' ) );
+$guarded_stdout = is_array( $guarded ) ? (string) ( $guarded['metadata']['stdout'] ?? '' ) : '';
+$assert( 'unwritable inherited HOME is not leaked', ! str_contains( $guarded_stdout, 'HOME=' . $poisoned_home ) );
+$assert( 'guarded channel still inherits other parent env', str_contains( $guarded_stdout, 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' ) );
+
+// #228: a channel that pins a writable HOME keeps it even when the inherited
+// HOME is poisoned — this is the kimaki installer's fix path.
+$pinned = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'pinned-home', 'recipient' => 'r', 'message' => 'm' ) );
+$pinned_stdout = is_array( $pinned ) ? (string) ( $pinned['metadata']['stdout'] ?? '' ) : '';
+$assert( 'pinned writable HOME wins over poisoned inherited HOME', str_contains( $pinned_stdout, 'HOME=' . sys_get_temp_dir() ) );
+// Restore HOME so any later code/tests see the original value.
+if ( false === $prev_home ) {
+	putenv( 'HOME' );
+} else {
+	putenv( 'HOME=' . $prev_home );
+}
 
 if ( ! empty( $failures ) ) {
 	echo "\nFAIL: " . count( $failures ) . " assertion(s)\n";


### PR DESCRIPTION
## Summary

The scheduled `EC Agent Progress Ping` Data Machine flow (flow 4) failed on dispatch with:

```
exited with code 64 ... DB Failed to create data directory /var/www/.kimaki: EACCES: permission denied, mkdir '/var/www/.kimaki'
```

…while the **same flow run manually** as the `opencode` user succeeded. The pipeline is fine — the only difference is the **HOME of the process that shells out to kimaki**.

## Root cause — the unit-vs-dispatch asymmetry

There are two paths that spawn kimaki, and only one of them set HOME:

| Path | HOME handling | Result |
|------|---------------|--------|
| **systemd unit** (`kimaki.service`) | ✅ sets `Environment=HOME=$SERVICE_HOME` + `Environment=KIMAKI_DATA_DIR=...` (fixed for the unit in #233/commit aaace07) | works |
| **CLI dispatch config** (`agents/dispatch-message` → CLI transport) | ❌ the installer-written `bridge:kimaki` channel block emitted `command/args/detach/timeout` but **no `env`**, so the generic transport's `build_env_map()` returned `null` and `proc_open` **inherited the caller's env** | broken under cron |

Under the WP-cron heartbeat (`wp cron event run` as **www-data**, whose passwd HOME is `/var/www` — root-owned, `0755`, unwritable), kimaki can't create `$HOME/.kimaki` and exits 64. The interactive `opencode` shell has a writable HOME, which is why manual runs worked. This is the same HOME-reset / config-dir-not-writable class as #93/#198.

## The fix — both halves (durable across upgrades)

**1. Installer (config) — the primary, upgrade-surviving fix**
- `lib/cli-channel.sh`: `cli_channel_register` / `_cli_channel_render_block` gain an **optional** `env_json` arg that renders an `'env' => [ ... ]` line into the channel block. A new `_cli_channel_json_object_to_php_array` helper (python3 + naive fallback, mirroring the existing array converter) converts the JSON object. **Channels with no env render byte-identically to the historical four-key block** — no churn for cc-connect/telegram.
- `bridges/kimaki.sh` → `_kimaki_register_cli_channel`: stamps `HOME` + `KIMAKI_DATA_DIR` into the channel `env`, **derived from the already-resolved adopted service identity** (`SERVICE_HOME` / `KIMAKI_DATA_DIR`) — never a hardcoded `/home/opencode`, so a RUN_AS_ROOT install pins `/root` and a non-root install pins the service user's home. Mirrors exactly what `_kimaki_install_systemd` does for the unit.
- Because every upgrade rewrites the marker block, the env now survives upgrades — this is why the installer half matters, not a one-off edit.

Generated block now looks like:
```php
$channels['kimaki'] = [
    'command' => '/usr/bin/kimaki',
    'args'    => [ 'send', '--channel', '{recipient}', '--prompt', '{message}' ],
    'detach'  => true,
    'timeout' => 600,
    'env'     => [ 'HOME' => '/home/opencode', 'KIMAKI_DATA_DIR' => '/home/opencode/.kimaki' ],
];
```
The transport already overlays `$config['env']` on top of the inherited env (`build_env_map`), so this configured HOME wins → `proc_open` no longer inherits `/var/www`.

**2. Transport (defense-in-depth, layer-pure)**
- `templates/wp-coding-agents-cli-transport.php` → `build_env_map()` no longer blindly passes a poisoned HOME through. If HOME is **not** channel-pinned and the effective value is empty or points at a non-writable directory, HOME is **dropped** so `proc_open` falls back to the system/account default instead of a guaranteed-unwritable path.
- Kept strictly generic: **no vendor names, no hardcoded paths** in the transport. The concrete writable HOME value comes from the channel config (installer-written), preserving layer purity.

## Verification

- `php tests/smoke-cli-transport.php` — 27/27 pass, including 3 new regression assertions:
  - unwritable inherited HOME is **not** leaked to the child,
  - guarded channel still inherits other parent env,
  - a channel-pinned writable HOME wins over a poisoned inherited HOME.
- `tests/cli-channel-perms.sh`, `tests/cli-channel-binary-path.sh`, `tests/cli-transport-install.sh` — all pass (binary-path exercises `_kimaki_register_cli_channel` with no SERVICE_HOME → emits no env → backward-compatible).
- `php -l` clean on the transport + smoke test; `bash -n` clean on `lib/cli-channel.sh` + `bridges/kimaki.sh`.
- Functional render check confirms the generated mu-plugin file is valid PHP and the no-env path is byte-identical to the prior four-key form. Verified the python3-absent fallback produces identical output.

Closes #228

cc <@1493317298151489577>