### PR TITLE
fix: make upgrade cover the Claude Code runtime + single-agent scoping

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -113,3 +113,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests/homeboy-agents-md.sh
         run: ./tests/homeboy-agents-md.sh
+
+  claude-code-hook-scope:
+    name: Claude Code hook agent scoping
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/claude-code-hook-scope.sh
+        run: ./tests/claude-code-hook-scope.sh

--- a/hooks/dm-agent-sync.sh
+++ b/hooks/dm-agent-sync.sh
@@ -55,6 +55,20 @@ detect_wp_cmd() {
 WP_CMD=$(detect_wp_cmd) || exit 0
 
 # ---------------------------------------------------------------------------
+# Optional single-agent scope (OpenCode parity)
+# ---------------------------------------------------------------------------
+# setup.sh / upgrade.sh write dm-agent-sync.env next to this hook with the
+# install's configured agent slug. When present, the hook injects only that
+# agent's files — exactly like the OpenCode runtime, which loads only the
+# configured agent's instructions. Absent the sidecar, the hook falls back to
+# discovering all active agents (legacy multi-agent behavior).
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$HOOK_DIR/dm-agent-sync.env" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$HOOK_DIR/dm-agent-sync.env"
+fi
+
+# ---------------------------------------------------------------------------
 # Refresh composable files before computing @ includes
 # ---------------------------------------------------------------------------
 # SectionRegistry callbacks can read live state (Intelligence sources, skill
@@ -68,14 +82,19 @@ WP_CMD=$(detect_wp_cmd) || exit 0
 $WP_CMD datamachine memory compose >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
-# Query active agents from Data Machine
+# Resolve which agents to inject
 # ---------------------------------------------------------------------------
+# Single-agent scope (OpenCode parity) when DM_AGENT_SLUG is configured;
+# otherwise discover every active agent from Data Machine.
 
-AGENTS_RAW=$($WP_CMD datamachine agents list --format=json 2>/dev/null) || exit 0
+if [ -n "${DM_AGENT_SLUG:-}" ]; then
+  ACTIVE_SLUGS="$DM_AGENT_SLUG"
+else
+  AGENTS_RAW=$($WP_CMD datamachine agents list --format=json 2>/dev/null) || exit 0
 
-# Extract JSON array. WP-CLI may append summary text (e.g. "Total: 2 agent(s).")
-# on the same line as the closing bracket. Use Python to safely extract the array.
-ACTIVE_SLUGS=$(echo "$AGENTS_RAW" | python3 -c "
+  # Extract JSON array. WP-CLI may append summary text (e.g. "Total: 2 agent(s).")
+  # on the same line as the closing bracket. Use Python to safely extract the array.
+  ACTIVE_SLUGS=$(echo "$AGENTS_RAW" | python3 -c "
 import sys, json, re
 raw = sys.stdin.read()
 # Extract the JSON array — everything from first [ to its matching ]
@@ -92,6 +111,7 @@ for a in data:
     if status == 'active':
         print(a['agent_slug'])
 " 2>/dev/null) || exit 0
+fi
 
 if [ -z "$ACTIVE_SLUGS" ]; then
   exit 0

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -67,12 +67,19 @@ upgrade_data_machine_plugins() {
   set_compose_agents_md_constant
 }
 
+# Derive a Data Machine agent slug from a site domain. Shared by setup
+# (create_dm_agent) and upgrade (claude-code runtime sync) so both compute the
+# same canonical slug: first domain label, lowercased, underscores → hyphens.
+derive_agent_slug() {
+  echo "$1" | sed 's/\..*//' | tr '[:upper:]' '[:lower:]' | tr '_' '-'
+}
+
 create_dm_agent() {
   log "Phase 4.5: Creating Data Machine agent..."
 
   # Derive agent slug from domain
   if [ -z "${AGENT_SLUG:-}" ]; then
-    AGENT_SLUG=$(echo "$SITE_DOMAIN" | sed 's/\..*//' | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    AGENT_SLUG=$(derive_agent_slug "$SITE_DOMAIN")
   fi
 
   if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/wp-config.php" ]; then

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -151,6 +151,9 @@ runtime_install_hooks() {
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would copy dm-agent-sync.sh to $hooks_dir"
+    if [ -n "${AGENT_SLUG:-}" ]; then
+      echo -e "${BLUE}[dry-run]${NC} Would write dm-agent-sync.env (DM_AGENT_SLUG=$AGENT_SLUG)"
+    fi
     echo -e "${BLUE}[dry-run]${NC} Would configure SessionStart hook in $settings_file"
     return
   fi
@@ -159,6 +162,16 @@ runtime_install_hooks() {
   cp "$hook_src" "$hook_dst"
   chmod +x "$hook_dst"
   log "Installed hook: $hook_dst"
+
+  # Persist the configured agent slug so the SessionStart hook scopes its @
+  # includes to just this install's agent — matching the OpenCode runtime,
+  # which loads only the configured agent's files. Without this sidecar the
+  # hook falls back to discovering all active agents.
+  local hook_env="$hooks_dir/dm-agent-sync.env"
+  if [ -n "${AGENT_SLUG:-}" ]; then
+    printf 'DM_AGENT_SLUG=%s\n' "$AGENT_SLUG" > "$hook_env"
+    log "Wrote hook agent scope: $hook_env (DM_AGENT_SLUG=$AGENT_SLUG)"
+  fi
 
   # Merge SessionStart hook, workspace permissions, and disable auto-memory in settings.json.
   # additionalDirectories alone is not enough: the Bash tool is gated by explicit

--- a/tests/claude-code-hook-scope.sh
+++ b/tests/claude-code-hook-scope.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# tests/claude-code-hook-scope.sh — Regression coverage for the Claude Code
+# SessionStart hook's agent scoping (hooks/dm-agent-sync.sh).
+#
+# Two modes:
+#   - dm-agent-sync.env present (DM_AGENT_SLUG set) -> inject ONLY that agent's
+#     files, exactly like the OpenCode runtime (single configured agent). The
+#     `agents list` discovery is skipped entirely.
+#   - no sidecar -> discover every active agent and inject all of their files
+#     (legacy multi-agent behavior).
+#
+# We mock `wp` on PATH so the test never touches a real WordPress install and
+# the agent list / memory paths are deterministic. STUDIO.md is intentionally
+# absent so detect_wp_cmd resolves to `wp --path=...`.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$SCRIPT_DIR/hooks/dm-agent-sync.sh"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Mock `wp` --------------------------------------------------------------
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+cat > "$BIN/wp" <<'WPEOF'
+#!/bin/bash
+# Deterministic Data Machine mock. Recognizes the three calls the hook makes.
+args="$*"
+case "$args" in
+  *"memory compose"*) exit 0 ;;
+  *"agents list"*)
+    echo '[{"agent_slug":"alpha","agent_name":"Alpha"},{"agent_slug":"beta","agent_name":"Beta"}]'
+    echo 'Total: 2 agent(s).'
+    ;;
+  *"memory paths"*)
+    slug=""
+    for a in "$@"; do
+      case "$a" in --agent=*) slug="${a#--agent=}" ;; esac
+    done
+    printf '{"agent_slug":"%s","relative_files":["wp-content/uploads/datamachine-files/agents/%s/SOUL.md","wp-content/uploads/datamachine-files/agents/%s/MEMORY.md"]}\n' "$slug" "$slug" "$slug"
+    ;;
+  *) exit 0 ;;
+esac
+WPEOF
+chmod +x "$BIN/wp"
+export PATH="$BIN:$PATH"
+
+FAILED=0
+pass() { echo "PASS  $1"; }
+fail() { echo "FAIL  $1"; FAILED=1; }
+
+seed_claude_md() {
+  local dir="$1"
+  cat > "$dir/CLAUDE.md" <<'MDEOF'
+# Test Site
+
+## Data Machine Memory
+
+<!-- DM_AGENT_SYNC_START -->
+<!-- DM_AGENT_SYNC_END -->
+MDEOF
+}
+
+# --- Case A: sidecar present -> single-agent scope --------------------------
+SITE_A="$TMP/siteA"
+mkdir -p "$SITE_A/.claude/hooks"
+seed_claude_md "$SITE_A"
+cp "$HOOK" "$SITE_A/.claude/hooks/dm-agent-sync.sh"
+printf 'DM_AGENT_SLUG=alpha\n' > "$SITE_A/.claude/hooks/dm-agent-sync.env"
+
+CLAUDE_PROJECT_DIR="$SITE_A" bash "$SITE_A/.claude/hooks/dm-agent-sync.sh"
+
+if grep -q 'agents/alpha/SOUL.md' "$SITE_A/CLAUDE.md"; then
+  pass "scoped: alpha (configured agent) injected"
+else
+  fail "scoped: alpha (configured agent) injected"
+fi
+if grep -q 'agents/beta/' "$SITE_A/CLAUDE.md"; then
+  fail "scoped: beta (other agent) excluded"
+else
+  pass "scoped: beta (other agent) excluded"
+fi
+
+# --- Case B: no sidecar -> all active agents -------------------------------
+SITE_B="$TMP/siteB"
+mkdir -p "$SITE_B/.claude/hooks"
+seed_claude_md "$SITE_B"
+cp "$HOOK" "$SITE_B/.claude/hooks/dm-agent-sync.sh"
+
+CLAUDE_PROJECT_DIR="$SITE_B" bash "$SITE_B/.claude/hooks/dm-agent-sync.sh"
+
+if grep -q 'agents/alpha/SOUL.md' "$SITE_B/CLAUDE.md" && grep -q 'agents/beta/SOUL.md' "$SITE_B/CLAUDE.md"; then
+  pass "unscoped: all active agents injected (alpha + beta)"
+else
+  fail "unscoped: all active agents injected (alpha + beta)"
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "OK — claude-code hook scope"
+else
+  echo "FAILED — claude-code hook scope"
+  exit 1
+fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -715,6 +715,123 @@ regenerate_agents_md() {
 }
 
 # ============================================================================
+# Phase 5b: Sync Claude Code runtime (SessionStart hook + CLAUDE.md)
+#   Claude Code installs aren't covered by the chat-bridge phases: opencode.json
+#   drift, kimaki plugins, and systemd units don't apply to them. Their managed
+#   surface is the SessionStart hook (.claude/hooks/dm-agent-sync.sh), its
+#   agent-scope sidecar, the settings.json hook registration, and the
+#   template-generated CLAUDE.md. Without this phase those silently rot: a stale
+#   hook keeps exit 0-ing and CLAUDE.md never gets its Data Machine memory
+#   block, so the agent boots with no personality/memory. This mirrors what
+#   setup.sh installs and keeps claude-code a first-class upgrade target
+#   alongside opencode.
+# ============================================================================
+
+# Resolve AGENT_SLUG for the claude-code runtime sync. Leaves AGENT_SLUG empty
+# when no single agent can be confidently resolved — the hook then falls back
+# to discovering all active agents.
+_resolve_claude_code_agent_slug() {
+  # 1. Explicit override (env / --agent-slug) wins.
+  [ -n "${AGENT_SLUG:-}" ] && return 0
+
+  # 2. Existing sidecar from a prior setup/upgrade.
+  local env_file="$SITE_PATH/.claude/hooks/dm-agent-sync.env"
+  if [ -f "$env_file" ]; then
+    AGENT_SLUG=$(sed -n 's/^DM_AGENT_SLUG=//p' "$env_file" | head -1)
+    [ -n "$AGENT_SLUG" ] && return 0
+  fi
+
+  # 3. Derive candidates and validate each against the DM agent list. Only
+  #    adopt a slug when an agent with that name actually exists, so we never
+  #    scope the hook to a non-existent agent. Two candidates, in order:
+  #      a. domain-derived (correct for VPS installs with a real siteurl)
+  #      b. directory-basename-derived (correct for Studio, where siteurl is
+  #         http://localhost:PORT and the agent is named after the site folder)
+  #    In dry-run, surface the first non-empty candidate without hitting the DB.
+  local candidate
+  for candidate in \
+    "$(derive_agent_slug "$SITE_DOMAIN")" \
+    "$(derive_agent_slug "$(basename "$SITE_PATH")")"; do
+    [ -n "$candidate" ] || continue
+    if [ "$DRY_RUN" = true ]; then
+      AGENT_SLUG="$candidate"
+      return 0
+    fi
+    if _dm_agent_slug_exists "$candidate"; then
+      AGENT_SLUG="$candidate"
+      return 0
+    fi
+  done
+}
+
+# Return 0 if a Data Machine agent with the given slug exists.
+_dm_agent_slug_exists() {
+  local slug="$1" json
+  # shellcheck disable=SC2086
+  json=$($WP_CMD datamachine agents list --format=json $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null) || return 1
+  echo "$json" | python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+m = re.search(r'\[.*\]', raw, re.DOTALL)
+if not m:
+    sys.exit(1)
+slug = sys.argv[1]
+data = json.loads(m.group())
+sys.exit(0 if any(a.get('agent_slug') == slug for a in data) else 1)
+" "$slug" >/dev/null 2>&1
+}
+
+sync_claude_code_runtime() {
+  _run_filter_active agents-md || return 0
+  [ "$RUNTIME" = "claude-code" ] || return 0
+
+  if ! declare -F runtime_install_hooks >/dev/null; then
+    return 0
+  fi
+
+  log "Phase 5b: Syncing Claude Code runtime (hook + CLAUDE.md)..."
+
+  _resolve_claude_code_agent_slug
+  if [ -n "${AGENT_SLUG:-}" ]; then
+    log "  Agent scope: $AGENT_SLUG (single-agent, OpenCode parity)"
+  else
+    log "  Agent scope: all active agents (no single agent resolved)"
+  fi
+
+  # Regenerate a degenerate CLAUDE.md. A healthy CLAUDE.md carries the
+  # DM_AGENT_SYNC sentinel block; if it's missing (truncated to @AGENTS.md by an
+  # older/legacy install) or the file is absent, rebuild from the template so
+  # the memory block and Studio context return. Only do this when a slug is
+  # resolved — regenerating with no agent would write an empty memory block.
+  local claude_md="$SITE_PATH/CLAUDE.md"
+  local need_regen=false
+  if [ ! -f "$claude_md" ]; then
+    need_regen=true
+  elif ! grep -q 'DM_AGENT_SYNC_START' "$claude_md"; then
+    need_regen=true
+  fi
+
+  if [ "$need_regen" = true ] && [ -n "${AGENT_SLUG:-}" ]; then
+    runtime_discover_dm_paths
+    if [ "$DRY_RUN" = true ]; then
+      echo -e "${BLUE}[dry-run]${NC} Would (back up and) regenerate CLAUDE.md from template"
+    elif [ -f "$claude_md" ]; then
+      cp "$claude_md" "$claude_md.backup.$TIMESTAMP"
+      rm -f "$claude_md"
+      log "  CLAUDE.md was missing the DM memory block — backed up to $claude_md.backup.$TIMESTAMP"
+      UPDATED_ITEMS+=("CLAUDE.md regenerated")
+    fi
+    runtime_generate_config
+  elif [ "$need_regen" = true ]; then
+    warn "  CLAUDE.md needs regeneration but no agent slug resolved — leaving as-is"
+  fi
+
+  # Recopy the SessionStart hook, refresh the agent-scope sidecar, and ensure
+  # settings.json registers the hook + workspace permissions. Idempotent.
+  runtime_install_hooks
+}
+
+# ============================================================================
 # Phase 6: Smart systemd update (merges host-specific Environment= lines)
 #   Dispatches to the active bridge's bridge_update_systemd hook (and
 #   bridge_update_launchd on macOS). Each bridge regenerates its unit file(s)
@@ -914,6 +1031,7 @@ check_opencode_json_drift
 ai_gateway_configure_opencode
 sync_skills
 regenerate_agents_md
+sync_claude_code_runtime
 update_chat_bridge_systemd
 update_chat_bridge_launchd
 remove_legacy_opencode_wrapper_phase


### PR DESCRIPTION
## Problem

On existing installs, the **Claude Code runtime silently rotted** while opencode kept working.

`upgrade.sh` upgrades opencode/kimaki (opencode.json drift, kimaki plugins, systemd units, AGENTS.md compose) but **never re-syncs the Claude Code SessionStart hook** (`.claude/hooks/dm-agent-sync.sh`) and **won't regenerate `CLAUDE.md`** (line: "don't clobber it"). So the claude-code runtime is installed once at setup and never updated.

The installed hook drifted to a broken version that `exit 0`s every session:
- strict `a.get('status') == 'active'` filter — but Data Machine removed the `status` field, so every row fails the filter and `ACTIVE_SLUGS` is empty;
- `datamachine agent paths` (a command that doesn't exist; it's `memory paths`);
- missing the pre-compose refresh.

Result: `CLAUDE.md` never gets its `<!-- DM_AGENT_SYNC_START -->` memory block and degenerates to just `@AGENTS.md`. The agent boots with **no `SOUL.md`/`MEMORY.md`** — no personality, no memory. opencode was unaffected because its runtime injects the configured agent's files into `opencode.json`'s `instructions` array directly.

## Fix

- **`upgrade.sh` — new Phase 5b (`sync_claude_code_runtime`)**: re-copies the hook, writes the agent-scope sidecar, refreshes `settings.json`, and regenerates a degenerate `CLAUDE.md` from the template. Makes claude-code a first-class upgrade target alongside opencode. Resolves the install's agent slug via: explicit override → existing sidecar → domain- or directory-basename-derived candidate **validated against the live DM agent list** (Studio's `siteurl` is `http://localhost:PORT`, so the directory basename is the reliable signal there).
- **`hooks/dm-agent-sync.sh` — single-agent scoping (OpenCode parity)**: when `dm-agent-sync.env` sets `DM_AGENT_SLUG`, inject only that agent's files. Falls back to all-active-agents discovery when the sidecar is absent (backward compatible). Also carries the upstream status/`memory paths`/compose fixes.
- **`runtimes/claude-code.sh`**: `runtime_install_hooks` writes the `dm-agent-sync.env` sidecar with the configured `AGENT_SLUG`.
- **`lib/data-machine.sh`**: extract `derive_agent_slug()` shared by setup and upgrade.
- **`tests/claude-code-hook-scope.sh` + CI**: regression coverage for both hook modes.

## Verification

Applied to a live Studio install via `./upgrade.sh --runtime claude-code --agents-md-only`:
- slug resolved to the install's agent (single-agent parity);
- `CLAUDE.md` regenerated with the agent's `SOUL.md`/`MEMORY.md`/`USER.md`/`SITE.md`/`RULES.md` and no other agents leaking in;
- installed hook byte-identical to the fixed repo hook and runs clean/idempotent.

Full CI shell suite + `.mjs` tests pass locally, including the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)