### PR TITLE
Support macOS bash in Homeboy provider config

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -97,8 +97,15 @@ homeboy_dmc_command_json() {
   local action="$1"
   local wp_argv=()
   local wp_flags=()
-  mapfile -t wp_argv < <(homeboy_dmc_wp_argv)
-  mapfile -t wp_flags < <(homeboy_dmc_wp_flags)
+  local value
+
+  while IFS= read -r value; do
+    wp_argv+=("$value")
+  done < <(homeboy_dmc_wp_argv)
+
+  while IFS= read -r value; do
+    wp_flags+=("$value")
+  done < <(homeboy_dmc_wp_flags)
 
   case "$action" in
     list)
@@ -516,7 +523,7 @@ configure_homeboy_wordpress_extension() {
     echo -e "${BLUE}[dry-run]${NC} homeboy extension setup wordpress"
     echo -e "${BLUE}[dry-run]${NC} homeboy extension list"
     echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update datamachine_code_homeboy_available 1"
-    echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy Codebox AGENTS.md guidance mu-plugin"
+    echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy AGENTS.md CLI guidance mu-plugin"
     print_homeboy_verification_commands
     return 0
   fi

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -72,6 +72,10 @@ HOMEBOY_CONFIG_LOG="$TMP/homeboy-config.log"
 STUDIO_LOG="$TMP/studio.log"
 export HOMEBOY_CONFIG_LOG STUDIO_LOG
 
+# macOS ships Bash 3.2, which has no mapfile/readarray builtin. Disable it
+# when the test runs under newer Bash so this path stays portable.
+enable -n mapfile 2>/dev/null || true
+
 DRY_RUN=true
 configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -664,7 +664,7 @@ regenerate_agents_md() {
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would backup $AGENTS_MD → $BACKUP"
-    echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy Codebox AGENTS.md guidance mu-plugin"
+    echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy AGENTS.md CLI guidance mu-plugin"
     echo -e "${BLUE}[dry-run]${NC} Would run: $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG"
     echo -e "${BLUE}[dry-run]${NC} Would symlink $CLAUDE_MD → AGENTS.md (Claude-model context)"
     return 0


### PR DESCRIPTION
## Summary
- replace `mapfile` in Homeboy DMC provider config generation with Bash 3-compatible read loops
- cover the path with a test that disables `mapfile` under newer Bash
- update stale dry-run text to refer to Homeboy AGENTS.md CLI guidance instead of Codebox guidance

## Testing
- `bash tests/homeboy-dmc-provider.sh`
- `bash tests/homeboy-agents-md.sh`
- `./upgrade.sh --dry-run --wp-path /Users/chubes/Studio/intelligence-chubes4`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the macOS Bash compatibility failure, drafting the compatibility fix, updating tests, and preparing this PR.