### PR TITLE
fix: refresh Anthropic OAuth after auth failures

### DIFF
--- a/runtimes/opencode/plugins/claude-code-auth.ts
+++ b/runtimes/opencode/plugins/claude-code-auth.ts
@@ -184,6 +184,17 @@ function upsertAccount(store: AccountStore, auth: OAuthStored, now = Date.now())
   store.activeIndex = index;
 }
 
+function replaceAccount(store: AccountStore, previous: OAuthStored, next: OAuthStored, now = Date.now()) {
+  const index = store.accounts.findIndex((account) => account.refresh === previous.refresh || account.access === previous.access || account.refresh === next.refresh || account.access === next.access);
+  if (index < 0) {
+    upsertAccount(store, next, now);
+    return;
+  }
+  const existing = store.accounts[index];
+  store.accounts[index] = { ...next, addedAt: existing?.addedAt ?? now, lastUsed: now };
+  store.activeIndex = index;
+}
+
 async function rememberAnthropicOAuth(auth: OAuthStored) {
   const store = await loadAccountStore();
   upsertAccount(store, auth);
@@ -611,7 +622,7 @@ async function getFreshOAuth(getAuth: () => Promise<OAuthStored | { type: string
       try {
         const refreshed = await refreshAnthropicToken(candidate.refresh);
         await writeAnthropicAuth(refreshed);
-        upsertAccount(store, refreshed);
+        replaceAccount(store, candidate, refreshed);
         await saveAccountStore(store);
         return refreshed;
       } catch (error) {
@@ -628,13 +639,37 @@ async function getFreshOAuth(getAuth: () => Promise<OAuthStored | { type: string
   });
 }
 
+async function refreshOAuthAfterAuthFailure(auth: OAuthStored) {
+  return withRefreshLock(async () => {
+    const latest = await readAnthropicAuth();
+    if (latest && !sameOAuth(latest, auth) && usableAccessToken(latest)) return latest;
+
+    const store = await loadAccountStore();
+    const refreshed = await refreshAnthropicToken(auth.refresh);
+    await writeAnthropicAuth(refreshed);
+    replaceAccount(store, auth, refreshed);
+    await saveAccountStore(store);
+    return refreshed;
+  });
+}
+
+async function rotateAndRefreshAnthropicAccount(auth: OAuthStored) {
+  const rotated = await rotateAnthropicAccount(auth);
+  if (!rotated || sameOAuth(rotated, auth)) return undefined;
+  try {
+    return await refreshOAuthAfterAuthFailure(rotated);
+  } catch {
+    return undefined;
+  }
+}
+
 async function getFreshOAuthOrRotate(getAuth: () => Promise<OAuthStored | { type: string }>) {
   try {
     return await getFreshOAuth(getAuth);
   } catch (error) {
     const auth = await readAnthropicAuth();
     if (auth) {
-      const rotated = await rotateAnthropicAccount(auth);
+      const rotated = await rotateAndRefreshAnthropicAccount(auth);
       if (rotated && !sameOAuth(rotated, auth)) return rotated;
     }
     throw error;
@@ -670,7 +705,17 @@ const claudeCodeAuthPlugin: Plugin = async () => ({
           if (!response.ok) {
             const bodyText = await response.clone().text().catch(() => "");
             if (shouldRotateAuth(response.status, bodyText)) {
-              const rotated = await rotateAnthropicAccount(freshAuth);
+              const refreshed = await refreshOAuthAfterAuthFailure(freshAuth).catch(() => undefined);
+              if (refreshed) {
+                headers.set("authorization", `Bearer ${refreshed.access}`);
+                response = await fetch(input, { ...(init ?? {}), body: rewritten.body, headers });
+              }
+            }
+          }
+          if (!response.ok) {
+            const bodyText = await response.clone().text().catch(() => "");
+            if (shouldRotateAuth(response.status, bodyText)) {
+              const rotated = await rotateAndRefreshAnthropicAccount(await readAnthropicAuth() ?? freshAuth);
               if (rotated) {
                 headers.set("authorization", `Bearer ${rotated.access}`);
                 response = await fetch(input, { ...(init ?? {}), body: rewritten.body, headers });

--- a/tests/opencode-claude-auth-refresh-hardening.sh
+++ b/tests/opencode-claude-auth-refresh-hardening.sh
@@ -23,5 +23,11 @@ require_source "function isInvalidGrantFailure" "invalid_grant refresh failure c
 require_source "const candidates = dedupeOAuthCandidates([latest, oauth, active, ...store.accounts])" "remembered account retry candidates"
 require_source "summarizeRefreshFailures" "redacted refresh failure diagnostics"
 require_source "getFreshOAuthOrRotate" "request path refresh fallback wrapper"
+require_source "function replaceAccount" "rotated refresh token replaces stale account entry"
+require_source "replaceAccount(store, candidate, refreshed)" "normal refresh replaces stale account entry"
+require_source "async function refreshOAuthAfterAuthFailure" "auth failure refresh retry helper"
+require_source "async function rotateAndRefreshAnthropicAccount" "rotated account refresh helper"
+require_source "const refreshed = await refreshOAuthAfterAuthFailure(freshAuth).catch(() => undefined)" "401 retry refreshes current credential"
+require_source "const rotated = await rotateAndRefreshAnthropicAccount(await readAnthropicAuth() ?? freshAuth)" "401 retry refreshes rotated credential"
 
 echo "PASS: tests/opencode-claude-auth-refresh-hardening.sh"


### PR DESCRIPTION
## Summary
- refresh the active Claude OAuth credential after Anthropic returns an auth failure before retrying
- refresh rotated accounts before using them for auth-failure retries
- replace stale account-store entries when refresh tokens rotate instead of appending duplicates

## Context
OpenCode `/connect` can leave Anthropic OAuth entries with stale access tokens in both `auth.json` and the remembered account rotation file. The previous hardening refreshed expired tokens before requests, but a 401 response rotated to another remembered account and reused that account's stored access token as-is. That could surface as "invalid authentication credentials" immediately after a successful login.

## Testing
- `tests/opencode-claude-auth-refresh-hardening.sh`
- `tests/opencode-local-plugin-path.sh`
- `bun build runtimes/opencode/plugins/claude-code-auth.ts --outfile /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/claude-code-auth-check.js --target=node`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosed the post-`/connect` stale-token retry path, implemented the OAuth refresh retry fix, and updated regression coverage.