### PR TITLE
Fix scheduled Kimaki dispatch user mismatch

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -64,9 +64,11 @@ bridge_install() {
 # channel ID (numeric string) the message is delivered to. `message` is the
 # message body.
 #
-# Register the native Kimaki binary. Kimaki 0.13 validates requested agents and
-# falls back to the default/build agent when a requested agent is unavailable,
-# so wp-coding-agents must not rewrite `--agent` itself.
+# Register the native Kimaki binary on local installs. On VPS installs, register
+# a stable dispatch wrapper that sudo-hops to the adopted service user before it
+# execs Kimaki. Kimaki 0.13 validates requested agents and falls back to the
+# default/build agent when a requested agent is unavailable, so wp-coding-agents
+# must not rewrite `--agent` itself.
 #
 # The command we register here is shelled by the Data Machine Code CLI transport
 # from the `agents/dispatch-message` ability, which runs inside PHP-FPM as the
@@ -81,7 +83,9 @@ bridge_install() {
 # npm-global symlink) over any private-home wrapper. See #198 / #93.
 _kimaki_register_cli_channel() {
   local cmd
-  if [ -n "${KIMAKI_BIN:-}" ] \
+  if [ "${LOCAL_MODE:-false}" != true ] && [ -n "${SERVICE_USER:-}" ] && [ "$SERVICE_USER" != "root" ]; then
+    cmd="/usr/local/bin/wp-coding-agents-kimaki-dispatch"
+  elif [ -n "${KIMAKI_BIN:-}" ] \
     && [ -x "$KIMAKI_BIN" ] \
     && ! _kimaki_is_legacy_adapter_file "$KIMAKI_BIN" \
     && _kimaki_path_is_web_traversable "$KIMAKI_BIN"; then
@@ -90,16 +94,11 @@ _kimaki_register_cli_channel() {
     cmd="$(_kimaki_find_native_binary)"
   fi
 
-  # Stamp the spawned kimaki's HOME + data-dir into the channel block so the
-  # CLI transport pins them at dispatch time instead of inheriting the caller's
-  # env. The transport is shelled from PHP-FPM / WP-cron (running as www-data,
-  # HOME=/var/www which is root-owned and unwritable), so an inherited HOME
-  # makes kimaki die with `EACCES mkdir /var/www/.kimaki`. This is the
-  # dispatch-config twin of the systemd unit's Environment=HOME/KIMAKI_DATA_DIR
-  # (see _kimaki_install_systemd). Derive from the already-resolved adopted
-  # service identity (SERVICE_HOME / KIMAKI_DATA_DIR), never a hardcoded path,
-  # so a RUN_AS_ROOT install pins /root and a non-root install pins the service
-  # user's home. See #228.
+  # Stamp the spawned kimaki's HOME + data-dir into the channel block so local
+  # dispatch does not inherit an unwritable caller HOME. VPS dispatch uses the
+  # wrapper installed by _kimaki_install_dispatch_helpers, which sudo-hops to
+  # SERVICE_USER before applying the same HOME/KIMAKI_DATA_DIR values; keeping
+  # them here is harmless defense-in-depth and preserves operator visibility.
   local service_home="${SERVICE_HOME:-}"
   local data_dir="${KIMAKI_DATA_DIR:-}"
   local env_json=""
@@ -235,6 +234,81 @@ _kimaki_sync_bin_helpers() {
 
   _kimaki_remove_legacy_session_helper "$HELPER_DIR"
   _kimaki_remove_legacy_command_shims "$HELPER_DIR"
+  _kimaki_install_dispatch_helpers
+}
+
+_kimaki_install_dispatch_helpers() {
+  if [ "${LOCAL_MODE:-false}" = true ] || [ -z "${SERVICE_USER:-}" ] || [ "$SERVICE_USER" = "root" ]; then
+    return 0
+  fi
+
+  local dispatch_wrapper="/usr/local/bin/wp-coding-agents-kimaki-dispatch"
+  local target_helper="/usr/local/lib/wp-coding-agents/kimaki-dispatch-target"
+  local sudoers_file="/etc/sudoers.d/wp-coding-agents-kimaki-dispatch"
+  local service_home="${SERVICE_HOME:-}"
+  local data_dir="${KIMAKI_DATA_DIR:-}"
+  local kimaki_bin="${KIMAKI_BIN:-}"
+  local path_value="${PATH:-/usr/local/bin:/usr/bin:/bin}"
+
+  [ -n "$service_home" ] || service_home="/home/$SERVICE_USER"
+  [ -n "$data_dir" ] || data_dir="$service_home/.kimaki"
+  if [ -z "$kimaki_bin" ] || [ "$kimaki_bin" = "$dispatch_wrapper" ]; then
+    kimaki_bin="$(_kimaki_find_native_binary)"
+  fi
+
+  local service_home_q data_dir_q kimaki_bin_q path_q target_helper_q service_user_q
+  service_home_q=$(_kimaki_shell_quote "$service_home")
+  data_dir_q=$(_kimaki_shell_quote "$data_dir")
+  kimaki_bin_q=$(_kimaki_shell_quote "$kimaki_bin")
+  path_q=$(_kimaki_shell_quote "$path_value")
+  target_helper_q=$(_kimaki_shell_quote "$target_helper")
+  service_user_q=$(_kimaki_shell_quote "$SERVICE_USER")
+
+  local target_content wrapper_content sudoers_content
+  target_content="#!/bin/sh
+set -eu
+export HOME=$service_home_q
+export KIMAKI_DATA_DIR=$data_dir_q
+export PATH=$path_q
+exec $kimaki_bin_q \"\$@\""
+
+  wrapper_content="#!/bin/sh
+set -eu
+exec sudo -n -H -u $service_user_q $target_helper_q \"\$@\""
+
+  sudoers_content="www-data ALL=($SERVICE_USER) NOPASSWD: $target_helper *"
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would install $target_helper"
+    echo -e "${BLUE}[dry-run]${NC} Would install $dispatch_wrapper"
+    echo -e "${BLUE}[dry-run]${NC} Would install $sudoers_file"
+    return 0
+  fi
+
+  install -d -m 0755 "$(dirname "$target_helper")"
+  printf '%s\n' "$target_content" > "$target_helper"
+  chown root:root "$target_helper"
+  chmod 0755 "$target_helper"
+
+  printf '%s\n' "$wrapper_content" > "$dispatch_wrapper"
+  chown root:root "$dispatch_wrapper"
+  chmod 0755 "$dispatch_wrapper"
+
+  printf '%s\n' "$sudoers_content" > "$sudoers_file"
+  chown root:root "$sudoers_file"
+  chmod 0440 "$sudoers_file"
+  if command -v visudo >/dev/null 2>&1; then
+    visudo -cf "$sudoers_file" >/dev/null
+  fi
+
+  log "  Installed Kimaki dispatch wrapper: $dispatch_wrapper → $SERVICE_USER"
+  UPDATED_ITEMS+=("Kimaki dispatch wrapper")
+}
+
+_kimaki_shell_quote() {
+  local value="$1"
+  value=${value//\'/\'\\\'\'}
+  printf "'%s'" "$value"
 }
 
 _kimaki_remove_legacy_session_helper() {

--- a/tests/cli-channel-binary-path.sh
+++ b/tests/cli-channel-binary-path.sh
@@ -25,13 +25,15 @@
 #      entry (private-home wrapper) in favor of a later reachable one.
 #   3. _kimaki_register_cli_channel ignores a KIMAKI_BIN that is executable but
 #      trapped under a non-traversable home, falling back to the reachable
-#      PATH binary.
-#   4. The registered command is never a path under a non-traversable home.
+#      PATH binary on local installs.
+#   4. A VPS service-user install registers the sudo dispatch wrapper, not the
+#      private-home binary that www-data cannot traverse.
+#   5. The registered command is never under a non-traversable home.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d /tmp/wpca-cli-channel.XXXXXX)"
 trap 'chmod -R u+rwx "$TMP" 2>/dev/null || true; rm -rf "$TMP"' EXIT
 
 # mktemp -d creates the dir at 0700 by design. This test simulates a WEB-
@@ -123,12 +125,12 @@ else
   fail "expected $reachable_dir/kimaki, got '$resolved'"
 fi
 
-# --- 3. register ignores trapped KIMAKI_BIN, falls back to reachable PATH ----
-echo "==> _kimaki_register_cli_channel ignores trapped KIMAKI_BIN"
+# --- 3. local register ignores trapped KIMAKI_BIN, falls back to reachable PATH
+echo "==> _kimaki_register_cli_channel ignores trapped KIMAKI_BIN on local installs"
 
 rm -f "$TMP/cli-channel.args"
 KIMAKI_BIN="$root_trap/.kimaki/bin/kimaki"   # executable but trapped under 0700
-PATH="$reachable_dir:/usr/bin:/bin" _kimaki_register_cli_channel
+LOCAL_MODE=true PATH="$reachable_dir:/usr/bin:/bin" _kimaki_register_cli_channel
 got="$(registered_command)"
 if [ "$got" = "$reachable_dir/kimaki" ]; then
   ok "trapped KIMAKI_BIN ignored; registered reachable $got"
@@ -136,7 +138,20 @@ else
   fail "expected reachable $reachable_dir/kimaki, got '$got'"
 fi
 
-# --- 4. registered command is never under a non-traversable home ------------
+# --- 4. VPS service-user register uses the sudo dispatch wrapper -------------
+echo "==> _kimaki_register_cli_channel uses wrapper for service-user VPS installs"
+
+rm -f "$TMP/cli-channel.args"
+LOCAL_MODE=false SERVICE_USER=opencode SERVICE_HOME="$home_trap" KIMAKI_DATA_DIR="$home_trap/.kimaki" \
+  KIMAKI_BIN="$root_trap/.kimaki/bin/kimaki" PATH="$reachable_dir:/usr/bin:/bin" _kimaki_register_cli_channel
+got_vps="$(registered_command)"
+if [ "$got_vps" = "/usr/local/bin/wp-coding-agents-kimaki-dispatch" ]; then
+  ok "VPS channel registers sudo dispatch wrapper"
+else
+  fail "expected /usr/local/bin/wp-coding-agents-kimaki-dispatch, got '$got_vps'"
+fi
+
+# --- 5. registered command is never under a non-traversable home ------------
 echo "==> registered command is web-traversable"
 
 if _kimaki_path_is_web_traversable "$got"; then
@@ -150,7 +165,7 @@ rm -f "$TMP/cli-channel.args"
 reachable_bin_dir="$TMP/reachable2/bin"
 make_kimaki "$reachable_bin_dir"
 KIMAKI_BIN="$reachable_bin_dir/kimaki"
-PATH="/usr/bin:/bin" _kimaki_register_cli_channel
+LOCAL_MODE=true PATH="/usr/bin:/bin" _kimaki_register_cli_channel
 got2="$(registered_command)"
 if [ "$got2" = "$reachable_bin_dir/kimaki" ]; then
   ok "reachable KIMAKI_BIN still honored (no regression)"


### PR DESCRIPTION
## Summary
- register VPS Kimaki dispatch through a stable sudo wrapper instead of direct private-home binaries
- install root-owned dispatch target and sudoers rule so www-data can dispatch as the adopted service user
- add regression coverage for service-user VPS channel registration

Fixes #240.

## Tests
- ==> register Homeboy Codebox guidance
  ok   guidance mu-plugin parses with php -l
  ok   mu-plugin mode 0644 after fresh write under umask 077
  ok   Homeboy Codebox block present
==> re-register Homeboy Codebox guidance (idempotent)
  ok   file unchanged on re-register
==> invalid public API inputs fail before writing broken PHP
  ok   invalid section id rejected
  ok   invalid priority rejected
  ok   invalid sync availability rejected
==> skip registration when Data Machine core gate is unavailable
  ok   SectionRegistry receives no wp-coding-agents guidance without core AGENTS gate
==> apply datamachine_sections action and inspect SectionRegistry call
  ok   SectionRegistry receives Homeboy Codebox guidance section
==> unregister Homeboy Codebox guidance
  ok   mu-plugin mode 0644 after unregister
  ok   Homeboy Codebox block removed
  ok   post-unregister file parses with php -l

OK: all AGENTS.md guidance assertions passed
==> existing gateway env is reused instead of rotated
[0;32m[wp-coding-agents][0m Reusing existing WP AI Gateway token reference at /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/tmp.ZPlhL8Kpkd/site/.opencode/wp-ai-gateway.env
  ok   existing token preserved
  ok   base URL refreshed
==> dry-run redacts gateway token material
  ok   dry-run does not print existing token
  ok   dry-run does not print fake token
  ok   dry-run leaves env token untouched
==> unit/plist dry-run diffs redact secrets
  ok   systemd-style secret redacted
  ok   plist-style secret redacted
==> Kimaki launchd inherits gateway environment
  ok   launchd includes gateway base URL
  ok   launchd includes gateway key
==> recursive gateway topologies are rejected in wp-coding-agents
  ok   recursive provider rejected
  ok   recursive provider-qualified model rejected
==> opencode.json merge uses OpenCode custom provider shape
[0;32m[wp-coding-agents][0m Merged WP AI Gateway provider into /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/tmp.ZPlhL8Kpkd/site/opencode.json
[0;32m[wp-coding-agents][0m OpenCode env file: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/tmp.ZPlhL8Kpkd/site/.opencode/wp-ai-gateway.env

OK: 11 / 11 assertions passed
==> rendering snapshots
==> diffs
  ok   cc-connect-launchd
  ok   cc-connect-systemd
  ok   kimaki-launchd
  ok   kimaki-systemd
  ok   telegram-bot-launchd
  ok   telegram-bot-systemd
  ok   telegram-serve-launchd
  ok   telegram-serve-systemd

OK: all snapshots match
PASS: tests/carried-claude-code-plugin.sh
==> _kimaki_path_is_web_traversable ancestor checks
  ok   accepts 0755-ancestor path
  ok   rejects 0700-ancestor (/root) path
  ok   rejects 0750-ancestor (/home/opencode) path
==> _kimaki_find_native_binary prefers reachable PATH entry
  ok   skips 0700 wrapper, returns reachable binary
==> _kimaki_register_cli_channel ignores trapped KIMAKI_BIN on local installs
  ok   trapped KIMAKI_BIN ignored; registered reachable /tmp/wpca-cli-channel.7cAiDT/reachable/bin/kimaki
==> _kimaki_register_cli_channel uses wrapper for service-user VPS installs
  ok   VPS channel registers sudo dispatch wrapper
==> registered command is web-traversable
  ok   registered command '/tmp/wpca-cli-channel.7cAiDT/reachable/bin/kimaki' is web-traversable
  ok   reachable KIMAKI_BIN still honored (no regression)

OK: all cli-channel binary-path assertions passed
==> register kimaki (fresh scaffold, umask 077)
  ok   fresh scaffold lands as 0644 under umask 077
==> simulate legacy 0600 file and verify self-heal on next register
  ok   mu-plugin self-healed to 0644 after sibling register
==> unregister opencode-telegram
  ok   mu-plugin mode 0644 after unregister

OK: all cli-channel perms assertions passed
  ok   transport mu-plugin written
  ok   transport mu-plugin matches template
  ok   transport mu-plugin mode 0644
  ok   transport mu-plugin mode 0644
OK: CLI transport install assertions passed
OK: existing-site domain detection scopes Studio WP-CLI to the site path and falls back when empty
==> homeboy present: emit generated CLI command map
  ok   guidance mu-plugin parses with php -l (present)
  ok   homeboy-cli block present
==> inspect generated section via datamachine_sections action
  ok   SectionRegistry receives generated Homeboy CLI map
==> re-sync with homeboy present (idempotent)
  ok   file unchanged on re-sync
==> homeboy absent: complete no-op (section removed, no stub)
  ok   homeboy-cli block removed when homeboy absent
  ok   no absent-homeboy stub emitted
  ok   post-no-op file parses with php -l

OK: all Homeboy CLI command-map assertions passed
OK: Homeboy Codebox canary command construction
OK: Homeboy component attachment prunes stale worktrees and skips metadata-less repos
OK: Homeboy project id resolves local Studio site by base_path
OK: Kimaki native fallback replaces local agent normalization
PASS: tests/kimaki-launchd-start.sh
PASS kimaki managed-plugin rig arg parser self-test
PASS kimaki managed-plugin rig
Artifacts: /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/tmp.vqlGVJMVC8/artifacts
OK: Kimaki managed-plugin rig
PASS: tests/opencode-local-plugin-path.sh
==> legacy wrapper is removed and real binary linked back
  ok   wrapper sentinel removed
  ok   stale .bak file removed
  ok   global opencode runs the real binary
  ok   rerun is idempotent
==> non-wrapper binaries are never touched
  ok   non-wrapper binary untouched
==> repo no longer ships legacy install machinery
  ok   lib/patch-claude-auth.py is gone
  ok   runtimes/opencode.sh has no _install_opencode_wrapper
  ok   runtimes/opencode.sh has no _patch_claude_auth_plugin
  ok   runtimes/opencode.sh does not list opencode-claude-auth as a managed plugin
  ok   lib/repair-opencode-json.py does not append opencode-claude-auth
  ok   upgrade.sh has no reapply_claude_auth_patch
  ok   upgrade.sh wires the removal phase

OK: 12 / 12 assertions passed
==> _compose_path_value
  ok   single dir
  ok   two distinct dirs
  ok   drops duplicate (npm-global case: kimaki and node share dir)
  ok   drops empty entries (no node found)
  ok   preserves first-occurrence order
  ok   all empty
==> _resolve_node_bin_dir
  ok   follows kimaki shim when no node on PATH (nvm case)
  ok   uses command -v when node is on PATH
  ok   empty when no node anywhere
  ok   empty when shim references missing node binary
  ok   no-hint: uses command -v

OK: 11 / 11 assertions passed
PASS: tests/post-upgrade-restore.sh (6 lines run1, 5 lines run3)
OK: repair-opencode-json removes managed agent shells and repairs local plugin paths
==> register opencode (fresh scaffold, umask 077)
  ok   mu-plugin created
  ok   scaffold parses with php -l
  ok   mu-plugin mode 0644 after fresh write under umask 077
  ok   opencode block present
==> re-register opencode with same signature (idempotent)
  ok   file unchanged on re-register
==> simulate legacy 0600 file and verify self-heal on next register
  ok   two-runtime file parses with php -l
  ok   mu-plugin mode self-healed to 0644 after sibling register
  ok   both runtime blocks present
==> re-register opencode with mutated signature
  ok   opencode block updated
  ok   kimaki block preserved across opencode mutation
==> unregister kimaki
  ok   kimaki block removed
  ok   opencode block preserved across kimaki unregister
  ok   post-unregister file parses with php -l
  ok   mu-plugin mode 0644 after unregister
==> apply_filters returns the expected shape
  ok   filter returns surviving opencode signature

OK: all runtime-signature assertions passed
==> adoption: root default + opencode unit -> opencode
[0;32m[wp-coding-agents][0m   Adopting service identity from kimaki.service: User=opencode (script default was root)
  ok   SERVICE_USER adopted from unit
  ok   RUN_AS_ROOT flipped to false
  ok   SERVICE_HOME re-derived
  ok   KIMAKI_DATA_DIR re-derived
==> adoption: no-op when unit matches script default
  ok   matching user unchanged
  ok   matching home unchanged
==> adoption: skipped when SERVICE_USER_FORCED=true
  ok   forced identity not overridden
==> adoption: skipped in LOCAL_MODE
  ok   local mode untouched
==> umask preservation
  ok   UMask carried into env block
  ok   env lines retained alongside UMask
  ok   no UMask -> env block unchanged
==> end-to-end: re-render after adoption keeps User=opencode + UMask
[0;32m[wp-coding-agents][0m   Adopting service identity from kimaki.service: User=opencode (script default was root)
  ok   rendered unit keeps User=opencode
  ok   rendered unit does NOT flip to root
  ok   rendered unit keeps UMask=0002
  ok   pkill scoped to adopted user
==> #232: binary resolution follows adopted identity (root invoker + opencode unit)
[0;32m[wp-coding-agents][0m   Adopting service identity from kimaki.service: User=opencode (script default was root)
  ok   resolved bin is under adopted SERVICE_HOME
  ok   resolved bin is NOT under /root
  ok   system-prefix binary preferred over per-user home
==> #232: identity guard warns on a /root binary under an opencode unit
  ok   guard warns on /root ExecStart binary
  ok   guard warns on /root PATH segment
  ok   guard silent on consistent opencode identity
  ok   guard silent on system-prefix binary

OK: all 22 service-identity adoption assertions passed
wp-codebox-subtree tests passed
=== smoke-cli-transport ===
  [PASS] valid entry normalizes
  [PASS] missing command is rejected
  [PASS] non-string arg is rejected
  [PASS] legacy option channel is present
  [PASS] new option channel is present
  [PASS] legacy filter channel is present
  [PASS] new filter channel is present
  [PASS] new registry wins collisions
  [PASS] message token substituted verbatim
  [PASS] conversation token substituted
  [PASS] claims registered channel
  [PASS] declines unknown channel
  [PASS] preserves prior handler
  [PASS] sync success returns array
  [PASS] sync success captures stdout
  [PASS] sync true succeeds
  [PASS] nonzero exit returns WP_Error
  [PASS] timeout returns WP_Error
  [PASS] execute unknown returns WP_Error
  [PASS] detached returns array
  [PASS] detached early exit returns WP_Error
  [PASS] empty channel env inherits parent env
  [PASS] configured channel env keeps parent env
  [PASS] configured channel env adds configured env
  [PASS] unwritable inherited HOME is not leaked
  [PASS] guarded channel still inherits other parent env
  [PASS] pinned writable HOME wins over poisoned inherited HOME

OK

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause verification, code changes, regression test updates, and local test execution.