### PR TITLE
Add Codex runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Human
         ▼
 Coding runtime
   ├─ OpenCode
-  └─ Claude Code
+  ├─ Claude Code
+  └─ Codex
         │
         ▼
 WordPress + Data Machine
@@ -47,7 +48,7 @@ Data Machine is the always-present composition layer. It owns the persistent age
 The agent should know only what it can use.
 
 - **Data Machine** is always present and composes `AGENTS.md`, `SOUL.md`, `MEMORY.md`, `USER.md`, and shared site guidance.
-- **Coding runtimes** add only their runtime-specific configuration, such as OpenCode instructions or Claude Code `@` includes.
+- **Coding runtimes** add only their runtime-specific configuration, such as OpenCode instructions, Claude Code `@` includes, or Codex's managed `AGENTS.override.md`.
 - **Chat bridges** describe the human communication surface when that bridge is selected.
 - **Developer orchestration layers** add guidance only when installed and verified.
 - **Unavailable tools** do not get stub instructions, fallback recipes, or negative constraints.
@@ -63,6 +64,13 @@ Run an agent from an existing local WordPress site and keep its context grounded
 ```bash
 EXISTING_WP=~/Studio/my-site ./setup.sh --local
 cd ~/Studio/my-site && opencode
+```
+
+Use Codex as the terminal runtime when you want the site context in a Codex session without a chat bridge:
+
+```bash
+EXISTING_WP=~/Studio/my-site ./setup.sh --local --runtime codex
+cd ~/Studio/my-site && codex
 ```
 
 ### Chat-Connected Agent
@@ -100,6 +108,7 @@ When an optional orchestrator is available, its own presence-gated AGENTS sectio
 | Data Machine | Agent identity, memory, composed guidance, abilities, flows, jobs | Always installed |
 | OpenCode | Coding runtime | Selected or auto-detected |
 | Claude Code | Coding runtime | Selected or auto-detected |
+| Codex | Coding runtime | Selected or auto-detected |
 | Data Machine Code | Workspace, git, GitHub, and worktree integration | Installed with the Data Machine stack |
 | Kimaki | Discord bridge for OpenCode sessions | Optional chat bridge |
 | cc-connect | Multi-platform bridge, commonly used with Claude Code | Optional chat bridge |
@@ -125,6 +134,7 @@ Select a runtime explicitly when needed:
 ```bash
 EXISTING_WP=~/Studio/my-site ./setup.sh --local --runtime opencode
 EXISTING_WP=~/Studio/my-site ./setup.sh --local --runtime claude-code
+EXISTING_WP=~/Studio/my-site ./setup.sh --local --runtime codex
 ```
 
 ### VPS
@@ -148,12 +158,12 @@ operator-entrypoints/wp-coding-agents-setup/setup.md
 
 | Flag | Description |
 | --- | --- |
-| `--runtime <name>` | Coding runtime: `opencode` or `claude-code`. Auto-detected when omitted. |
+| `--runtime <name>` | Coding runtime: `opencode`, `claude-code`, or `codex`. Auto-detected when omitted. |
 | `--local` | Local machine mode. Skips server infrastructure. |
 | `--existing` | Add to an existing WordPress install. |
 | `--wp-path <path>` | WordPress root path. Implies `--existing`. |
 | `--agent-slug <slug>` | Override the Data Machine agent slug. |
