### PR TITLE
Configure Homeboy DMC worktree provider

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -51,6 +51,75 @@ homeboy_server_json() {
   printf '{"host":"localhost","user":"%s","port":%s}' "$user" "$port"
 }
 
+homeboy_json_array() {
+  local first=true value
+  printf '['
+  for value in "$@"; do
+    if [ "$first" = true ]; then
+      first=false
+    else
+      printf ','
+    fi
+    printf '"%s"' "$(homeboy_json_escape "$value")"
+  done
+  printf ']'
+}
+
+homeboy_dmc_wp_argv() {
+  local argv=()
+  if [ "${IS_STUDIO:-false}" = true ]; then
+    argv=(studio wp)
+  else
+    # WP_CMD is intentionally a command string in setup profiles (e.g. "wp" or
+    # "studio wp"). Split it the same way the existing wp_cmd helper invokes it.
+    # shellcheck disable=SC2206
+    argv=(${WP_CMD:-wp})
+  fi
+
+  printf '%s\n' "${argv[@]}"
+}
+
+homeboy_dmc_wp_flags() {
+  local argv=()
+
+  if [ -n "${SITE_PATH:-}" ]; then
+    argv+=(--path="$SITE_PATH")
+  fi
+
+  # shellcheck disable=SC2206
+  local root_flags=(${WP_ROOT_FLAG:-})
+  argv+=("${root_flags[@]}")
+
+  printf '%s\n' "${argv[@]}"
+}
+
+homeboy_dmc_command_json() {
+  local action="$1"
+  local wp_argv=()
+  local wp_flags=()
+  mapfile -t wp_argv < <(homeboy_dmc_wp_argv)
+  mapfile -t wp_flags < <(homeboy_dmc_wp_flags)
+
+  case "$action" in
+    list)
+      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree list --format=json "${wp_flags[@]}"
+      ;;
+    cleanup_preview)
+      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --dry-run --format=json "${wp_flags[@]}"
+      ;;
+    cleanup_apply)
+      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --format=json "${wp_flags[@]}"
+      ;;
+  esac
+}
+
+homeboy_dmc_worktree_provider_json() {
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"list":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+    "$(homeboy_dmc_command_json list)" \
+    "$(homeboy_dmc_command_json cleanup_preview)" \
+    "$(homeboy_dmc_command_json cleanup_apply)"
+}
+
 homeboy_project_id() {
   # 1. Explicit override.
   if [ -n "${HOMEBOY_PROJECT_ID:-}" ]; then
@@ -383,6 +452,37 @@ setup_homeboy_project() {
     fi
     log "Created Homeboy project '$project_id'"
   fi
+}
+
+configure_homeboy_dmc_worktree_provider() {
+  if [ "${HOMEBOY_MODE:-auto}" = "disabled" ]; then
+    log "Skipping Homeboy DMC worktree provider setup (--no-homeboy)"
+    return 0
+  fi
+
+  if ! command -v homeboy >/dev/null 2>&1; then
+    homeboy_handle_failure "Homeboy is not callable from this setup/runtime PATH; skipping DMC worktree provider setup."
+    return 0
+  fi
+
+  local provider_json
+  provider_json="$(homeboy_dmc_worktree_provider_json)"
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} homeboy config set /worktree_providers/dmc '$provider_json'"
+    return 0
+  fi
+
+  if [ -n "${SITE_PATH:-}" ] && { [ -f "$SITE_PATH/wp-config.php" ] || [ -f "$SITE_PATH/wp-load.php" ]; }; then
+    if ! wp_cmd datamachine-code workspace worktree list --format=json >/dev/null 2>&1; then
+      homeboy_handle_failure "Data Machine Code WP-CLI commands are not available; skipping Homeboy DMC worktree provider setup."
+      return 0
+    fi
+  fi
+
+  log "Configuring Homeboy DMC worktree provider."
+  homeboy_run config set /worktree_providers/dmc "$provider_json" >/dev/null || \
+    homeboy_handle_failure "Homeboy DMC worktree provider config failed."
 }
 
 configure_homeboy_wordpress_extension() {

--- a/setup.sh
+++ b/setup.sh
@@ -368,6 +368,7 @@ if [ "$RUNTIME_ONLY" != true ]; then
   sync_carried_plugins
   install_extra_plugins
   setup_homeboy_project
+  configure_homeboy_dmc_worktree_provider
   setup_nginx
   setup_ssl
   setup_service_permissions

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# tests/homeboy-dmc-provider.sh — Homeboy DMC worktree provider config.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/wordpress.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/homeboy.sh"
+
+TMP="$(mktemp -d)"
+ORIGINAL_PATH="$PATH"
+trap 'rm -rf "$TMP"' EXIT
+
+SITE_PATH="$TMP/site"
+WP_CMD="wp"
+WP_ROOT_FLAG=""
+IS_STUDIO=true
+LOCAL_MODE=true
+HOMEBOY_MODE="auto"
+WITH_HOMEBOY=false
+mkdir -p "$SITE_PATH"
+touch "$SITE_PATH/wp-config.php"
+
+assert_contains() {
+  local needle="$1" file="$2"
+  if ! grep -qF -- "$needle" "$file"; then
+    echo "FAIL: expected '$needle' in $file"
+    cat "$file"
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1" file="$2"
+  if grep -qF -- "$needle" "$file"; then
+    echo "FAIL: unexpected '$needle' in $file"
+    cat "$file"
+    exit 1
+  fi
+}
+
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/homeboy" <<'SH'
+#!/bin/sh
+if [ "$1 $2" = "config set" ]; then
+  printf '%s|%s\n' "$3" "$4" >> "$HOMEBOY_CONFIG_LOG"
+  exit 0
+fi
+exit 2
+SH
+chmod +x "$FAKE_BIN/homeboy"
+
+cat > "$FAKE_BIN/studio" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >> "$STUDIO_LOG"
+if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree list" ]; then
+  printf '{"success":true,"data":[]}\n'
+  exit 0
+fi
+exit 2
+SH
+chmod +x "$FAKE_BIN/studio"
+
+PATH="$FAKE_BIN:$PATH"
+HOMEBOY_CONFIG_LOG="$TMP/homeboy-config.log"
+STUDIO_LOG="$TMP/studio.log"
+export HOMEBOY_CONFIG_LOG STUDIO_LOG
+
+DRY_RUN=true
+configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
+
+assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
+assert_contains "\"list\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+if [ -f "$HOMEBOY_CONFIG_LOG" ]; then
+  echo "FAIL: dry-run should not call homeboy config set"
+  cat "$HOMEBOY_CONFIG_LOG"
+  exit 1
+fi
+
+DRY_RUN=false
+configure_homeboy_dmc_worktree_provider > "$TMP/apply.log"
+
+assert_contains "wp datamachine-code workspace worktree list --format=json --path=$SITE_PATH" "$STUDIO_LOG"
+assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
+assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
+
+HOMEBOY_MODE="disabled"
+HOMEBOY_CONFIG_LOG="$TMP/disabled-homeboy-config.log"
+export HOMEBOY_CONFIG_LOG
+configure_homeboy_dmc_worktree_provider > "$TMP/disabled.log"
+assert_contains "Skipping Homeboy DMC worktree provider setup (--no-homeboy)" "$TMP/disabled.log"
+if [ -f "$HOMEBOY_CONFIG_LOG" ]; then
+  echo "FAIL: disabled mode should not call homeboy config set"
+  cat "$HOMEBOY_CONFIG_LOG"
+  exit 1
+fi
+
+HOMEBOY_MODE="auto"
+SANDBIN="$TMP/sandbin"
+mkdir -p "$SANDBIN"
+for tool in grep cat rm; do
+  resolved="$(PATH="$ORIGINAL_PATH" command -v "$tool" 2>/dev/null || true)"
+  [ -n "$resolved" ] && ln -sf "$resolved" "$SANDBIN/$tool"
+done
+PATH="$SANDBIN"
+configure_homeboy_dmc_worktree_provider > "$TMP/absent.log"
+assert_contains "Homeboy is not callable from this setup/runtime PATH; skipping DMC worktree provider setup." "$TMP/absent.log"
+assert_not_contains "config set" "$TMP/absent.log"
+
+echo "OK: Homeboy DMC worktree provider config respects dry-run and optional skips"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -113,6 +113,8 @@ RUNTIME=""
 DETECTED_RUNTIMES=()
 IS_STUDIO=false
 CHAT_BRIDGE=""
+HOMEBOY_MODE="${HOMEBOY_MODE:-auto}"
+WITH_HOMEBOY="${WITH_HOMEBOY:-false}"
 # True when the operator forced the identity via --root / --non-root.
 # Suppresses adopt_service_identity_from_units (existing-unit adoption).
 SERVICE_USER_FORCED=false
@@ -369,6 +371,11 @@ update_data_machine_plugins() {
   upgrade_data_machine_plugins
   sync_carried_plugins
   update_wp_codebox_plugin_subtree
+}
+
+configure_homeboy_dmc_worktree_provider_phase() {
+  _run_filter_active plugins || return 0
+  configure_homeboy_dmc_worktree_provider
 }
 
 sync_cli_transport_runtime() {
@@ -1024,6 +1031,7 @@ _print_verify_block() {
 # ============================================================================
 
 update_data_machine_plugins
+configure_homeboy_dmc_worktree_provider_phase
 sync_cli_transport_runtime
 update_ai_gateway
 sync_chat_bridge_config


### PR DESCRIPTION
## Summary
- configure Homeboy `/worktree_providers/dmc` during setup/upgrade
- render provider commands from the detected WP command shape and site flags
- add tests for dry-run rendering, apply path, and skip behavior

## Tests
- `bash -n lib/homeboy.sh setup.sh upgrade.sh tests/homeboy-dmc-provider.sh`
- `bash tests/homeboy-dmc-provider.sh`
- `bash tests/homeboy-components.sh`
- `bash tests/homeboy-agents-md.sh`
- `bash tests/homeboy-project-id.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, and PR preparation.