### PR TITLE
fix: sync OpenCode auth plugin during upgrade

### DIFF
--- a/tests/upgrade-opencode-auth-plugin-sync.sh
+++ b/tests/upgrade-opencode-auth-plugin-sync.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# tests/upgrade-opencode-auth-plugin-sync.sh - upgrade syncs OpenCode auth plugin on mixed-runtime installs.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+UPGRADE="$SCRIPT_DIR/upgrade.sh"
+
+require_source() {
+  local pattern="$1"
+  local description="$2"
+  if ! grep -Fq "$pattern" "$UPGRADE"; then
+    echo "FAIL: missing $description" >&2
+    echo "pattern: $pattern" >&2
+    exit 1
+  fi
+}
+
+require_source "upgrade_opencode_claude_code_auth_plugin_path()" "upgrade-owned OpenCode auth plugin path helper"
+require_source "upgrade_install_opencode_claude_code_auth_plugin()" "upgrade-owned OpenCode auth plugin installer"
+require_source 'source_path="$SCRIPT_DIR/runtimes/opencode/plugins/claude-code-auth.ts"' "copy from released OpenCode auth plugin source"
+require_source "upgrade_install_opencode_claude_code_auth_plugin" "opencode.json drift phase installs auth plugin"
+require_source 'CLAUDE_CODE_AUTH_PLUGIN="$(upgrade_opencode_claude_code_auth_plugin_path)"' "repair helper receives site-local auth plugin path"
+
+echo "PASS: tests/upgrade-opencode-auth-plugin-sync.sh"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -458,6 +458,38 @@ sync_chat_bridge_config() {
 # All other keys are preserved. A .backup.<ts> is written alongside.
 # ============================================================================
 
+upgrade_opencode_claude_code_auth_plugin_path() {
+  printf '%s/.opencode/plugins/claude-code-auth.ts' "$SITE_PATH"
+}
+
+upgrade_install_opencode_claude_code_auth_plugin() {
+  [ "${WITH_CLAUDE_CODE_AUTH:-false}" = true ] || return 0
+
+  local plugin_path plugins_dir source_path
+  plugin_path="$(upgrade_opencode_claude_code_auth_plugin_path)"
+  plugins_dir="$(dirname "$plugin_path")"
+  source_path="$SCRIPT_DIR/runtimes/opencode/plugins/claude-code-auth.ts"
+
+  if [ ! -f "$source_path" ]; then
+    warn "Phase 3b: $source_path not found — skipping Claude Code auth OpenCode plugin sync"
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would install Claude Code auth OpenCode plugin at $plugin_path"
+    return 0
+  fi
+
+  mkdir -p "$plugins_dir"
+  if [ -f "$plugin_path" ] && cmp -s "$source_path" "$plugin_path"; then
+    return 0
+  fi
+
+  cp "$source_path" "$plugin_path"
+  chmod 644 "$plugin_path"
+  UPDATED_ITEMS+=("OpenCode Claude Code auth plugin ($plugin_path)")
+}
+
 check_opencode_json_drift() {
   _run_filter_active opencode-json || return 0
 
@@ -494,13 +526,11 @@ check_opencode_json_drift() {
 
   # Kimaki plugins dir — match what bridges/kimaki.sh::bridge_sync_config resolved.
   local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
-  if declare -F opencode_install_claude_code_auth_plugin >/dev/null; then
-    opencode_install_claude_code_auth_plugin
-  fi
+  upgrade_install_opencode_claude_code_auth_plugin
   local CLAUDE_CODE_AUTH_PLUGIN=""
   local claude_code_auth_args=()
-  if declare -F opencode_claude_code_auth_enabled >/dev/null && opencode_claude_code_auth_enabled; then
-    CLAUDE_CODE_AUTH_PLUGIN="$(opencode_claude_code_auth_plugin_path)"
+  if [ "${WITH_CLAUDE_CODE_AUTH:-false}" = true ]; then
+    CLAUDE_CODE_AUTH_PLUGIN="$(upgrade_opencode_claude_code_auth_plugin_path)"
     claude_code_auth_args=(--claude-code-auth-plugin "$CLAUDE_CODE_AUTH_PLUGIN")
   fi
 


### PR DESCRIPTION
## Summary
- copy the site-local OpenCode Claude auth plugin during upgrade even when Claude Code is the primary detected runtime
- pass that site-local plugin path into opencode.json repair without sourcing the OpenCode runtime file mid-upgrade
- add regression coverage for the mixed-runtime upgrade path

## Testing
- tests/upgrade-opencode-auth-plugin-sync.sh
- tests/opencode-claude-auth-refresh-hardening.sh
- tests/opencode-local-plugin-path.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosed the mixed-runtime upgrade gap, implemented the upgrade-path fix, and added regression coverage.