-| `--chat <bridge>` | Chat bridge: `kimaki`, `cc-connect`, or `telegram`. |
+| `--chat <bridge>` | Chat bridge: `kimaki`, `cc-connect`, or `telegram`. Codex currently runs without a managed chat bridge. |
 | `--no-chat` | Skip chat bridge setup. |
 | `--with-homeboy` | Enable optional Homeboy project/lab integration when available. |
 | `--with-ai-gateway` | Enable optional [WP AI Gateway](https://github.com/Automattic/wp-ai-gateway) setup for OpenCode runtimes. |
@@ -187,6 +197,21 @@ Claude Code uses `CLAUDE.md` with generated `@` includes. A SessionStart hook re
 
 When Claude Code is selected or detected, `wp-coding-agents` installs the carried `ai-provider-for-claude-code` plugin so WordPress AI Client consumers can use the local Claude Code OAuth-backed provider when appropriate.
 
+### Codex
+
+Codex reads `AGENTS.override.md` from the WordPress site root when present, before falling back to `AGENTS.md`. Because Codex does not load arbitrary instruction files from an `instructions` array or Claude-style `@` includes, setup and upgrade generate a Codex-owned `AGENTS.override.md` from the shared `AGENTS.md` plus the local Data Machine memory files.
+
+Keeping the Codex memory mirror in `AGENTS.override.md` avoids polluting the shared `AGENTS.md` that OpenCode also reads. On a site with both runtimes, OpenCode keeps using `AGENTS.md` plus `opencode.json` instructions, while Codex gets the same site guidance and memory through its generated override.
+
+Setup installs the managed upgrade skill into `.agents/skills`, registers Codex thread attribution for Data Machine Code when available, and leaves global Codex config and auth state alone.
+
+Codex does not currently have a managed chat bridge in this repo, so setup defaults to terminal/manual operation:
+
+```bash
+EXISTING_WP=~/Studio/my-site ./setup.sh --local --runtime codex
+cd ~/Studio/my-site && codex
+```
+
 ### Kimaki
 
 Kimaki is the Discord surface for OpenCode. Managed installs replace Kimaki's generic runtime prompt with a small bridge prompt so orchestration, workspace, tunnel, and preview guidance can come from the installed components that own those capabilities.
@@ -217,7 +242,7 @@ Data Machine manages the agent's persistent files:
 | `MEMORY.md` | Agent | Persistent project knowledge |
 | `USER.md` | User | Human profile and preferences |
 
-The selected runtime reads the composed files at session start. The agent can update memory through Data Machine instead of relying on runtime-specific memory features.
+The selected runtime reads this memory at session start. OpenCode references the files from `opencode.json`, Claude Code uses generated `@` includes, and Codex receives the same file contents through a generated site-root `AGENTS.override.md`. The agent can update memory through Data Machine instead of relying on runtime-specific memory features.
 
 ## Abilities And Dispatch
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- add Codex as a supported runtime with generated AGENTS.override.md loading, project-local skills, runtime attribution, and a managed Data Machine memory mirror
+
 ## [1.6.2] - 2026-06-30
 
 ### Fixed

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -254,6 +254,11 @@ _print_bare_runtime_start() {
   echo ""
 }
 _print_bare_runtime_cmd() {
+  if declare -F runtime_start_cmd >/dev/null; then
+    echo "    $(runtime_start_cmd)"
+    return
+  fi
+
   if [ "$RUNTIME" = "claude-code" ]; then
     echo "    cd $SITE_PATH && claude"
   else

--- a/operator-entrypoints/wp-coding-agents-setup/interview.md
+++ b/operator-entrypoints/wp-coding-agents-setup/interview.md
@@ -22,6 +22,7 @@ Collect the facts needed to install wp-coding-agents. Do not build commands, run
    Ask which runtime or runtimes the user wants:
    - `opencode`
    - `claude-code`
+   - `codex`
    - `multiple`
 
    If they choose multiple, collect the desired runtime list. If they are unsure, record `auto` so `setup.sh` can auto-detect.
@@ -34,10 +35,12 @@ Collect the facts needed to install wp-coding-agents. Do not build commands, run
    - `none` — terminal/SSH/manual only.
    - `auto` — let setup choose the default bridge for the runtime.
 
+   Codex currently has no managed chat bridge in wp-coding-agents; use `none` or `auto` for Codex unless the setup script grows a Codex bridge.
+
    For Telegram, collect whether `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USER_ID` are available.
 
-5. **Codex / gateway path**
-   Ask this only when the user mentions Codex, Codebox minions, OpenCode/Kimaki external clients, or WP AI Gateway.
+5. **Codebox / gateway path**
+   Ask this only when the user mentions Codebox minions, OpenCode/Kimaki external clients, or WP AI Gateway. Plain Codex runtime selection is handled by the runtime axis above and does not require a provider/gateway path.
 
    Record one of:
    - `codebox-minions` — provider auth is inherited inside Codebox; WP AI Gateway is not required.
@@ -73,7 +76,7 @@ Return the profile as JSON in this shape so the compiler script can map it deter
     "migration_backups_ready": false
   },
   "runtime": {
-    "selection": "auto | opencode | claude-code | multiple",
+    "selection": "auto | opencode | claude-code | codex | multiple",
     "runtimes": []
   },
   "chat_bridge": {

--- a/operator-entrypoints/wp-coding-agents-setup/setup.md
+++ b/operator-entrypoints/wp-coding-agents-setup/setup.md
@@ -78,7 +78,7 @@ Use when the operator says things like:
 
 - "Help me install wp-coding-agents on my server"
 - "Set up a coding agent on this VPS"
-- "Add Claude Code / OpenCode to my existing WordPress site"
+- "Add Claude Code / OpenCode / Codex to my existing WordPress site"
 - "Set up a local AI agent on my machine"
 - "Install wp-coding-agents with WordPress Studio"
 - "Set it up with Homeboy"

--- a/operator-entrypoints/wp-coding-agents-setup/verify.md
+++ b/operator-entrypoints/wp-coding-agents-setup/verify.md
@@ -63,6 +63,16 @@ opencode --version
 claude --version
 ```
 
+### `verify-runtime-codex`
+
+```bash
+codex --version
+test -f /path/to/site/AGENTS.md
+test -f /path/to/site/AGENTS.override.md
+grep -q 'WP_CODING_AGENTS_CODEX_MEMORY_START' /path/to/site/AGENTS.override.md
+test -d /path/to/site/.agents/skills/upgrade-wp-coding-agents
+```
+
 ### `verify-runtime-multiple`
 
 Run the selected runtime checks for each runtime in the compiled profile. If the setup used auto-detection, compare the detected runtime list from setup output with installed runtime binaries.

--- a/runtimes/codex.sh
+++ b/runtimes/codex.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# Runtime: Codex — install, AGENTS.md generation, project-local skills
+
+CODEX_MANAGED_OVERRIDE_START="<!-- WP_CODING_AGENTS_CODEX_OVERRIDE_START -->"
+CODEX_MANAGED_OVERRIDE_END="<!-- WP_CODING_AGENTS_CODEX_OVERRIDE_END -->"
+CODEX_DM_MEMORY_START="<!-- WP_CODING_AGENTS_CODEX_MEMORY_START -->"
+CODEX_DM_MEMORY_END="<!-- WP_CODING_AGENTS_CODEX_MEMORY_END -->"
+
+runtime_install() {
+  log "Phase 7: Installing Codex..."
+
+  if ! command -v codex &> /dev/null || [ "$DRY_RUN" = true ]; then
+    run_cmd npm install -g @openai/codex
+  else
+    log "Codex already installed: $(codex --version 2>/dev/null || echo 'unknown')"
+  fi
+
+  _codex_register_runtime_signature
+}
+
+# Codex exports CODEX_THREAD_ID into shell/tool subprocesses. Register it so
+# Data Machine Code can attribute worktree activity back to the active Codex
+# thread when the runtime is launched from a managed site.
+_codex_register_runtime_signature() {
+  if ! declare -F runtime_signature_register >/dev/null; then
+    return 0
+  fi
+  runtime_signature_register \
+    "codex" \
+    '{"thread_id":"CODEX_THREAD_ID"}'
+}
+
+runtime_discover_dm_paths() {
+  if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/wp-config.php" ]; then
+    AGENT_FLAG=""
+    if [ -n "${AGENT_SLUG:-}" ]; then
+      AGENT_FLAG="--agent=$AGENT_SLUG"
+    fi
+
+    DM_INJECTABLE_RAW=$(wp_cmd datamachine memory injectable-files --format=json $AGENT_FLAG 2>/dev/null || echo "")
+    DM_INJECTABLE_JSON=$(echo "$DM_INJECTABLE_RAW" | sed -n '/^\[/,/^\]/p')
+    if [ -n "$DM_INJECTABLE_JSON" ]; then
+      DM_AGENT_FILES=$(echo "$DM_INJECTABLE_JSON" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for f in data:
+    path = f.get('path')
+    if path:
+        print(path)
+" 2>/dev/null || true)
+      if [ -n "$DM_AGENT_FILES" ]; then
+        log "Agent files discovered via '$WP_CMD datamachine memory injectable-files${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+        return
+      fi
+    fi
+
+    DM_PATHS_RAW=$(wp_cmd datamachine memory paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
+    DM_PATHS_JSON=$(echo "$DM_PATHS_RAW" | sed -n '/^{/,/^}/p')
+    if [ -n "$DM_PATHS_JSON" ]; then
+      DM_AGENT_FILES=$(echo "$DM_PATHS_JSON" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for f in data.get('relative_files', []):
+    print(f)
+" 2>/dev/null || true)
+      if [ -n "$DM_AGENT_FILES" ]; then
+        log "Agent files discovered via '$WP_CMD datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+        return
+      fi
+    fi
+
+    warn "'$WP_CMD datamachine memory injectable-files' and 'memory paths' returned no JSON — Codex AGENTS.md memory block will be skipped"
+    DM_AGENT_FILES=""
+  else
+    DM_DRY_SLUG="${AGENT_SLUG:-AGENT_SLUG}"
+    DM_AGENT_FILES="wp-content/uploads/datamachine-files/shared/SITE.md
+wp-content/uploads/datamachine-files/shared/RULES.md
+wp-content/uploads/datamachine-files/agents/${DM_DRY_SLUG}/SOUL.md
+wp-content/uploads/datamachine-files/users/USER_ID/USER.md
+wp-content/uploads/datamachine-files/agents/${DM_DRY_SLUG}/MEMORY.md"
+    log "Dry-run: using placeholder agent paths (slug: $DM_DRY_SLUG)"
+  fi
+}
+
+runtime_generate_config() {
+  log "Codex reads project instructions from AGENTS.md; no runtime config file required."
+}
+
+runtime_install_hooks() {
+  return 0
+}
+
+runtime_generate_instructions() {
+  if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/AGENTS.md" ]; then
+    log "Phase 8: AGENTS.md already exists — preserving file and syncing Codex override"
+    _codex_sync_override
+    return
+  fi
+
+  log "Phase 8: Generating AGENTS.md..."
+
+  # Compose from Data Machine's SectionRegistry. DM is mandatory, and Codex
+  # loads AGENTS.md directly from the working directory.
+  if [ "$DRY_RUN" = false ]; then
+    sync_homeboy_availability
+    if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
+      log "AGENTS.md composed from SectionRegistry"
+      _codex_sync_override
+      return
+    fi
+    warn "Compose failed — falling back to static template"
+  fi
+
+  local agents_tmpl="$SCRIPT_DIR/workspace/AGENTS.md"
+  if [ ! -f "$agents_tmpl" ]; then
+    error "AGENTS.md template not found at $agents_tmpl"
+  fi
+
+  local wp_cli_display="wp"
+  if [ "$IS_STUDIO" = true ]; then
+    wp_cli_display="studio wp"
+  elif [ "$LOCAL_MODE" = false ]; then
+    wp_cli_display="wp $WP_ROOT_FLAG --path=$SITE_PATH"
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would generate AGENTS.md from template"
+    _codex_sync_override
+  else
+    local agents_md
+    agents_md=$(sed "s|{{WP_CLI_CMD}}|$wp_cli_display|g" "$agents_tmpl")
+    write_file "$SITE_PATH/AGENTS.md" "$agents_md"
+    _codex_sync_override
+  fi
+}
+
+runtime_sync_instructions() {
+  runtime_discover_dm_paths
+  _codex_sync_override
+}
+
+_codex_sync_override() {
+  local agents_md="$SITE_PATH/AGENTS.md"
+  local codex_agents_md="$SITE_PATH/AGENTS.override.md"
+
+  if [ -z "${DM_AGENT_FILES:-}" ]; then
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would sync Codex AGENTS.override.md from $agents_md plus Data Machine memory"
+    return 0
+  fi
+
+  if [ ! -f "$agents_md" ]; then
+    warn "Codex base AGENTS.md not found at $agents_md — skipping AGENTS.override.md sync"
+    return 0
+  fi
+
+  if [ -f "$codex_agents_md" ] && ! grep -Fq "$CODEX_MANAGED_OVERRIDE_START" "$codex_agents_md"; then
+    warn "Codex AGENTS.override.md already exists and is not managed by wp-coding-agents — leaving it untouched"
+    return 0
+  fi
+
+  _codex_remove_legacy_agents_memory_block
+
+  local memory_list
+  memory_list=$(mktemp)
+  printf '%s\n' "$DM_AGENT_FILES" > "$memory_list"
+
+  CODEX_MANAGED_OVERRIDE_START="$CODEX_MANAGED_OVERRIDE_START" \
+  CODEX_MANAGED_OVERRIDE_END="$CODEX_MANAGED_OVERRIDE_END" \
+  CODEX_DM_MEMORY_START="$CODEX_DM_MEMORY_START" \
+  CODEX_DM_MEMORY_END="$CODEX_DM_MEMORY_END" \
+  python3 - "$agents_md" "$codex_agents_md" "$SITE_PATH" "$memory_list" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+agents_path = Path(sys.argv[1])
+override_path = Path(sys.argv[2])
+site_path = Path(sys.argv[3])
+list_path = Path(sys.argv[4])
+override_start = os.environ["CODEX_MANAGED_OVERRIDE_START"]
+override_end = os.environ["CODEX_MANAGED_OVERRIDE_END"]
+memory_start = os.environ["CODEX_DM_MEMORY_START"]
+memory_end = os.environ["CODEX_DM_MEMORY_END"]
+
+base = agents_path.read_text(encoding="utf-8").rstrip()
+paths = [line.strip() for line in list_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+sections = [
+    override_start,
+    "<!-- Generated from AGENTS.md plus Data Machine memory for Codex. -->",
+    "<!-- Do not edit this file by hand; edit AGENTS.md or Data Machine memory and rerun setup/upgrade. -->",
+    "",
+    base,
+    "",
+    memory_start,
+    "## Data Machine Memory",
+    "",
+    "Codex reads this managed section from the local WordPress site's Data Machine memory files.",
+]
+
+for raw_path in paths:
+    path = Path(raw_path).expanduser()
+    display_path = raw_path
+    if not path.is_absolute():
+        path = site_path / raw_path
+        display_path = raw_path
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        sections.extend(["", f"### Source: `{display_path}`", "", "_File not found at sync time._"])
+        continue
+
+    sections.extend(["", f"### Source: `{display_path}`", "", content.rstrip()])
+
+sections.extend(["", memory_end, override_end])
+updated = "\n".join(sections).rstrip() + "\n"
+
+override_path.write_text(updated, encoding="utf-8")
+PY
+  rm -f "$memory_list"
+  log "Synced Codex AGENTS.override.md from AGENTS.md plus Data Machine memory"
+}
+
+_codex_remove_legacy_agents_memory_block() {
+  local agents_md="$SITE_PATH/AGENTS.md"
+
+  if [ ! -f "$agents_md" ] || ! grep -Fq "$CODEX_DM_MEMORY_START" "$agents_md"; then
+    return 0
+  fi
+
+  CODEX_DM_MEMORY_START="$CODEX_DM_MEMORY_START" \
+  CODEX_DM_MEMORY_END="$CODEX_DM_MEMORY_END" \
+  python3 - "$agents_md" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+start = os.environ["CODEX_DM_MEMORY_START"]
+end = os.environ["CODEX_DM_MEMORY_END"]
+content = path.read_text(encoding="utf-8")
+
+if start not in content or end not in content:
+    raise SystemExit(0)
+
+before = content.split(start, 1)[0].rstrip()
+after = content.split(end, 1)[1].lstrip()
+parts = [part for part in (before, after.rstrip()) if part]
+path.write_text("\n\n".join(parts).rstrip() + "\n", encoding="utf-8")
+PY
+  log "Removed legacy Codex memory block from shared AGENTS.md"
+}
+
+runtime_merge_mcp_servers() {
+  if [ -z "${MCP_SERVERS:-}" ]; then
+    return 0
+  fi
+
+  warn "MCP_SERVERS auto-merge is not supported for Codex yet; configure Codex MCP with 'codex mcp add'."
+}
+
+runtime_skills_dir() {
+  echo "$SITE_PATH/.agents/skills"
+}
+
+runtime_start_cmd() {
+  echo "cd $SITE_PATH && codex"
+}
+
+runtime_print_summary() {
+  echo "Codex:"
+  echo "  Config:   $SITE_PATH/AGENTS.override.md"
+  echo "  Base:     $SITE_PATH/AGENTS.md"
+  echo "  Skills:   $(runtime_skills_dir)"
+  echo ""
+}

--- a/scripts/compile-setup-profile.mjs
+++ b/scripts/compile-setup-profile.mjs
@@ -158,6 +158,7 @@ function compile(profile) {
   } else if (bridge !== "auto") {
     addFlag(command, "--chat", bridge)
   }
+  const effectiveBridge = bridge === "auto" && runtime.primary === "codex" ? "none" : bridge
 
   if (overlays.homeboy) addFlag(command, "--with-homeboy")
   if (overlays.multisite || overlays.subdomain_multisite) addFlag(command, "--multisite")
@@ -194,11 +195,11 @@ function compile(profile) {
   }
   if (runtime.selection === "multiple") verification.add("verify-runtime-multiple")
 
-  if (bridge === "none") {
+  if (effectiveBridge === "none") {
     verification.add("verify-bridge-none")
-  } else if (bridge !== "auto") {
-    verification.add(`verify-bridge-${bridge}`)
-    if (bridge === "kimaki" && (runtimeNames.includes("opencode") || runtime.selection === "auto")) {
+  } else if (effectiveBridge !== "auto") {
+    verification.add(`verify-bridge-${effectiveBridge}`)
+    if (effectiveBridge === "kimaki" && (runtimeNames.includes("opencode") || runtime.selection === "auto")) {
       verification.add("verify-bridge-kimaki-opencode-plugins")
     }
   }
@@ -211,7 +212,7 @@ function compile(profile) {
     summary: {
       target: installTarget,
       runtime_axis: runtime.selection,
-      bridge_axis: bridge,
+      bridge_axis: effectiveBridge,
       overlays: Object.entries(overlays)
         .filter(([, value]) => value === true)
         .map(([key]) => key),

--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,7 @@ WITH_HOMEBOY=false
 WITH_AI_GATEWAY=false
 ROTATE_AI_GATEWAY_TOKEN=false
 RUNTIME=""
+CHAT_BRIDGE_EXPLICIT=false
 HOMEBOY_MODE="auto"
 HOMEBOY_PROJECT_ID="${HOMEBOY_PROJECT_ID:-}"
 DETECTED_RUNTIMES=()
@@ -101,6 +102,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --chat)
       CHAT_BRIDGE="$2"
+      CHAT_BRIDGE_EXPLICIT=true
       shift 2
       ;;
     --skip-ssl)
@@ -205,6 +207,7 @@ USAGE:
   Existing WordPress: EXISTING_WP=/var/www/mysite ./setup.sh --existing
   Local (macOS/Linux): EXISTING_WP=/path/to/wordpress ./setup.sh --local
   With Claude Code:   ./setup.sh --runtime claude-code --existing
+  With Codex:         ./setup.sh --runtime codex --existing --no-chat
 
 OPTIONS:
   --existing         Add agent to existing WordPress (skip WP install)
@@ -218,7 +221,7 @@ OPTIONS:
   --agent-name <n>   Override Data Machine agent display name (default: blogname)
   --no-chat          Skip chat bridge installation
   --chat <bridge>    Chat bridge to install (default: kimaki for opencode,
-                     cc-connect for claude-code)
+                     cc-connect for claude-code, none for codex)
                      Supported: kimaki (Discord), cc-connect, telegram
   --skip-deps        Skip apt package installation
   --multisite        Convert to WordPress Multisite (subdirectory by default)
@@ -303,10 +306,10 @@ fi
 #
 # RUNTIME is the "primary" runtime — the one that drives runtime_install,
 # runtime_generate_config, runtime_install_hooks, and the chat-bridge default.
-# First-match cascade: claude-code > opencode.
+# First-match cascade: claude-code > opencode > codex.
 #
 # DETECTED_RUNTIMES is the list of ALL runtimes whose binary is present. On a
-# machine with both claude and opencode installed, the upgrade skill gets
+# machine with claude, opencode, and codex installed, the upgrade skill gets
 # installed into every detected runtime's skills dir (see install_skills in lib/skills.sh).
 # Explicit --runtime <name> narrows both lists to that single runtime.
 if [ -n "$RUNTIME" ]; then
@@ -318,6 +321,9 @@ else
   fi
   if command -v opencode &>/dev/null; then
     DETECTED_RUNTIMES+=("opencode")
+  fi
+  if command -v codex &>/dev/null; then
+    DETECTED_RUNTIMES+=("codex")
   fi
   if [ ${#DETECTED_RUNTIMES[@]} -eq 0 ]; then
     # Nothing installed yet — default to opencode (will be installed).
@@ -338,8 +344,17 @@ source "$RUNTIME_FILE"
 if [ -z "$CHAT_BRIDGE" ]; then
   case "$RUNTIME" in
     claude-code) CHAT_BRIDGE="cc-connect" ;;
+    codex)       INSTALL_CHAT=false ;;
     *)                       CHAT_BRIDGE="kimaki" ;;
   esac
+fi
+
+if [ "$RUNTIME" = "codex" ] && [ "$INSTALL_CHAT" = true ]; then
+  if [ "$CHAT_BRIDGE_EXPLICIT" = true ]; then
+    error "Codex runtime does not currently support chat bridges; use --no-chat or omit --chat."
+  fi
+  INSTALL_CHAT=false
+  CHAT_BRIDGE=""
 fi
 
 # ============================================================================

--- a/tests/codex-runtime.sh
+++ b/tests/codex-runtime.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# tests/codex-runtime.sh — Regression coverage for the Codex runtime adapter.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+export SITE_PATH="$TMP/site"
+export DRY_RUN=false
+export IS_STUDIO=false
+export LOCAL_MODE=true
+export WP_ROOT_FLAG=
+export WP_CMD=wp
+export AGENT_SLUG=builder
+mkdir -p "$SITE_PATH/wp-content/mu-plugins"
+touch "$SITE_PATH/wp-config.php"
+mkdir -p "$SITE_PATH/wp-content/uploads/datamachine-files/shared"
+mkdir -p "$SITE_PATH/wp-content/uploads/datamachine-files/agents/builder"
+mkdir -p "$SITE_PATH/wp-content/uploads/datamachine-files/users/1"
+printf 'site context sentinel\n' > "$SITE_PATH/wp-content/uploads/datamachine-files/shared/SITE.md"
+printf 'rules context sentinel\n' > "$SITE_PATH/wp-content/uploads/datamachine-files/shared/RULES.md"
+printf 'soul context sentinel\n' > "$SITE_PATH/wp-content/uploads/datamachine-files/agents/builder/SOUL.md"
+printf 'user context sentinel\n' > "$SITE_PATH/wp-content/uploads/datamachine-files/users/1/USER.md"
+printf 'memory context sentinel\n' > "$SITE_PATH/wp-content/uploads/datamachine-files/agents/builder/MEMORY.md"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/runtime-signature.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/runtimes/codex.sh"
+
+UPDATED_ITEMS=()
+
+sync_homeboy_availability() { :; }
+wp_cmd() {
+  case "$1 $2 $3" in
+    "datamachine memory injectable-files")
+      cat <<'JSON'
+[
+  {"path":"wp-content/uploads/datamachine-files/shared/SITE.md"},
+  {"path":"wp-content/uploads/datamachine-files/shared/RULES.md"},
+  {"path":"wp-content/uploads/datamachine-files/agents/builder/SOUL.md"},
+  {"path":"wp-content/uploads/datamachine-files/users/1/USER.md"},
+  {"path":"wp-content/uploads/datamachine-files/agents/builder/MEMORY.md"}
+]
+JSON
+      return 0
+      ;;
+    "datamachine memory compose")
+      return 1
+      ;;
+  esac
+  return 1
+}
+
+FAILED=0
+pass() { echo "PASS  $1"; }
+fail() { echo "FAIL  $1"; FAILED=1; }
+
+if [ "$(runtime_skills_dir)" = "$SITE_PATH/.agents/skills" ]; then
+  pass "skills install target is project-local .agents/skills"
+else
+  fail "skills install target is project-local .agents/skills"
+fi
+
+runtime_discover_dm_paths
+
+cat > "$SITE_PATH/AGENTS.md" <<'EOF_AGENTS'
+# Existing shared instructions
+
+<!-- WP_CODING_AGENTS_CODEX_MEMORY_START -->
+## Data Machine Memory
+
+legacy inline block
+<!-- WP_CODING_AGENTS_CODEX_MEMORY_END -->
+EOF_AGENTS
+runtime_generate_instructions
+
+if grep -q "# Existing shared instructions" "$SITE_PATH/AGENTS.md" && ! grep -q "WP_CODING_AGENTS_CODEX_MEMORY_START" "$SITE_PATH/AGENTS.md"; then
+  pass "existing AGENTS.md preserved and legacy Codex memory block removed"
+else
+  fail "existing AGENTS.md preserved and legacy Codex memory block removed"
+fi
+
+if [ -f "$SITE_PATH/AGENTS.override.md" ] && grep -q "# Existing shared instructions" "$SITE_PATH/AGENTS.override.md" && grep -q "WP_CODING_AGENTS_CODEX_MEMORY_START" "$SITE_PATH/AGENTS.override.md"; then
+  pass "Codex AGENTS.override.md mirrors shared instructions and memory block"
+else
+  fail "Codex AGENTS.override.md mirrors shared instructions and memory block"
+fi
+
+if grep -q "site context sentinel" "$SITE_PATH/AGENTS.override.md" && grep -q "memory context sentinel" "$SITE_PATH/AGENTS.override.md"; then
+  pass "Codex override includes Data Machine memory file contents"
+else
+  fail "Codex override includes Data Machine memory file contents"
+fi
+
+rm -f "$SITE_PATH/AGENTS.md" "$SITE_PATH/AGENTS.override.md"
+runtime_generate_instructions
+
+if [ -f "$SITE_PATH/AGENTS.md" ] && [ -f "$SITE_PATH/AGENTS.override.md" ] && grep -q "WP-CLI: \`wp\`" "$SITE_PATH/AGENTS.md" && grep -q "WP_CODING_AGENTS_CODEX_MEMORY_START" "$SITE_PATH/AGENTS.override.md"; then
+  pass "AGENTS.md fallback template generated for Codex"
+else
+  fail "AGENTS.md fallback template generated for Codex"
+fi
+
+if [ ! -e "$SITE_PATH/CLAUDE.md" ]; then
+  pass "Codex runtime does not create CLAUDE.md"
+else
+  fail "Codex runtime does not create CLAUDE.md"
+fi
+
+if [ "$(runtime_start_cmd)" = "cd $SITE_PATH && codex" ]; then
+  pass "manual start command uses codex"
+else
+  fail "manual start command uses codex"
+fi
+
+_codex_register_runtime_signature
+RUNTIME_MU="$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-runtimes.php"
+if grep -q "BEGIN runtime:codex" "$RUNTIME_MU" && grep -q "CODEX_THREAD_ID" "$RUNTIME_MU"; then
+  pass "Codex runtime signature registered"
+else
+  fail "Codex runtime signature registered"
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "OK: codex runtime"
+else
+  echo "FAILED: codex runtime"
+  exit 1
+fi

--- a/tests/setup-profile-compiler.mjs
+++ b/tests/setup-profile-compiler.mjs
@@ -65,6 +65,22 @@ function compile(profile) {
 {
   const plan = compile({
     install_target: "local",
+    target: { wordpress_path: "/Users/chubes/Studio/site" },
+    runtime: { selection: "codex" },
+    chat_bridge: { selection: "auto" },
+    overlays: {},
+    agent: {},
+  })
+
+  assert.equal(plan.commands.dry_run, "EXISTING_WP=/Users/chubes/Studio/site ./setup.sh --local --runtime codex --dry-run")
+  assert.equal(plan.summary.bridge_axis, "none")
+  assert.ok(plan.verification.overlays.includes("verify-runtime-codex"))
+  assert.ok(plan.verification.overlays.includes("verify-bridge-none"))
+}
+
+{
+  const plan = compile({
+    install_target: "local",
     target: { wordpress_path: "/home/chris/site" },
     runtime: { selection: "multiple", runtimes: ["opencode", "claude-code"] },
     chat_bridge: { selection: "none" },

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -264,7 +264,8 @@ fi
 
 # Auto-detect runtime(s). Same model as setup.sh: DETECTED_RUNTIMES is the
 # full list (drives multi-runtime skills install); RUNTIME is the primary
-# (first-match cascade). Explicit --runtime narrows to a single runtime.
+# (first-match cascade: claude-code > opencode > codex). Explicit --runtime
+# narrows to a single runtime.
 if [ -n "$RUNTIME" ]; then
   DETECTED_RUNTIMES=("$RUNTIME")
 else
@@ -273,6 +274,9 @@ else
   fi
   if command -v opencode &>/dev/null; then
     DETECTED_RUNTIMES+=("opencode")
+  fi
+  if command -v codex &>/dev/null; then
+    DETECTED_RUNTIMES+=("codex")
   fi
   if [ ${#DETECTED_RUNTIMES[@]} -eq 0 ]; then
     warn "No runtime binary found — defaulting to opencode"
@@ -296,7 +300,13 @@ detect_environment
 # bridge_detect_vps for the full probe order (launchd plists + command -v
 # on local; systemd unit files on VPS). Priority order is set by
 # BRIDGE_DETECTION_ORDER in _dispatch.sh: kimaki > cc-connect > telegram.
-if [ "$LOCAL_MODE" = true ]; then
+#
+# Codex has no managed bridge in wp-coding-agents today. An explicit
+# `--runtime codex` upgrade should sync Codex-owned files only, not pick up an
+# unrelated local Kimaki/cc-connect install and rewrite its config.
+if [ "$RUNTIME" = "codex" ]; then
+  CHAT_BRIDGE=""
+elif [ "$LOCAL_MODE" = true ]; then
   CHAT_BRIDGE=$(bridge_detect_local)
 else
   CHAT_BRIDGE=$(bridge_detect_vps)
@@ -666,7 +676,9 @@ regenerate_agents_md() {
     echo -e "${BLUE}[dry-run]${NC} Would backup $AGENTS_MD → $BACKUP"
     echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy AGENTS.md CLI guidance mu-plugin"
     echo -e "${BLUE}[dry-run]${NC} Would run: $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG"
-    echo -e "${BLUE}[dry-run]${NC} Would symlink $CLAUDE_MD → AGENTS.md (Claude-model context)"
+    if _runtime_detected opencode; then
+      echo -e "${BLUE}[dry-run]${NC} Would symlink $CLAUDE_MD → AGENTS.md (Claude-model context)"
+    fi
     return 0
   fi
 
@@ -703,13 +715,13 @@ regenerate_agents_md() {
     fi
   fi
 
-  # Symlink CLAUDE.md → AGENTS.md so Claude-model sessions get the same DM context.
+  # Symlink CLAUDE.md → AGENTS.md so Claude-model OpenCode sessions get the same DM context.
   # OpenCode reads both filenames from the cwd glob (AGENTS.md, CLAUDE.md, CONTEXT.md),
   # Claude Code reads only CLAUDE.md. Symlink keeps both runtimes covered without
   # duplicating content or risking drift on AGENTS.md regeneration. Relative target
   # ensures the symlink survives directory moves.
   # See: Extra-Chill/wp-coding-agents#108
-  if [ -f "$AGENTS_MD" ]; then
+  if [ -f "$AGENTS_MD" ] && _runtime_detected opencode; then
     # Skip if CLAUDE.md exists as a regular file (e.g. claude-code runtime
     # generates its own CLAUDE.md from a template — don't clobber it).
     if [ -L "$CLAUDE_MD" ] || [ ! -e "$CLAUDE_MD" ]; then
@@ -719,6 +731,15 @@ regenerate_agents_md() {
       log "  CLAUDE.md exists as a regular file — leaving it alone (runtime-managed)"
     fi
   fi
+}
+
+_runtime_detected() {
+  local candidate="$1"
+  local runtime
+  for runtime in "${DETECTED_RUNTIMES[@]:-}"; do
+    [ "$runtime" = "$candidate" ] && return 0
+  done
+  [ "${RUNTIME:-}" = "$candidate" ]
 }
 
 # ============================================================================
@@ -838,6 +859,54 @@ sync_claude_code_runtime() {
   runtime_install_hooks
 }
 
+sync_runtime_signature() {
+  _run_filter_active patch || return 0
+
+  _runtime_detected codex || return 0
+
+  local codex_runtime_file="$SCRIPT_DIR/runtimes/codex.sh"
+  if ! declare -F _codex_register_runtime_signature >/dev/null; then
+    # shellcheck disable=SC1090
+    source "$codex_runtime_file"
+  fi
+
+  if declare -F _codex_register_runtime_signature >/dev/null; then
+    log "Phase 5c: Syncing Codex runtime signature..."
+    _codex_register_runtime_signature
+  fi
+
+  if [ "$RUNTIME" != "codex" ] && [ -n "${RUNTIME_FILE:-}" ] && [ -f "$RUNTIME_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$RUNTIME_FILE"
+  fi
+}
+
+sync_runtime_instructions() {
+  _run_filter_active agents-md || return 0
+
+  if _runtime_detected codex; then
+    local codex_runtime_file="$SCRIPT_DIR/runtimes/codex.sh"
+    if [ "$RUNTIME" != "codex" ]; then
+      # shellcheck disable=SC1090
+      source "$codex_runtime_file"
+    fi
+    if declare -F runtime_sync_instructions >/dev/null; then
+      log "Phase 5d: Syncing Codex runtime instructions..."
+      runtime_sync_instructions
+    fi
+    if [ "$RUNTIME" != "codex" ] && [ -n "${RUNTIME_FILE:-}" ] && [ -f "$RUNTIME_FILE" ]; then
+      # shellcheck disable=SC1090
+      source "$RUNTIME_FILE"
+    fi
+    return 0
+  fi
+
+  if declare -F runtime_sync_instructions >/dev/null; then
+    log "Phase 5d: Syncing $RUNTIME runtime instructions..."
+    runtime_sync_instructions
+  fi
+}
+
 # ============================================================================
 # Phase 6: Smart systemd update (merges host-specific Environment= lines)
 #   Dispatches to the active bridge's bridge_update_systemd hook (and
@@ -896,7 +965,7 @@ remove_legacy_opencode_wrapper_phase() {
   _run_filter_active patch || return 0
 
   if [ "$RUNTIME" != "opencode" ] && [ "$CHAT_BRIDGE" != "kimaki" ]; then
-    log "Phase 7: Skipping (runtime is $RUNTIME and chat bridge is $CHAT_BRIDGE)"
+    log "Phase 7: Skipping (runtime is $RUNTIME and chat bridge is ${CHAT_BRIDGE:-none})"
     return 0
   fi
 
@@ -916,6 +985,14 @@ remove_legacy_opencode_wrapper_phase() {
   # actually differs from what is already on disk.
   if declare -F _opencode_register_runtime_signature >/dev/null; then
     _opencode_register_runtime_signature
+  fi
+
+  # This phase may source runtimes/opencode.sh for helper access even when the
+  # primary runtime is something else. Restore the selected runtime functions
+  # so summary/verification paths still come from the active runtime.
+  if [ "$RUNTIME" != "opencode" ] && [ -n "${RUNTIME_FILE:-}" ] && [ -f "$RUNTIME_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$RUNTIME_FILE"
   fi
 }
 
@@ -1040,6 +1117,8 @@ ai_gateway_configure_opencode
 sync_skills
 regenerate_agents_md
 sync_claude_code_runtime
+sync_runtime_signature
+sync_runtime_instructions
 update_chat_bridge_systemd
 update_chat_bridge_launchd
 remove_legacy_opencode_wrapper_phase


### PR DESCRIPTION
## Summary
- add a Codex runtime adapter with project-local skills, CODEX_THREAD_ID attribution, and terminal start command
- generate Codex-specific AGENTS.override.md from shared AGENTS.md plus Data Machine memory so OpenCode does not double-load memory
- update setup/upgrade detection, operator docs, setup profile compiler, and regression tests

## Verification
- bash -n setup.sh upgrade.sh runtimes/codex.sh tests/codex-runtime.sh
- bash tests/codex-runtime.sh
- bash tests/runtime-signature.sh
- node tests/setup-profile-compiler.mjs
- ./setup.sh --help
- EXISTING_WP=/private/tmp/wpca-codex-dryrun ./setup.sh --local --runtime codex --dry-run
- EXISTING_WP=/private/tmp/wpca-codex-dryrun ./upgrade.sh --local --runtime codex --dry-run --skip-plugins
- git diff --check