### PR TITLE
Add OpenCode Claude Code auth

### DIFF
--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -44,6 +44,7 @@ CLI usage:
     --runtime <opencode|claude-code> \
     --chat-bridge <kimaki|cc-connect|telegram|none> \
     [--kimaki-plugins-dir <path>] \
+    [--claude-code-auth-plugin <path>] \
     [--additive | --apply] \
     [--backup-suffix <timestamp>]
 
@@ -77,6 +78,7 @@ def expected_plugins(
     runtime: str,
     chat_bridge: str,
     kimaki_plugins_dir: str,
+    claude_code_auth_plugin: str = "",
 ) -> List[str]:
     """Return the `plugin` array wp-coding-agents setup would produce today.
 
@@ -100,6 +102,9 @@ def expected_plugins(
     if chat_bridge == "kimaki":
         plugins.append(f"{kimaki_plugins_dir}/dm-context-filter.ts")
         plugins.append(f"{kimaki_plugins_dir}/dm-agent-sync.ts")
+
+    if claude_code_auth_plugin:
+        plugins.append(claude_code_auth_plugin)
 
     return plugins
 
@@ -361,6 +366,11 @@ def main() -> int:
         default="/opt/kimaki-config/plugins",
         help="Directory where DM plugins live (VPS default: /opt/kimaki-config/plugins)",
     )
+    parser.add_argument(
+        "--claude-code-auth-plugin",
+        default="",
+        help="Optional managed OpenCode Claude Code OAuth auth plugin path",
+    )
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(
         "--apply",
@@ -426,6 +436,7 @@ def main() -> int:
         runtime=args.runtime,
         chat_bridge=args.chat_bridge,
         kimaki_plugins_dir=args.kimaki_plugins_dir.rstrip("/"),
+        claude_code_auth_plugin=args.claude_code_auth_plugin,
     )
 
     current: List[str] = list(data.get("plugin", []))

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -14,6 +14,44 @@ runtime_install() {
   _opencode_register_runtime_signature
 }
 
+opencode_claude_code_auth_enabled() {
+  [ "${WITH_CLAUDE_CODE_AUTH:-false}" = true ] || return 1
+  [ "${RUNTIME:-}" = "opencode" ] && return 0
+
+  local runtime
+  for runtime in "${DETECTED_RUNTIMES[@]:-}"; do
+    [ "$runtime" = "opencode" ] && return 0
+  done
+  return 1
+}
+
+opencode_claude_code_auth_plugins_dir() {
+  printf '%s/.opencode/plugins' "$SITE_PATH"
+}
+
+opencode_claude_code_auth_plugin_path() {
+  printf '%s/claude-code-auth.ts' "$(opencode_claude_code_auth_plugins_dir)"
+}
+
+opencode_install_claude_code_auth_plugin() {
+  opencode_claude_code_auth_enabled || return 0
+
+  local plugins_dir plugin_path source_path
+  plugins_dir="$(opencode_claude_code_auth_plugins_dir)"
+  plugin_path="$(opencode_claude_code_auth_plugin_path)"
+  source_path="$SCRIPT_DIR/runtimes/opencode/plugins/claude-code-auth.ts"
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would install Claude Code auth OpenCode plugin at $plugin_path"
+    return 0
+  fi
+
+  mkdir -p "$plugins_dir"
+  cp "$source_path" "$plugin_path"
+  chmod 644 "$plugin_path"
+  UPDATED_ITEMS+=("OpenCode Claude Code auth plugin ($plugin_path)")
+}
+
 # _opencode_register_runtime_signature
 #
 # Publish opencode's worktree session-attribution env-var contract for the
@@ -169,6 +207,8 @@ runtime_generate_config() {
     fi
   fi
 
+  opencode_install_claude_code_auth_plugin
+
   # On existing opencode.json, delegate to the repair helper in --additive
   # mode. This adds managed plugin entries the user is missing and applies
   # the prompt → instructions migration (fixes Anthropic Claude Max OAuth,
@@ -191,17 +231,16 @@ runtime_generate_config() {
     OPENCODE_JSON="$OPENCODE_JSON,\n  \"small_model\": \"${OPENCODE_SMALL_MODEL}\""
   fi
 
-  # OpenCode plugins. wp-coding-agents only manages plugins it owns end to
-  # end: dm-context-filter.ts and dm-agent-sync.ts on Kimaki bridges. The sync
-  # plugin refreshes composed memory files without mutating config.agent slots.
-  # opencode-claude-auth plugin is intentionally NOT installed on any bridge:
-  # Kimaki ships a built-in AnthropicAuthPlugin and non-kimaki bridges use
-  # opencode's native auth flow (`opencode auth login anthropic`). See
-  # Extra-Chill/wp-coding-agents#117.
+  # OpenCode plugins. The Data Machine prompt/memory plugins are managed on
+  # Kimaki bridges. Claude Code OAuth auth is an explicit OpenCode runtime
+  # opt-in so direct opencode sessions can use Claude Pro/Max subscription auth.
   OPENCODE_PLUGINS=""
   if [ "$CHAT_BRIDGE" = "kimaki" ]; then
     OPENCODE_PLUGINS="${OPENCODE_PLUGINS}\n    \"${KIMAKI_PLUGINS_DIR}/dm-context-filter.ts\","
     OPENCODE_PLUGINS="${OPENCODE_PLUGINS}\n    \"${KIMAKI_PLUGINS_DIR}/dm-agent-sync.ts\","
+  fi
+  if opencode_claude_code_auth_enabled; then
+    OPENCODE_PLUGINS="${OPENCODE_PLUGINS}\n    \"$(opencode_claude_code_auth_plugin_path)\","
   fi
 
   if [ -n "$OPENCODE_PLUGINS" ]; then
@@ -273,6 +312,8 @@ _runtime_repair_opencode_json_additive() {
 
   local BRIDGE_ARG="${CHAT_BRIDGE:-none}"
   local PLUGINS_DIR="${KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
+  local CLAUDE_CODE_AUTH_PLUGIN=""
+  local claude_code_auth_args=()
   local SUFFIX
   SUFFIX="$(date +%Y%m%d-%H%M%S)"
   local MANAGED_INSTRUCTIONS_FILE=""
@@ -281,6 +322,10 @@ _runtime_repair_opencode_json_additive() {
     MANAGED_INSTRUCTIONS_FILE=$(mktemp)
     printf '%s\n' "$DM_AGENT_FILES" > "$MANAGED_INSTRUCTIONS_FILE"
     managed_args=(--managed-instructions-file "$MANAGED_INSTRUCTIONS_FILE")
+  fi
+  if opencode_claude_code_auth_enabled; then
+    CLAUDE_CODE_AUTH_PLUGIN="$(opencode_claude_code_auth_plugin_path)"
+    claude_code_auth_args=(--claude-code-auth-plugin "$CLAUDE_CODE_AUTH_PLUGIN")
   fi
 
   log "opencode.json already exists — running additive repair..."
@@ -291,6 +336,7 @@ _runtime_repair_opencode_json_additive() {
     --runtime opencode \
     --chat-bridge "$BRIDGE_ARG" \
     --kimaki-plugins-dir "$PLUGINS_DIR" \
+    "${claude_code_auth_args[@]}" \
     "${managed_args[@]}" \
     --additive \
     --backup-suffix "$SUFFIX" 2>&1) && repair_rc=0 || repair_rc=$?

--- a/runtimes/opencode/plugins/claude-code-auth.ts
+++ b/runtimes/opencode/plugins/claude-code-auth.ts
@@ -1,0 +1,574 @@
+// claude-code-auth.ts - OpenCode Anthropic auth via Claude Code OAuth.
+//
+// Self-contained for direct OpenCode installs. It mirrors Kimaki's proven
+// Claude Code OAuth/request-shaping path without loading Kimaki bridge plugins.
+
+import type { Plugin } from "@opencode-ai/plugin";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { homedir } from "node:os";
+import path from "node:path";
+import * as fs from "node:fs/promises";
+
+type OAuthStored = { type: "oauth"; refresh: string; access: string; expires: number };
+type OAuthSuccess = { type: "success"; refresh: string; access: string; expires: number };
+type CallbackResult = { code: string; state: string };
+type AccountRecord = OAuthStored & { addedAt: number; lastUsed: number };
+type AccountStore = { version: number; activeIndex: number; accounts: AccountRecord[] };
+
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+const CALLBACK_PORT = 53692;
+const CALLBACK_PATH = "/callback";
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+const SCOPES = "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+const OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
+const CLAUDE_CODE_VERSION = "2.1.75";
+const CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude.";
+const OPENCODE_IDENTITY = "You are OpenCode, the best coding agent on the planet.";
+const SUBAGENT_MODEL_IDENTITY = "You are powered by the model named";
+const ENV_CLOSE_TAG = "</env>";
+const CLAUDE_CODE_BETA = "claude-code-20250219";
+const OAUTH_BETA = "oauth-2025-04-20";
+const FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
+const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
+
+const ANTHROPIC_HOSTS = new Set(["api.anthropic.com", "claude.ai", "console.anthropic.com", "platform.claude.com"]);
+const TOOL_NAMES: Record<string, string> = {
+  bash: "Bash",
+  edit: "Edit",
+  glob: "Glob",
+  grep: "Grep",
+  question: "AskUserQuestion",
+  read: "Read",
+  skill: "Skill",
+  task: "Task",
+  todowrite: "TodoWrite",
+  webfetch: "WebFetch",
+  websearch: "WebSearch",
+  write: "Write",
+};
+
+function authFilePath() {
+  if (process.env.XDG_DATA_HOME) return path.join(process.env.XDG_DATA_HOME, "opencode", "auth.json");
+  return path.join(homedir(), ".local", "share", "opencode", "auth.json");
+}
+
+function accountsFilePath() {
+  if (process.env.XDG_DATA_HOME) return path.join(process.env.XDG_DATA_HOME, "opencode", "anthropic-oauth-accounts.json");
+  return path.join(homedir(), ".local", "share", "opencode", "anthropic-oauth-accounts.json");
+}
+
+async function readJson<T>(filePath: string, fallback: T): Promise<T> {
+  try { return JSON.parse(await fs.readFile(filePath, "utf8")) as T; } catch { return fallback; }
+}
+
+async function writeJson(filePath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2), "utf8");
+  await fs.chmod(filePath, 0o600);
+}
+
+async function writeAnthropicAuth(auth: OAuthStored) {
+  const file = authFilePath();
+  const data = await readJson<Record<string, unknown>>(file, {});
+  data.anthropic = auth;
+  await writeJson(file, data);
+}
+
+function normalizeAccountStore(input: Partial<AccountStore> | null | undefined): AccountStore {
+  const accounts = Array.isArray(input?.accounts)
+    ? input.accounts.filter((account): account is AccountRecord => {
+      return !!account && account.type === "oauth" && typeof account.refresh === "string" && typeof account.access === "string" && typeof account.expires === "number" && typeof account.addedAt === "number" && typeof account.lastUsed === "number";
+    })
+    : [];
+  const rawIndex = typeof input?.activeIndex === "number" ? Math.floor(input.activeIndex) : 0;
+  const activeIndex = accounts.length === 0 ? 0 : ((rawIndex % accounts.length) + accounts.length) % accounts.length;
+  return { version: 1, activeIndex, accounts };
+}
+
+async function loadAccountStore() {
+  return normalizeAccountStore(await readJson<Partial<AccountStore> | null>(accountsFilePath(), null));
+}
+
+async function saveAccountStore(store: AccountStore) {
+  await writeJson(accountsFilePath(), normalizeAccountStore(store));
+}
+
+function findCurrentAccountIndex(store: AccountStore, auth: OAuthStored) {
+  if (!store.accounts.length) return 0;
+  const byRefresh = store.accounts.findIndex((account) => account.refresh === auth.refresh);
+  if (byRefresh >= 0) return byRefresh;
+  const byAccess = store.accounts.findIndex((account) => account.access === auth.access);
+  if (byAccess >= 0) return byAccess;
+  return store.activeIndex;
+}
+
+function upsertAccount(store: AccountStore, auth: OAuthStored, now = Date.now()) {
+  const index = store.accounts.findIndex((account) => account.refresh === auth.refresh || account.access === auth.access);
+  const nextAccount: AccountRecord = { ...auth, addedAt: now, lastUsed: now };
+  if (index < 0) {
+    store.accounts.push(nextAccount);
+    store.activeIndex = store.accounts.length - 1;
+    return;
+  }
+  const existing = store.accounts[index];
+  store.accounts[index] = { ...nextAccount, addedAt: existing?.addedAt ?? now };
+  store.activeIndex = index;
+}
+
+async function rememberAnthropicOAuth(auth: OAuthStored) {
+  const store = await loadAccountStore();
+  upsertAccount(store, auth);
+  await saveAccountStore(store);
+}
+
+async function rotateAnthropicAccount(auth: OAuthStored) {
+  const store = await loadAccountStore();
+  if (store.accounts.length < 2) return undefined;
+
+  const currentIndex = findCurrentAccountIndex(store, auth);
+  const nextIndex = (currentIndex + 1) % store.accounts.length;
+  const nextAccount = store.accounts[nextIndex];
+  if (!nextAccount) return undefined;
+
+  nextAccount.lastUsed = Date.now();
+  store.activeIndex = nextIndex;
+  await saveAccountStore(store);
+  const nextAuth: OAuthStored = {
+    type: "oauth",
+    refresh: nextAccount.refresh,
+    access: nextAccount.access,
+    expires: nextAccount.expires,
+  };
+  await writeAnthropicAuth(nextAuth);
+  return nextAuth;
+}
+
+function shouldRotateAuth(status: number, bodyText: string) {
+  const haystack = bodyText.toLowerCase();
+  if (status === 429 || status === 401 || status === 403) return true;
+  return haystack.includes("rate_limit") || haystack.includes("rate limit") || haystack.includes("usage limit") || haystack.includes("usage_limit") || haystack.includes("usage_limit_reached") || haystack.includes("usage_not_included") || haystack.includes("invalid api key") || haystack.includes("authentication_error") || haystack.includes("permission_error");
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+async function generatePKCE() {
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64urlEncode(verifierBytes);
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return { verifier, challenge: base64urlEncode(new Uint8Array(hash)) };
+}
+
+async function requestText(url: string, options: { method: string; headers?: Record<string, string>; body?: string }) {
+  return new Promise<string>((resolve, reject) => {
+    const payload = JSON.stringify({ url, ...options });
+    const child = spawn("node", ["-e", `
+const input = JSON.parse(process.argv[1]);
+(async () => {
+  const response = await fetch(input.url, {
+    method: input.method,
+    headers: input.headers,
+    body: input.body,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    console.error(JSON.stringify({ status: response.status, body: text }));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exit(1);
+});
+`.trim(), payload], { stdio: ["ignore", "pipe", "pipe"] });
+
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`Request timed out. url=${url}`));
+    }, 30_000);
+
+    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        try {
+          const parsed = JSON.parse(stderr.trim()) as { status?: number; body?: string };
+          if (typeof parsed.status === "number") {
+            reject(new Error(`HTTP ${parsed.status} from ${url}: ${parsed.body ?? ""}`));
+            return;
+          }
+        } catch {}
+        reject(new Error(stderr.trim() || `Node helper exited with code ${code}`));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+async function postJson(url: string, body: Record<string, string | number>) {
+  const requestBody = JSON.stringify(body);
+  const text = await requestText(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Length": String(Buffer.byteLength(requestBody)),
+      "Content-Type": "application/json",
+    },
+    body: requestBody,
+  });
+  return JSON.parse(text) as unknown;
+}
+
+function parseTokenResponse(json: unknown) {
+  const data = json as { access_token?: string; refresh_token?: string; expires_in?: number };
+  if (!data.access_token || !data.refresh_token) throw new Error(`Invalid token response: ${JSON.stringify(json)}`);
+  return {
+    access: data.access_token,
+    refresh: data.refresh_token,
+    expires: Date.now() + (data.expires_in ?? 3600) * 1000 - 5 * 60 * 1000,
+  };
+}
+
+async function exchangeAuthorizationCode(code: string, state: string, verifier: string): Promise<OAuthSuccess> {
+  const data = parseTokenResponse(await postJson(TOKEN_URL, {
+    grant_type: "authorization_code",
+    client_id: CLIENT_ID,
+    code,
+    state,
+    redirect_uri: REDIRECT_URI,
+    code_verifier: verifier,
+  }));
+  return { type: "success", ...data };
+}
+
+async function refreshAnthropicToken(refreshToken: string): Promise<OAuthStored> {
+  const data = parseTokenResponse(await postJson(TOKEN_URL, {
+    grant_type: "refresh_token",
+    client_id: CLIENT_ID,
+    refresh_token: refreshToken,
+  }));
+  return { type: "oauth", ...data };
+}
+
+async function startCallbackServer(expectedState: string) {
+  return new Promise<{ server: Server; cancelWait: () => void; waitForCode: () => Promise<CallbackResult | null> }>((resolve, reject) => {
+    let settle: ((value: CallbackResult | null) => void) | undefined;
+    let settled = false;
+    const waitPromise = new Promise<CallbackResult | null>((res) => {
+      settle = (value) => { if (!settled) { settled = true; res(value); } };
+    });
+    const server = createServer((req, res) => {
+      try {
+        const url = new URL(req.url || "", "http://localhost");
+        if (url.pathname !== CALLBACK_PATH) { res.writeHead(404).end("Not found"); return; }
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+        const error = url.searchParams.get("error");
+        if (error || !code || !state || state !== expectedState) { res.writeHead(400).end("Authentication failed"); return; }
+        res.writeHead(200, { "Content-Type": "text/plain" }).end("Authentication successful. You can close this window.");
+        settle?.({ code, state });
+      } catch { res.writeHead(500).end("Internal error"); }
+    });
+    server.once("error", reject);
+    server.listen(CALLBACK_PORT, "127.0.0.1", () => resolve({ server, cancelWait: () => settle?.(null), waitForCode: () => waitPromise }));
+  });
+}
+
+function closeServer(server: Server) {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function beginAuthorizationFlow() {
+  const pkce = await generatePKCE();
+  const callbackServer = await startCallbackServer(pkce.verifier);
+  const authParams = new URLSearchParams({
+    code: "true",
+    client_id: CLIENT_ID,
+    response_type: "code",
+    redirect_uri: REDIRECT_URI,
+    scope: SCOPES,
+    code_challenge: pkce.challenge,
+    code_challenge_method: "S256",
+    state: pkce.verifier,
+  });
+  return { url: `https://claude.ai/oauth/authorize?${authParams.toString()}`, verifier: pkce.verifier, callbackServer };
+}
+
+function parseManualInput(input: string): CallbackResult {
+  try {
+    const url = new URL(input);
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    if (code) return { code, state: state || "" };
+  } catch {}
+  if (input.includes("#")) {
+    const [code = "", state = ""] = input.split("#", 2);
+    return { code, state };
+  }
+  if (input.includes("code=")) {
+    const params = new URLSearchParams(input);
+    const code = params.get("code");
+    if (code) return { code, state: params.get("state") || "" };
+  }
+  return { code: input, state: "" };
+}
+
+async function waitForCallback(callbackServer: Awaited<ReturnType<typeof startCallbackServer>>, manualInput?: string): Promise<CallbackResult> {
+  try {
+    const quick = await Promise.race([callbackServer.waitForCode(), new Promise<null>((resolve) => setTimeout(() => resolve(null), 50))]);
+    if (quick?.code) return quick;
+    const trimmed = manualInput?.trim();
+    if (trimmed) return parseManualInput(trimmed);
+    const result = await Promise.race([callbackServer.waitForCode(), new Promise<null>((resolve) => setTimeout(() => resolve(null), OAUTH_TIMEOUT_MS))]);
+    if (!result?.code) throw new Error("Timed out waiting for OAuth callback");
+    return result;
+  } finally {
+    callbackServer.cancelWait();
+    await closeServer(callbackServer.server);
+  }
+}
+
+function buildAuthorizeHandler() {
+  return async () => {
+    const auth = await beginAuthorizationFlow();
+    let pendingAuthResult: Promise<OAuthSuccess | { type: "failed" }> | undefined;
+    const isRemote = Boolean(process.env.KIMAKI || process.env.WP_CODING_AGENTS_REMOTE_AUTH);
+    const finalize = async (result: CallbackResult) => {
+      const creds = await exchangeAuthorizationCode(result.code, result.state || auth.verifier, auth.verifier);
+      const oauth: OAuthStored = { type: "oauth", refresh: creds.refresh, access: creds.access, expires: creds.expires };
+      await writeAnthropicAuth(oauth);
+      await rememberAnthropicOAuth(oauth);
+      return creds;
+    };
+    if (!isRemote) {
+      return {
+        url: auth.url,
+        instructions: "Complete login in your browser. OpenCode will catch the localhost callback automatically.",
+        method: "auto" as const,
+        callback: async () => {
+          pendingAuthResult ??= (async () => { try { return await finalize(await waitForCallback(auth.callbackServer)); } catch { return { type: "failed" as const }; } })();
+          return pendingAuthResult;
+        },
+      };
+    }
+    return {
+      url: auth.url,
+      instructions: "Complete login in your browser, then paste the final redirect URL from the address bar here. Pasting just the authorization code also works.",
+      method: "code" as const,
+      callback: async (input: string) => {
+        pendingAuthResult ??= (async () => { try { return await finalize(await waitForCallback(auth.callbackServer, input)); } catch { return { type: "failed" as const }; } })();
+        return pendingAuthResult;
+      },
+    };
+  };
+}
+
+function replaceBlockWithCompactEnv(text: string, startIdx: number, endIdx: number) {
+  const strippedBlock = text.slice(startIdx, endIdx);
+  const cwd = strippedBlock.match(/Working directory:\s*(.+)/)?.[1]?.trim() || strippedBlock.match(/<cwd>([^<]+)<\/cwd>/)?.[1] || process.cwd();
+  return `${text.slice(0, startIdx)}\n<environment>\n<cwd>${cwd}</cwd>\n</environment>\nRead, write, and edit files under ${cwd}.\n\n${text.slice(endIdx)}`;
+}
+
+function sanitizeSystemText(text: string) {
+  const startIdx = text.indexOf(OPENCODE_IDENTITY);
+  if (startIdx !== -1) {
+    const envCloseIdx = text.indexOf(ENV_CLOSE_TAG, startIdx);
+    if (envCloseIdx === -1) return text;
+    const endIdx = envCloseIdx + ENV_CLOSE_TAG.length;
+    return replaceBlockWithCompactEnv(text, startIdx, text[endIdx] === "\n" ? endIdx + 1 : endIdx);
+  }
+  const subagentIdx = text.indexOf(SUBAGENT_MODEL_IDENTITY);
+  if (subagentIdx !== -1) {
+    const envCloseIdx = text.indexOf(ENV_CLOSE_TAG, subagentIdx);
+    if (envCloseIdx === -1) return text;
+    const endIdx = envCloseIdx + ENV_CLOSE_TAG.length;
+    return replaceBlockWithCompactEnv(text, subagentIdx, text[endIdx] === "\n" ? endIdx + 1 : endIdx);
+  }
+  return text;
+}
+
+function mapSystemPart(part: unknown): unknown {
+  if (typeof part === "string") return { type: "text", text: sanitizeSystemText(part) };
+  if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part && typeof part.text === "string") {
+    return { ...part, text: sanitizeSystemText(part.text) };
+  }
+  return part;
+}
+
+function prependClaudeCodeIdentity(system: unknown) {
+  const identityBlock = { type: "text", text: CLAUDE_CODE_IDENTITY };
+  if (typeof system === "undefined") return [identityBlock];
+  if (typeof system === "string") return [identityBlock, { type: "text", text: sanitizeSystemText(system) }];
+  if (!Array.isArray(system)) return [identityBlock, system];
+  const sanitized = system.map(mapSystemPart);
+  const first = sanitized[0];
+  if (first && typeof first === "object" && "type" in first && first.type === "text" && "text" in first && first.text === CLAUDE_CODE_IDENTITY) return sanitized;
+  return [identityBlock, ...sanitized];
+}
+
+function rewriteRequestPayload(body: string | undefined) {
+  if (!body) return { body, modelId: undefined, reverseToolNameMap: new Map<string, string>() };
+  try {
+    const payload = JSON.parse(body) as Record<string, unknown>;
+    const modelId = typeof payload.model === "string" ? payload.model : undefined;
+    const reverseToolNameMap = new Map<string, string>();
+    if (Array.isArray(payload.tools)) {
+      payload.tools = payload.tools.map((tool) => {
+        if (!tool || typeof tool !== "object") return tool;
+        const name = (tool as { name?: unknown }).name;
+        if (typeof name !== "string") return tool;
+        const mapped = TOOL_NAMES[name.toLowerCase()] ?? name;
+        reverseToolNameMap.set(mapped, name);
+        return { ...(tool as Record<string, unknown>), name: mapped };
+      });
+    }
+    payload.system = prependClaudeCodeIdentity(payload.system);
+
+    if (payload.tool_choice && typeof payload.tool_choice === "object" && (payload.tool_choice as { type?: unknown }).type === "tool") {
+      const name = (payload.tool_choice as { name?: unknown }).name;
+      if (typeof name === "string") {
+        payload.tool_choice = { ...(payload.tool_choice as Record<string, unknown>), name: TOOL_NAMES[name.toLowerCase()] ?? name };
+      }
+    }
+
+    if (Array.isArray(payload.messages)) {
+      payload.messages = payload.messages.map((message) => {
+        if (!message || typeof message !== "object") return message;
+        const content = (message as { content?: unknown }).content;
+        if (!Array.isArray(content)) return message;
+        return {
+          ...(message as Record<string, unknown>),
+          content: content.map((block) => {
+            if (!block || typeof block !== "object") return block;
+            const item = block as { type?: unknown; name?: unknown };
+            if (item.type !== "tool_use" || typeof item.name !== "string") return block;
+            return { ...(block as Record<string, unknown>), name: TOOL_NAMES[item.name.toLowerCase()] ?? item.name };
+          }),
+        };
+      });
+    }
+
+    return { body: JSON.stringify(payload), modelId, reverseToolNameMap };
+  } catch { return { body, modelId: undefined, reverseToolNameMap: new Map<string, string>() }; }
+}
+
+function wrapResponseStream(response: Response, reverseToolNameMap: Map<string, string>) {
+  if (!response.body || reverseToolNameMap.size === 0) return response;
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let carry = "";
+  const transform = (text: string) => text.replace(/"name"\s*:\s*"([^"]+)"/g, (full, name: string) => {
+    const original = reverseToolNameMap.get(name);
+    return original ? full.replace(`"${name}"`, `"${original}"`) : full;
+  });
+
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        const finalText = carry + decoder.decode();
+        if (finalText) controller.enqueue(encoder.encode(transform(finalText)));
+        controller.close();
+        return;
+      }
+      carry += decoder.decode(value, { stream: true });
+      if (carry.length <= 256) return;
+      const output = carry.slice(0, -256);
+      carry = carry.slice(-256);
+      controller.enqueue(encoder.encode(transform(output)));
+    },
+    async cancel(reason) { await reader.cancel(reason); },
+  });
+
+  return new Response(stream, { status: response.status, statusText: response.statusText, headers: response.headers });
+}
+
+function getRequiredBetas(modelId: string | undefined) {
+  const betas = [CLAUDE_CODE_BETA, OAUTH_BETA, FINE_GRAINED_TOOL_STREAMING_BETA];
+  if (!modelId?.includes("opus-4-6") && !modelId?.includes("opus-4.6") && !modelId?.includes("sonnet-4-6") && !modelId?.includes("sonnet-4.6")) betas.push(INTERLEAVED_THINKING_BETA);
+  return betas;
+}
+
+function mergeBetas(existing: string | null, required: string[]) {
+  return [...new Set([...required, ...(existing || "").split(",").map((s) => s.trim()).filter(Boolean)])].join(",");
+}
+
+async function getFreshOAuth(getAuth: () => Promise<OAuthStored | { type: string }>) {
+  const auth = await getAuth();
+  if (auth.type !== "oauth") return undefined;
+  const oauth = auth as OAuthStored;
+  if (oauth.access && oauth.expires > Date.now()) return oauth;
+  const refreshed = await refreshAnthropicToken(oauth.refresh);
+  await writeAnthropicAuth(refreshed);
+  const store = await loadAccountStore();
+  if (store.accounts.length > 0) {
+    upsertAccount(store, refreshed);
+    await saveAccountStore(store);
+  }
+  return refreshed;
+}
+
+const claudeCodeAuthPlugin: Plugin = async () => ({
+  auth: {
+    provider: "anthropic",
+    async loader(getAuth: () => Promise<OAuthStored | { type: string }>, provider: { models: Record<string, { cost?: unknown }> }) {
+      const auth = await getAuth();
+      if (auth.type !== "oauth") return {};
+      for (const model of Object.values(provider.models)) model.cost = { input: 0, output: 0, cache: { read: 0, write: 0 } };
+      return {
+        apiKey: "",
+        async fetch(input: Request | string | URL, init?: RequestInit) {
+          const url = (() => { try { return new URL(input instanceof Request ? input.url : input.toString()); } catch { return null; } })();
+          if (!url || !ANTHROPIC_HOSTS.has(url.hostname)) return fetch(input, init);
+          const originalBody = typeof init?.body === "string" ? init.body : input instanceof Request ? await input.clone().text().catch(() => undefined) : undefined;
+          const rewritten = rewriteRequestPayload(originalBody);
+          const freshAuth = await getFreshOAuth(getAuth);
+          if (!freshAuth) return fetch(input, init);
+          const headers = new Headers(init?.headers);
+          if (input instanceof Request) input.headers.forEach((value, key) => { if (!headers.has(key)) headers.set(key, value); });
+          headers.set("accept", "application/json");
+          headers.set("anthropic-beta", mergeBetas(headers.get("anthropic-beta"), getRequiredBetas(rewritten.modelId)));
+          headers.set("anthropic-dangerous-direct-browser-access", "true");
+          headers.set("authorization", `Bearer ${freshAuth.access}`);
+          headers.set("user-agent", process.env.OPENCODE_ANTHROPIC_USER_AGENT || `claude-cli/${CLAUDE_CODE_VERSION}`);
+          headers.set("x-app", "cli");
+          headers.delete("x-api-key");
+          let response = await fetch(input, { ...(init ?? {}), body: rewritten.body, headers });
+          if (!response.ok) {
+            const bodyText = await response.clone().text().catch(() => "");
+            if (shouldRotateAuth(response.status, bodyText)) {
+              const rotated = await rotateAnthropicAccount(freshAuth);
+              if (rotated) {
+                headers.set("authorization", `Bearer ${rotated.access}`);
+                response = await fetch(input, { ...(init ?? {}), body: rewritten.body, headers });
+              }
+            }
+          }
+          return wrapResponseStream(response, rewritten.reverseToolNameMap);
+        },
+      };
+    },
+    methods: [
+      { label: "Claude Pro/Max", type: "oauth", authorize: buildAuthorizeHandler() },
+      { provider: "anthropic", label: "Manually enter API Key", type: "api" },
+    ],
+  },
+});
+
+export { claudeCodeAuthPlugin };

--- a/setup.sh
+++ b/setup.sh
@@ -60,6 +60,7 @@ SKILLS_ONLY=false
 RUNTIME_ONLY=false
 WITH_HOMEBOY=false
 WITH_AI_GATEWAY=false
+WITH_CLAUDE_CODE_AUTH=true
 ROTATE_AI_GATEWAY_TOKEN=false
 RUNTIME=""
 CHAT_BRIDGE_EXPLICIT=false
@@ -140,6 +141,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --with-ai-gateway)
       WITH_AI_GATEWAY=true
+      shift
+      ;;
+    --with-claude-code-auth)
+      WITH_CLAUDE_CODE_AUTH=true
+      shift
+      ;;
+    --no-claude-code-auth)
+      WITH_CLAUDE_CODE_AUTH=false
       shift
       ;;
     --ai-gateway-provider)
@@ -243,8 +252,11 @@ OPTIONS:
                      OpenCode model ID exposed by the gateway provider
                      (default: site-default)
   --rotate-ai-gateway-token
-                     Mint a new gateway token instead of reusing the existing
-                     .opencode/wp-ai-gateway.env value
+                      Mint a new gateway token instead of reusing the existing
+                      .opencode/wp-ai-gateway.env value
+  --no-claude-code-auth
+                      Skip the managed direct OpenCode Claude Pro/Max OAuth
+                      auth plugin. Installed by default for OpenCode runtimes.
   --no-homeboy       Skip Homeboy project setup, even if homeboy is installed
   --homeboy-project-id <id>
                      Override Homeboy project ID (default: agent/site slug)
@@ -274,6 +286,7 @@ ENVIRONMENT VARIABLES:
   AI_GATEWAY_ROUTE_MODEL     Backend model used by --with-ai-gateway
   AI_GATEWAY_MODEL_ID        OpenCode gateway model id (default: site-default)
   AI_GATEWAY_SITE_URL        Public site URL for OPENAI_BASE_URL override
+  WITH_CLAUDE_CODE_AUTH      false to skip direct OpenCode Claude Pro/Max auth
   KIMAKI_BOT_TOKEN          Discord bot token (skip interactive setup)
   TELEGRAM_BOT_TOKEN        Telegram bot token from @BotFather (--chat telegram)
   TELEGRAM_ALLOWED_USER_ID  Numeric Telegram user ID (--chat telegram)

--- a/tests/opencode-local-plugin-path.sh
+++ b/tests/opencode-local-plugin-path.sh
@@ -20,6 +20,9 @@ export OPENCODE_MODEL=""
 export OPENCODE_SMALL_MODEL=""
 export DM_WORKSPACE_DIR="$TMP/workspace"
 export DM_AGENT_FILES="wp-content/uploads/datamachine-files/shared/SITE.md"
+export WITH_CLAUDE_CODE_AUTH=true
+export RUNTIME="opencode"
+UPDATED_ITEMS=()
 
 log() { :; }
 warn() { printf '%s\n' "$*" >&2; }
@@ -40,10 +43,45 @@ with open(opencode_json, encoding="utf-8") as handle:
 expected = [
     f"{kimaki_data_dir}/kimaki-config/plugins/dm-context-filter.ts",
     f"{kimaki_data_dir}/kimaki-config/plugins/dm-agent-sync.ts",
+    f"{opencode_json.rsplit('/', 1)[0]}/.opencode/plugins/claude-code-auth.ts",
 ]
 actual = data.get("plugin")
 if actual != expected:
     raise SystemExit(f"unexpected local plugin paths: {actual}")
 PY
+
+if [ ! -f "$SITE_PATH/.opencode/plugins/claude-code-auth.ts" ]; then
+  echo "FAIL: default Claude Code auth plugin was not installed"
+  exit 1
+fi
+
+WITH_CLAUDE_CODE_AUTH=false
+SITE_PATH="$TMP/site-without-auth"
+mkdir -p "$SITE_PATH" "$KIMAKI_DATA_DIR"
+UPDATED_ITEMS=()
+
+runtime_generate_config
+
+python3 - "$SITE_PATH/opencode.json" "$KIMAKI_DATA_DIR" "$SITE_PATH" <<'PY'
+import json
+import sys
+
+opencode_json, kimaki_data_dir, site_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(opencode_json, encoding="utf-8") as handle:
+    data = json.load(handle)
+
+expected = [
+    f"{kimaki_data_dir}/kimaki-config/plugins/dm-context-filter.ts",
+    f"{kimaki_data_dir}/kimaki-config/plugins/dm-agent-sync.ts",
+]
+actual = data.get("plugin")
+if actual != expected:
+    raise SystemExit(f"unexpected opt-out plugin paths: {actual}")
+PY
+
+if [ -f "$SITE_PATH/.opencode/plugins/claude-code-auth.ts" ]; then
+  echo "FAIL: Claude Code auth plugin was installed despite opt-out"
+  exit 1
+fi
 
 echo "PASS: tests/opencode-local-plugin-path.sh"

--- a/tests/repair-opencode-json.sh
+++ b/tests/repair-opencode-json.sh
@@ -182,4 +182,31 @@ if data.get("instructions") != expected:
 PY
 grep -q '"instruction_sync": "synced"' "$TMP/managed-instructions.out"
 
+cat > "$TMP/claude-code-auth-plugin.json" <<'JSON'
+{
+  "plugin": []
+}
+JSON
+
+python3 "$REPAIR" \
+  --file "$TMP/claude-code-auth-plugin.json" \
+  --runtime opencode \
+  --chat-bridge none \
+  --kimaki-plugins-dir /opt/kimaki-config/plugins \
+  --claude-code-auth-plugin /srv/site/.opencode/plugins/claude-code-auth.ts \
+  --additive > "$TMP/claude-code-auth-plugin.out"
+
+python3 - "$TMP/claude-code-auth-plugin.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+expected = ["/srv/site/.opencode/plugins/claude-code-auth.ts"]
+if data.get("plugin") != expected:
+    raise SystemExit(f"unexpected claude code auth plugin paths: {data.get('plugin')}")
+PY
+grep -q '"status": "additive_repaired"' "$TMP/claude-code-auth-plugin.out"
+
 echo "OK: repair-opencode-json removes managed agent shells and repairs local plugin paths"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -95,6 +95,7 @@ AGENTS_MD_ONLY=false
 REPAIR_OPENCODE_JSON=false
 SKIP_PLUGINS=false
 WITH_AI_GATEWAY=false
+WITH_CLAUDE_CODE_AUTH=true
 ROTATE_AI_GATEWAY_TOKEN=false
 SHOW_HELP=false
 
@@ -129,6 +130,8 @@ while [[ $# -gt 0 ]]; do
     --repair-opencode-json) REPAIR_OPENCODE_JSON=true; shift ;;
     --skip-plugins)  SKIP_PLUGINS=true; shift ;;
     --with-ai-gateway) WITH_AI_GATEWAY=true; shift ;;
+    --with-claude-code-auth) WITH_CLAUDE_CODE_AUTH=true; shift ;;
+    --no-claude-code-auth) WITH_CLAUDE_CODE_AUTH=false; shift ;;
     --ai-gateway-provider) AI_GATEWAY_ROUTE_PROVIDER="$2"; shift 2 ;;
     --ai-gateway-model) AI_GATEWAY_ROUTE_MODEL="$2"; shift 2 ;;
     --ai-gateway-opencode-model) AI_GATEWAY_MODEL_ID="$2"; shift 2 ;;
@@ -185,6 +188,10 @@ USAGE:
                                 Explicitly mint a replacement gateway token.
   ./upgrade.sh --with-ai-gateway --ai-gateway-provider openai --ai-gateway-model gpt-4o-mini
                                 Configure the WordPress gateway backend route.
+  ./upgrade.sh --no-claude-code-auth
+                                Skip direct OpenCode Claude Pro/Max auth.
+                                The managed auth plugin is installed by default
+                                for OpenCode runtimes.
 
 SERVICE IDENTITY:
   By default the upgrade adopts the service user from the EXISTING
@@ -227,6 +234,9 @@ OPT-IN TOUCHES:
     .opencode/wp-ai-gateway.env, and additively merges provider.wp-ai-gateway
     into opencode.json. Existing gateway tokens are reused unless
     --rotate-ai-gateway-token is also passed.
+  - OpenCode Claude Code auth — installs a managed OpenCode plugin under
+    .opencode/plugins and adds it to opencode.json so direct OpenCode can
+    authenticate with Claude Pro/Max OAuth. Use --no-claude-code-auth to skip.
 HELP
   exit 0
 fi
@@ -484,6 +494,15 @@ check_opencode_json_drift() {
 
   # Kimaki plugins dir — match what bridges/kimaki.sh::bridge_sync_config resolved.
   local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
+  if declare -F opencode_install_claude_code_auth_plugin >/dev/null; then
+    opencode_install_claude_code_auth_plugin
+  fi
+  local CLAUDE_CODE_AUTH_PLUGIN=""
+  local claude_code_auth_args=()
+  if declare -F opencode_claude_code_auth_enabled >/dev/null && opencode_claude_code_auth_enabled; then
+    CLAUDE_CODE_AUTH_PLUGIN="$(opencode_claude_code_auth_plugin_path)"
+    claude_code_auth_args=(--claude-code-auth-plugin "$CLAUDE_CODE_AUTH_PLUGIN")
+  fi
 
   # Runtime arg for repair-opencode-json.py: always `opencode` when the file
   # exists. The primary RUNTIME may be `claude-code`, but the presence of
@@ -543,7 +562,11 @@ for item in data:
     if [ -n "$MANAGED_INSTRUCTIONS_FILE" ]; then
       managed_arg_display=" --managed-instructions-file $MANAGED_INSTRUCTIONS_FILE"
     fi
-    echo -e "${BLUE}[dry-run]${NC} Would run: python3 $HELPER --file $OPENCODE_JSON_FILE --runtime $RUNTIME_ARG --chat-bridge $BRIDGE_ARG --kimaki-plugins-dir $PLUGINS_DIR$managed_arg_display $MODE_FLAG"
+    local claude_auth_arg_display=""
+    if [ -n "$CLAUDE_CODE_AUTH_PLUGIN" ]; then
+      claude_auth_arg_display=" --claude-code-auth-plugin $CLAUDE_CODE_AUTH_PLUGIN"
+    fi
+    echo -e "${BLUE}[dry-run]${NC} Would run: python3 $HELPER --file $OPENCODE_JSON_FILE --runtime $RUNTIME_ARG --chat-bridge $BRIDGE_ARG --kimaki-plugins-dir $PLUGINS_DIR$claude_auth_arg_display$managed_arg_display $MODE_FLAG"
     local dry_out
     local managed_args=()
     if [ -n "$MANAGED_INSTRUCTIONS_FILE" ]; then
@@ -554,6 +577,7 @@ for item in data:
       --runtime "$RUNTIME_ARG" \
       --chat-bridge "$BRIDGE_ARG" \
       --kimaki-plugins-dir "$PLUGINS_DIR" \
+      "${claude_code_auth_args[@]}" \
       "${managed_args[@]}" 2>&1 || true)
     echo "$dry_out" | sed 's/^/    /'
     [ -z "$MANAGED_INSTRUCTIONS_FILE" ] || rm -f "$MANAGED_INSTRUCTIONS_FILE"
@@ -570,6 +594,7 @@ for item in data:
     --runtime "$RUNTIME_ARG" \
     --chat-bridge "$BRIDGE_ARG" \
     --kimaki-plugins-dir "$PLUGINS_DIR" \
+    "${claude_code_auth_args[@]}" \
     "${managed_args[@]}" \
     "$MODE_FLAG" \
     --backup-suffix "$TIMESTAMP" 2>&1) && repair_rc=0 || repair_rc=$?


### PR DESCRIPTION
## Summary
- add a managed OpenCode plugin for Claude Code OAuth auth against Anthropic
- install the plugin by default for OpenCode runtimes, with --no-claude-code-auth opt-out
- preserve auth plugin entries through opencode.json repair/setup paths
- add account rotation storage and retry-on-rate-limit/auth handling

## Testing
- bash tests/repair-opencode-json.sh
- bash tests/opencode-local-plugin-path.sh
- bash -n setup.sh && bash -n upgrade.sh && bash -n runtimes/opencode.sh && python3 -m py_compile lib/repair-opencode-json.py
- verified isolated OpenCode server exposes Anthropic auth methods including Claude Pro/Max
- verified live local site completed Claude Pro/Max OAuth login after child-process token exchange fix

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Reviewed Kimaki's OpenCode auth behavior, implemented the standalone wp-coding-agents OpenCode plugin, wired setup/upgrade repair paths, and ran verification.