### PR TITLE
Clarify Homeboy AGENTS orchestration map

### DIFF
--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -14,9 +14,6 @@
 #   agents_md_guidance_ensure_mu_plugin_file
 #   agents_md_guidance_register <section_id> <priority> <label> <description> <content>
 #   agents_md_guidance_unregister <section_id>
-#   agents_md_guidance_sync_homeboy_codebox <available:true|false>
-#   agents_md_guidance_register_homeboy_codebox
-#   agents_md_guidance_unregister_homeboy_codebox
 #   agents_md_guidance_sync_homeboy_cli          # presence-gated on `command -v homeboy`
 #   agents_md_guidance_register_homeboy_cli
 #   agents_md_guidance_unregister_homeboy_cli
@@ -174,51 +171,6 @@ agents_md_guidance_unregister() {
   fi
 }
 
-agents_md_guidance_sync_homeboy_codebox() {
-  local available="${1:-false}"
-  case "$available" in
-    true) agents_md_guidance_register_homeboy_codebox ;;
-    false) agents_md_guidance_unregister_homeboy_codebox ;;
-    *)
-      warn "  agents_md_guidance_sync_homeboy_codebox: expected true or false, got '$available'"
-      return 1
-      ;;
-  esac
-}
-
-agents_md_guidance_register_homeboy_codebox() {
-  agents_md_guidance_register \
-    "homeboy-codebox-agent-tasks" \
-    36 \
-    "Homeboy Codebox agent tasks" \
-    "Homeboy-owned async coding-agent fan-out through WP Codebox sandboxes." \
-    "$(agents_md_guidance_homeboy_codebox_content)"
-}
-
-agents_md_guidance_unregister_homeboy_codebox() {
-  agents_md_guidance_unregister "homeboy-codebox-agent-tasks"
-}
-
-agents_md_guidance_homeboy_codebox_content() {
-  cat <<'MD'
-**Agent tasks:** use `homeboy agent-task --help` to choose the durable agent workflow: cook, fanout, loop, lifecycle, evidence, diagnosis, promotion, and review-finalization surfaces live there when available. Use `homeboy agent-task providers` to inspect registered executor providers. Homeboy owns task plans, durable run state, queueing, concurrency, retries, logs, artifacts, and promotion back into the review workflow.
-
-**Codebox executor:** use the `codebox` backend for disposable WP Codebox WordPress sandboxes. WP Codebox owns sandbox recipes, plugin/runtime overlays, agent invocation, and artifact bundles; Homeboy owns orchestration around those recipes.
-
-**Workspace shape:** use the workspace selected by Homeboy: a component checkout, `homeboy worktree` task workspace, adopted `@workspace:<handle>` path, or sandbox mount supplied by an agent-task executor. Homeboy owns the task/workspace record and safety gates; workspace providers are implementation details.
-
-**WP Codebox agent mode:** use sandbox mode for Codebox coding tasks. Sandbox mode exposes the bounded workspace tools needed to read, edit, and verify files.
-
-**Codex provider:** Codebox Codex tasks need the OpenAI Codex provider plugin/runtime overlay and `AI_PROVIDER_OPENAI_CODEX_*` secrets passed via `secret_env`. Never print token values in logs or task instructions.
-
-**Claude Code provider:** Codebox Claude Code tasks use the `ai-provider-for-claude-code` plugin carried by wp-coding-agents. It is backed by Claude Code OAuth credentials through WP AI Client / PHP AI Client, not the `claude` binary, not an Anthropic API key, and not WP AI Gateway. Provider id: `claude-code`. Provide credentials through `AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN` and optional `AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN` / `AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT`; never pass Claude subscription/session material through task prompts or logs.
-
-**Operator verbs:** `homeboy release`, `homeboy deploy`, and `homeboy ssh` are operator actions. Use them only when the user explicitly asks for that action.
-
-**Chat bridges:** Kimaki, Discord, and other chat bridges display task status and results while Homeboy remains the source of truth for task state and artifacts.
-MD
-}
-
 # ---------------------------------------------------------------------------
 # Homeboy CLI command map (issue #208)
 #
