### PR TITLE
Fix Kimaki dispatch sudoers for service user

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -276,7 +276,7 @@ exec $kimaki_bin_q \"\$@\""
 set -eu
 exec sudo -n -H -u $service_user_q $target_helper_q \"\$@\""
 
-  sudoers_content="www-data ALL=($SERVICE_USER) NOPASSWD: $target_helper *"
+  sudoers_content=$(_kimaki_dispatch_sudoers_content "$SERVICE_USER" "$target_helper")
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would install $target_helper"
@@ -303,6 +303,27 @@ exec sudo -n -H -u $service_user_q $target_helper_q \"\$@\""
 
   log "  Installed Kimaki dispatch wrapper: $dispatch_wrapper → $SERVICE_USER"
   UPDATED_ITEMS+=("Kimaki dispatch wrapper")
+}
+
+_kimaki_dispatch_sudoers_content() {
+  local service_user="$1"
+  local target_helper="$2"
+  local caller
+  local seen_callers=""
+
+  for caller in www-data "$service_user"; do
+    [ -n "$caller" ] || continue
+    case "
+$seen_callers
+" in
+      *"
+$caller
+"*) continue ;;
+    esac
+    seen_callers="${seen_callers:-}
+$caller"
+    printf '%s ALL=(%s) NOPASSWD: %s *\n' "$caller" "$service_user" "$target_helper"
+  done
 }
 
 _kimaki_shell_quote() {

--- a/tests/service-identity-adoption.sh
+++ b/tests/service-identity-adoption.sh
@@ -221,7 +221,7 @@ RESOLVED_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
 assert "resolved bin is under adopted SERVICE_HOME" \
   "$([ "$RESOLVED_BIN" = "$ADOPTED_HOME/.kimaki/bin/kimaki" ]; echo $?)"
 assert "resolved bin is NOT under /root" \
-  "$(case "$RESOLVED_BIN" in /root/*) echo 1 ;; *) echo 0 ;; esac)"
+  "$([[ "$RESOLVED_BIN" != /root/* ]]; echo $?)"
 
 # A real system-prefix binary wins over the per-user home (issue option 1).
 printf '#!/bin/sh\n' > "$BIN232/usr-bin-kimaki"
@@ -255,6 +255,24 @@ assert "guard silent on consistent opencode identity" \
 GUARD_SYS=$(_kimaki_assert_bin_identity "/usr/bin/kimaki" "/usr/bin:/bin" 2>&1)
 assert "guard silent on system-prefix binary" \
   "$([ -z "$GUARD_SYS" ]; echo $?)"
+
+# Issue #243: the dispatch wrapper can be invoked by WP-cron as www-data or by
+# Kimaki/session-triggered jobs as the adopted service user. Both callers need
+# the narrow same target grant because the wrapper always sudo -u SERVICE_USER.
+echo "==> #243: dispatch sudoers covers cron and service-user callers"
+SUDOERS=$(_kimaki_dispatch_sudoers_content \
+  "opencode" \
+  "/usr/local/lib/wp-coding-agents/kimaki-dispatch-target")
+assert "sudoers grants www-data -> opencode" \
+  "$(echo "$SUDOERS" | grep -q '^www-data ALL=(opencode) NOPASSWD: /usr/local/lib/wp-coding-agents/kimaki-dispatch-target \*$'; echo $?)"
+assert "sudoers grants opencode -> opencode" \
+  "$(echo "$SUDOERS" | grep -q '^opencode ALL=(opencode) NOPASSWD: /usr/local/lib/wp-coding-agents/kimaki-dispatch-target \*$'; echo $?)"
+
+SUDOERS_DEDUPED=$(_kimaki_dispatch_sudoers_content \
+  "www-data" \
+  "/usr/local/lib/wp-coding-agents/kimaki-dispatch-target")
+assert "sudoers dedupes www-data service user" \
+  "$([ "$(echo "$SUDOERS_DEDUPED" | grep -c '^www-data ALL=')" = "1" ]; echo $?)"
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary
- Generate Kimaki dispatch sudoers grants for both `www-data` and the adopted service user.
- Keep the grant scoped to `kimaki-dispatch-target`.
- Add regression coverage for `opencode -> opencode` dispatch and deduping.

## Testing
- `tests/service-identity-adoption.sh`
- `tests/bridge-render.sh`
- `node tests/effective-prompt/run.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosis, code changes, regression test updates, and verification.