@@ -357,16 +309,7 @@ for name, summary in commands:
 lines.append("")
 lines.append(
     "Discover everything: `homeboy --help`. Drill into any command with "
-    "`homeboy <command> --help`. Releases (`homeboy release`) and deploys "
-    "(`homeboy deploy`) are operator actions — run them only when the user "
-    "explicitly asks."
-)
-lines.append("")
-lines.append(
-    "For component-aware work, prefer Homeboy entrypoints because they preserve "
-    "project context, workspace records, lab routing, gates, logs, artifacts, "
-    "and promotion evidence. Direct shell commands are still appropriate for "
-    "narrow inspection or edits inside the selected workspace."
+    "`homeboy <command> --help`."
 )
 
 sys.stdout.write("\n".join(lines))
@@ -381,7 +324,7 @@ _agents_md_guidance_render_block() {
   AGENTS_MD_GUIDANCE_DESCRIPTION="$description" \
   AGENTS_MD_GUIDANCE_CONTENT="$content" \
   AGENTS_MD_GUIDANCE_FRESHNESS="${AGENTS_MD_GUIDANCE_FRESHNESS:-conditional}" \
-  AGENTS_MD_GUIDANCE_CONDITIONS="${AGENTS_MD_GUIDANCE_CONDITIONS:-Registered when Homeboy Codebox agent-task tooling is available; removed when unavailable.}" \
+  AGENTS_MD_GUIDANCE_CONDITIONS="${AGENTS_MD_GUIDANCE_CONDITIONS:-Registered by wp-coding-agents when the integration is available; removed when unavailable.}" \
   python3 <<'PY'
 import os
 import re

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -201,11 +201,11 @@ agents_md_guidance_unregister_homeboy_codebox() {
 
 agents_md_guidance_homeboy_codebox_content() {
   cat <<'MD'
-**Agent tasks:** `homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote`; use `homeboy agent-task providers` to inspect registered executor providers. Homeboy owns task plans, durable run state, queueing, concurrency, retries, logs, artifacts, and promotion back into the review workflow.
+**Agent tasks:** use `homeboy agent-task --help` to choose the durable agent workflow: cook, fanout, loop, lifecycle, evidence, diagnosis, promotion, and review-finalization surfaces live there when available. Use `homeboy agent-task providers` to inspect registered executor providers. Homeboy owns task plans, durable run state, queueing, concurrency, retries, logs, artifacts, and promotion back into the review workflow.
 
 **Codebox executor:** use the `codebox` backend for disposable WP Codebox WordPress sandboxes. WP Codebox owns sandbox recipes, plugin/runtime overlays, agent invocation, and artifact bundles; Homeboy owns orchestration around those recipes.
 
-**Workspace shape:** pass an explicit workspace root for code edits, usually a Data Machine Code worktree under `<workspace>/<repo>@<slug>` locally or the equivalent mounted path inside a sandbox. Keep primary checkouts read-only.
+**Workspace shape:** use the workspace selected by Homeboy: a component checkout, `homeboy worktree` task workspace, adopted `@workspace:<handle>` path, or sandbox mount supplied by an agent-task executor. Homeboy owns the task/workspace record and safety gates; workspace providers are implementation details.
 
 **WP Codebox agent mode:** use sandbox mode for Codebox coding tasks. Sandbox mode exposes the bounded workspace tools needed to read, edit, and verify files.
 
@@ -325,13 +325,32 @@ commands = [(n, s) for (n, s) in commands if n not in SKIP]
 if not commands:
     sys.exit(1)
 
+command_summaries = {name: summary for name, summary in commands}
+common_order = [
+    "status",
+    "triage",
+    "worktree",
+    "review",
+    "build",
+    "test",
+    "agent-task",
+    "runs",
+]
+
 lines = []
 lines.append(
-    "Homeboy is the host orchestrator binary — build, deploy, release, triage, "
-    "test, and inspect components from the CLI. It is detected on this host, so "
-    "the command map below is generated from `homeboy --help` and refreshes "
-    "whenever homeboy is upgraded."
+    "Homeboy is the SRE and developer orchestration CLI for projects, "
+    "components, task worktrees, lab/offload routing, gates, durable runs, "
+    "artifacts, releases, and deploy workflows. Use this map to choose the "
+    "Homeboy command surface, then run `homeboy <command> --help` for exact "
+    "flags."
 )
+common_entrypoints = [name for name in common_order if name in command_summaries]
+if common_entrypoints:
+    lines.append("")
+    lines.append("Common entrypoints:")
+    for name in common_entrypoints:
+        lines.append(f"- `homeboy {name}` — {command_summaries[name]}")
 lines.append("")
 for name, summary in commands:
     lines.append(f"- `homeboy {name}` — {summary}")
@@ -341,6 +360,13 @@ lines.append(
     "`homeboy <command> --help`. Releases (`homeboy release`) and deploys "
     "(`homeboy deploy`) are operator actions — run them only when the user "
     "explicitly asks."
+)
+lines.append("")
+lines.append(
+    "For component-aware work, prefer Homeboy entrypoints because they preserve "
+    "project context, workspace records, lab routing, gates, logs, artifacts, "
+    "and promotion evidence. Direct shell commands are still appropriate for "
+    "narrow inspection or edits inside the selected workspace."
 )
 
 sys.stdout.write("\n".join(lines))

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -392,16 +392,6 @@ sync_homeboy_agents_md_guidance() {
   if declare -F agents_md_guidance_sync_homeboy_cli >/dev/null; then
     agents_md_guidance_sync_homeboy_cli
   fi
-
-  if ! declare -F agents_md_guidance_sync_homeboy_codebox >/dev/null; then
-    return 0
-  fi
-
-  if [ "${HOMEBOY_WORDPRESS_READY:-false}" = true ] || homeboy_wordpress_extension_ready; then
-    agents_md_guidance_sync_homeboy_codebox true
-  else
-    agents_md_guidance_sync_homeboy_codebox false
-  fi
 }
 
 setup_homeboy_project() {

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -189,7 +189,9 @@ namespace {
         'freshness' => \$call[4]['freshness'] ?? null,
         'conditions' => \$call[4]['conditions'] ?? null,
         'starts_with_homeboy_style_category' => str_starts_with( \$content, '**Agent tasks:**' ),
-        'has_agent_task_verbs' => str_contains( \$content, 'homeboy agent-task submit|run|run-plan|status|logs|artifacts|promote' ),
+        'has_agent_task_map' => str_contains( \$content, 'homeboy agent-task --help' ) && str_contains( \$content, 'durable agent workflow' ),
+        'has_homeboy_workspace_shape' => str_contains( \$content, 'homeboy worktree' ) && str_contains( \$content, 'workspace providers are implementation details' ),
+        'omits_dmc_workspace_shape' => ! str_contains( \$content, 'Data Machine Code worktree' ),
         'has_sandbox_mode' => str_contains( \$content, 'use sandbox mode for Codebox coding tasks' ),
         'has_operator_boundary' => str_contains( \$content, 'homeboy release' ) && str_contains( \$content, 'Use them only when the user explicitly asks' ),
         'has_old_workflow_comparison' => str_contains( \$content, 'instead of' ) || str_contains( \$content, 'manual chat-session fleets' ),
@@ -198,7 +200,7 @@ namespace {
 PHP
 
 RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","owner":"wp-coding-agents","freshness":"conditional","conditions":"Registered when Homeboy Codebox agent-task tooling is available; removed when unavailable.","starts_with_homeboy_style_category":true,"has_agent_task_verbs":true,"has_sandbox_mode":true,"has_operator_boundary":true,"has_old_workflow_comparison":false}'
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","owner":"wp-coding-agents","freshness":"conditional","conditions":"Registered when Homeboy Codebox agent-task tooling is available; removed when unavailable.","starts_with_homeboy_style_category":true,"has_agent_task_map":true,"has_homeboy_workspace_shape":true,"omits_dmc_workspace_shape":true,"has_sandbox_mode":true,"has_operator_boundary":true,"has_old_workflow_comparison":false}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives Homeboy Codebox guidance section"
 
 echo "==> unregister Homeboy Codebox guidance"

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -96,32 +96,31 @@ assert_fails() {
   fi
 }
 
-echo "==> register Homeboy Codebox guidance"
+echo "==> register generic guidance"
 (
   umask 077
-  agents_md_guidance_sync_homeboy_codebox true
+  agents_md_guidance_register "sample-guidance" 36 "Sample guidance" "Sample generated guidance." "## Sample guidance"
 )
 
 assert_php_lint "$MU_FILE" "guidance mu-plugin parses with php -l"
 assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after fresh write under umask 077"
 
-if grep -q "BEGIN agents-md-guidance:homeboy-codebox-agent-tasks" "$MU_FILE"; then
-  echo "  ok   Homeboy Codebox block present"
+if grep -q "BEGIN agents-md-guidance:sample-guidance" "$MU_FILE"; then
+  echo "  ok   sample guidance block present"
 else
-  echo "  FAIL Homeboy Codebox block missing"
+  echo "  FAIL sample guidance block missing"
   FAILED=$((FAILED + 1))
 fi
 
-echo "==> re-register Homeboy Codebox guidance (idempotent)"
+echo "==> re-register generic guidance (idempotent)"
 HASH_BEFORE=$(file_hash "$MU_FILE")
-agents_md_guidance_sync_homeboy_codebox true
+agents_md_guidance_register "sample-guidance" 36 "Sample guidance" "Sample generated guidance." "## Sample guidance"
 HASH_AFTER=$(file_hash "$MU_FILE")
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-register"
 
 echo "==> invalid public API inputs fail before writing broken PHP"
 assert_fails "invalid section id rejected" agents_md_guidance_register "bad section" 36 "Bad" "Bad" "## Bad"
 assert_fails "invalid priority rejected" agents_md_guidance_register "bad-priority" "later" "Bad" "Bad" "## Bad"
-assert_fails "invalid sync availability rejected" agents_md_guidance_sync_homeboy_codebox maybe
 
 echo "==> skip registration when Data Machine core gate is unavailable"
 SHIM_DISABLED="$TMP/section-shim-disabled.php"
@@ -188,30 +187,24 @@ namespace {
         'owner' => \$call[4]['owner'] ?? null,
         'freshness' => \$call[4]['freshness'] ?? null,
         'conditions' => \$call[4]['conditions'] ?? null,
-        'starts_with_homeboy_style_category' => str_starts_with( \$content, '**Agent tasks:**' ),
-        'has_agent_task_map' => str_contains( \$content, 'homeboy agent-task --help' ) && str_contains( \$content, 'durable agent workflow' ),
-        'has_homeboy_workspace_shape' => str_contains( \$content, 'homeboy worktree' ) && str_contains( \$content, 'workspace providers are implementation details' ),
-        'omits_dmc_workspace_shape' => ! str_contains( \$content, 'Data Machine Code worktree' ),
-        'has_sandbox_mode' => str_contains( \$content, 'use sandbox mode for Codebox coding tasks' ),
-        'has_operator_boundary' => str_contains( \$content, 'homeboy release' ) && str_contains( \$content, 'Use them only when the user explicitly asks' ),
-        'has_old_workflow_comparison' => str_contains( \$content, 'instead of' ) || str_contains( \$content, 'manual chat-session fleets' ),
+        'content' => \$content,
     ]);
 }
 PHP
 
 RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-codebox-agent-tasks","priority":36,"label":"Homeboy Codebox agent tasks","owner":"wp-coding-agents","freshness":"conditional","conditions":"Registered when Homeboy Codebox agent-task tooling is available; removed when unavailable.","starts_with_homeboy_style_category":true,"has_agent_task_map":true,"has_homeboy_workspace_shape":true,"omits_dmc_workspace_shape":true,"has_sandbox_mode":true,"has_operator_boundary":true,"has_old_workflow_comparison":false}'
-assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives Homeboy Codebox guidance section"
+EXPECTED='{"filename":"AGENTS.md","slug":"sample-guidance","priority":36,"label":"Sample guidance","owner":"wp-coding-agents","freshness":"conditional","conditions":"Registered by wp-coding-agents when the integration is available; removed when unavailable.","content":"## Sample guidance"}'
+assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives generic guidance section"
 
-echo "==> unregister Homeboy Codebox guidance"
+echo "==> unregister generic guidance"
 chmod 0600 "$MU_FILE"
-agents_md_guidance_sync_homeboy_codebox false
+agents_md_guidance_unregister "sample-guidance"
 assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
-if grep -q "BEGIN agents-md-guidance:homeboy-codebox-agent-tasks" "$MU_FILE"; then
-  echo "  FAIL Homeboy Codebox block still present after unregister"
+if grep -q "BEGIN agents-md-guidance:sample-guidance" "$MU_FILE"; then
+  echo "  FAIL sample guidance block still present after unregister"
   FAILED=$((FAILED + 1))
 else
-  echo "  ok   Homeboy Codebox block removed"
+  echo "  ok   sample guidance block removed"
 fi
 assert_php_lint "$MU_FILE" "post-unregister file parses with php -l"
 

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -151,19 +151,16 @@ namespace {
         'has_status' => str_contains( \$content, '- \`homeboy status\` — Actionable component status overview' ),
         'has_orchestrator_intro' => str_contains( \$content, 'Homeboy is the SRE and developer orchestration CLI' ),
         'has_common_entrypoints' => str_contains( \$content, 'Common entrypoints:' ),
-        'has_component_routing_footer' => str_contains( \$content, 'For component-aware work, prefer Homeboy entrypoints' ),
-        'allows_narrow_shell_commands' => str_contains( \$content, 'Direct shell commands are still appropriate for narrow inspection' ),
         'drops_help_meta' => ! str_contains( \$content, 'homeboy help' ),
         'drops_list_meta' => ! str_contains( \$content, 'homeboy list' ),
         'has_discover_footer' => str_contains( \$content, 'Discover everything: \`homeboy --help\`' ),
         'has_per_command_footer' => str_contains( \$content, 'homeboy <command> --help' ),
-        'has_operator_boundary' => str_contains( \$content, 'operator actions' ),
     ]);
 }
 PHP
 
 RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"conditional","has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"has_component_routing_footer":true,"allows_narrow_shell_commands":true,"drops_help_meta":true,"drops_list_meta":true,"has_discover_footer":true,"has_per_command_footer":true,"has_operator_boundary":true}'
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"conditional","has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"drops_help_meta":true,"drops_list_meta":true,"has_discover_footer":true,"has_per_command_footer":true}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives generated Homeboy CLI map"
 
 echo "==> re-sync with homeboy present (idempotent)"

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -149,6 +149,10 @@ namespace {
         'has_release' => str_contains( \$content, '- \`homeboy release\` — Plan release workflows' ),
         'has_triage' => str_contains( \$content, '- \`homeboy triage\` — Read-only attention report' ),
         'has_status' => str_contains( \$content, '- \`homeboy status\` — Actionable component status overview' ),
+        'has_orchestrator_intro' => str_contains( \$content, 'Homeboy is the SRE and developer orchestration CLI' ),
+        'has_common_entrypoints' => str_contains( \$content, 'Common entrypoints:' ),
+        'has_component_routing_footer' => str_contains( \$content, 'For component-aware work, prefer Homeboy entrypoints' ),
+        'allows_narrow_shell_commands' => str_contains( \$content, 'Direct shell commands are still appropriate for narrow inspection' ),
         'drops_help_meta' => ! str_contains( \$content, 'homeboy help' ),
         'drops_list_meta' => ! str_contains( \$content, 'homeboy list' ),
         'has_discover_footer' => str_contains( \$content, 'Discover everything: \`homeboy --help\`' ),
@@ -159,7 +163,7 @@ namespace {
 PHP
 
 RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"conditional","has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"drops_help_meta":true,"drops_list_meta":true,"has_discover_footer":true,"has_per_command_footer":true,"has_operator_boundary":true}'
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"conditional","has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"has_component_routing_footer":true,"allows_narrow_shell_commands":true,"drops_help_meta":true,"drops_list_meta":true,"has_discover_footer":true,"has_per_command_footer":true,"has_operator_boundary":true}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives generated Homeboy CLI map"
 
 echo "==> re-sync with homeboy present (idempotent)"


### PR DESCRIPTION
## Summary
- frame Homeboy as the SRE/developer orchestration CLI while preserving the generated command-map purpose
- add common Homeboy entrypoints generated from the parsed top-level command list
- remove the extra Homeboy Codebox AGENTS.md guidance section entirely
- keep wp-coding-agents AGENTS.md output agnostic to Codebox, Codex, Claude Code, chat bridges, and operator-policy prose

## Testing
- `bash tests/homeboy-agents-md.sh`
- `bash tests/agents-md-guidance.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the generator wording, removing stale provider-specific guidance, updating regression tests, and preparing this PR.