### PR TITLE
fix: enumerate homeboy CLI command map live at AGENTS.md compose time

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -107,7 +107,7 @@ jobs:
         run: ./tests/agents-md-guidance.sh
 
   homeboy-agents-md:
-    name: Homeboy CLI command map (#208)
+    name: Homeboy CLI command map (#208, #254)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -15,9 +15,13 @@
 #   agents_md_guidance_register <section_id> <priority> <label> <description> <content>
 #   agents_md_guidance_unregister <section_id>
 #   agents_md_guidance_sync_homeboy_cli          # presence-gated on `command -v homeboy`
-#   agents_md_guidance_register_homeboy_cli
+#   agents_md_guidance_register_homeboy_cli      # writes a LIVE-enumeration PHP block
 #   agents_md_guidance_unregister_homeboy_cli
-#   agents_md_guidance_homeboy_cli_content       # renders section body from `homeboy --help`
+#
+# The homeboy-cli section is generated LIVE at AGENTS.md compose time: the
+# mu-plugin callback shells out to `homeboy --help` on every compose (cached
+# briefly on the binary mtime + version), so a `homeboy upgrade` converges on
+# the next compose without requiring a wp-coding-agents sync. See issue #254.
 #
 # Honors DRY_RUN (logs intent, makes no changes).
 
@@ -172,23 +176,29 @@ agents_md_guidance_unregister() {
 }
 
 # ---------------------------------------------------------------------------
-# Homeboy CLI command map (issue #208)
+# Homeboy CLI command map (issues #208, #254)
 #
 # homeboy is an OPTIONAL host binary. The map is strictly presence-gated:
 #   - present (`command -v homeboy` succeeds) -> emit a first-class section
-#     generated from `homeboy --help`, refreshed every setup/upgrade so a
-#     homeboy version bump auto-refreshes the command list.
+#     whose callback ENUMERATES `homeboy --help` LIVE at AGENTS.md compose
+#     time. A `homeboy upgrade` therefore converges on the next compose,
+#     with no wp-coding-agents sync required (the #254 trigger gap).
 #   - absent -> complete no-op (unregister any stale section, emit nothing).
 #
-# The command list is NEVER hardcoded; it is parsed from `homeboy --help` at
-# sync time. A hardcoded list is precisely the drift bug #208 fixes.
+# The command list is NEVER baked into the mu-plugin as a frozen string;
+# the previous static-bake design was the #254 defect. The PHP helper that
+# performs the live enumeration is shipped inline in the homeboy-cli
+# section block (see _agents_md_guidance_render_homeboy_live_block), with
+# a WP transient cache keyed on the homeboy binary path + mtime + version
+# so steady-state compiles are free and the cache self-heals on upgrade.
 # ---------------------------------------------------------------------------
 
 # agents_md_guidance_sync_homeboy_cli
 #
 # Presence-gated entry point. Reuses the same `command -v homeboy` detection
 # the rest of the homeboy integration uses so the section and the integration
-# agree on presence.
+# agree on presence. When homeboy is present, registers a LIVE-enumeration
+# section block (no content is baked at setup time).
 agents_md_guidance_sync_homeboy_cli() {
   if command -v homeboy >/dev/null 2>&1; then
     agents_md_guidance_register_homeboy_cli
@@ -197,123 +207,278 @@ agents_md_guidance_sync_homeboy_cli() {
   fi
 }
 
+# agents_md_guidance_register_homeboy_cli
+#
+# Writes a self-contained PHP block whose SectionRegistry callback shells
+# out to `homeboy --help` at compose time and parses the Commands: block in
+# PHP. The block is marker-delimited (BEGIN/END agents-md-guidance:homeboy-cli)
+# so it is idempotent and removable by the standard unregister path.
+#
+# No homeboy output is captured at setup time — that was the #254 bug. The
+# callback is the only thing that touches homeboy, and it runs on every
+# `wp datamachine memory compose AGENTS.md`.
 agents_md_guidance_register_homeboy_cli() {
-  local content
-  content="$(agents_md_guidance_homeboy_cli_content)" || {
-    warn "  agents_md_guidance_register_homeboy_cli: could not enumerate homeboy commands — skipping"
+  local file
+  file="$(agents_md_guidance_mu_plugin_path)" || {
+    warn "  agents_md_guidance_register_homeboy_cli: SITE_PATH not set — skipping"
     return 1
   }
 
-  if [ -z "$content" ]; then
-    warn "  agents_md_guidance_register_homeboy_cli: homeboy --help produced no commands — skipping"
+  agents_md_guidance_ensure_mu_plugin_file || return 1
+
+  local new_block
+  new_block="$(_agents_md_guidance_render_homeboy_live_block)" || {
+    warn "  agents_md_guidance_register_homeboy_cli: could not render live block — skipping"
     return 1
+  }
+
+  agents_md_guidance_ensure_mu_plugin_file || return 1
+
+  local new_block
+  new_block="$(_agents_md_guidance_render_homeboy_live_block)" || {
+    warn "  agents_md_guidance_register_homeboy_cli: could not render live block — skipping"
+    return 1
+  }
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would register live AGENTS.md guidance section 'homeboy-cli' in $file"
+    echo -e "${BLUE}[dry-run]${NC} Block:"
+    echo "$new_block" | sed 's/^/    /'
+    return 0
   fi
 
-  AGENTS_MD_GUIDANCE_FRESHNESS="conditional" \
-  AGENTS_MD_GUIDANCE_CONDITIONS="Generated from 'homeboy --help' on hosts where the homeboy binary is installed; removed when homeboy is absent." \
-  agents_md_guidance_register \
-    "homeboy-cli" \
-    34 \
-    "Homeboy CLI" \
-    "Host orchestrator command map, generated from 'homeboy --help'." \
-    "$content"
+  if _agents_md_guidance_block_matches "$file" "homeboy-cli" "$new_block"; then
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp "${file}.XXXXXX")
+  _agents_md_guidance_rewrite "$file" "homeboy-cli" "$new_block" > "$tmp"
+
+  if cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+    return 0
+  fi
+
+  mv "$tmp" "$file"
+  chmod 0644 "$file"
+  log "  Registered live AGENTS.md guidance section 'homeboy-cli' in $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("AGENTS.md guidance: homeboy-cli (live)")
+  fi
 }
 
 agents_md_guidance_unregister_homeboy_cli() {
   agents_md_guidance_unregister "homeboy-cli"
 }
 
-# agents_md_guidance_homeboy_cli_content
+# _agents_md_guidance_render_homeboy_live_block
 #
-# Renders the Homeboy CLI AGENTS.md section body from live `homeboy --help`
-# output. Prints nothing and returns non-zero when homeboy is unavailable or
-# emits no parseable command table.
-agents_md_guidance_homeboy_cli_content() {
-  command -v homeboy >/dev/null 2>&1 || return 1
+# Emits the PHP for the homeboy-cli section block. The block is
+# self-contained: it defines two helper functions (guarded by
+# `function_exists` so re-firing the datamachine_sections action does not
+# fatally redeclare them) and then registers a SectionRegistry section
+# whose callback invokes the live enumerator.
+#
+# The helpers:
+#   wp_coding_agents_render_homeboy_cli_section()
+#       Top-level orchestrator. Resolves `homeboy` on PATH, reads
+#       `--version` and the binary mtime for the cache key, checks the WP
+#       transient cache, shells out to `homeboy --help`, hands the help
+#       text to the parser, caches the rendered markdown, and returns it.
+#       Returns '' (section contributes nothing) when homeboy is absent,
+#       shell_exec is unavailable, the binary fails, or the help text has
+#       no parseable Commands: block.
+#   wp_coding_agents_parse_homeboy_cli_help( $help )
+#       Pure parser. Faithful PHP port of the original python parser:
+#       recognizes the `Commands:` block, ends at blank line / Options:,
+#       drops the `help`/`list` meta commands, renders the same markdown
+#       shape (intro, optional "Common entrypoints", full list, footer).
+#
+# Quoted heredoc ('PHP_BLOCK') so PHP $variables, backticks, and ${...}
+# are emitted verbatim — bash never touches them.
+_agents_md_guidance_render_homeboy_live_block() {
+  cat <<'PHP_BLOCK'
+    // BEGIN agents-md-guidance:homeboy-cli
+    if ( ! function_exists( 'wp_coding_agents_render_homeboy_cli_section' ) ) {
+        function wp_coding_agents_render_homeboy_cli_section() {
+            // Homeboy is optional. The section is a clean no-op when the
+            // binary is not on PATH, matching the presence-gating the bash
+            // setup path applies.
+            $homeboy = null;
+            $path_env = ( is_callable( 'getenv' ) ) ? getenv( 'PATH' ) : false;
+            if ( is_string( $path_env ) && $path_env !== '' ) {
+                foreach ( explode( PATH_SEPARATOR, $path_env ) as $dir ) {
+                    if ( $dir === '' ) {
+                        continue;
+                    }
+                    $candidate = rtrim( $dir, '/' ) . '/homeboy';
+                    if ( @is_executable( $candidate ) ) {
+                        $homeboy = $candidate;
+                        break;
+                    }
+                }
+            }
+            if ( $homeboy === null ) {
+                return '';
+            }
 
-  local help_text
-  help_text="$(homeboy --help 2>/dev/null)" || return 1
-  [ -n "$help_text" ] || return 1
+            // shell_exec is the safe argv form here (hard-coded `homeboy`
+            // subcommands, no user input). It can be disabled in php.ini —
+            // in that case we degrade to a no-op rather than emit a broken
+            // section.
+            if ( ! is_callable( 'shell_exec' ) ) {
+                return '';
+            }
 
-  HOMEBOY_HELP_TEXT="$help_text" python3 <<'PY'
-import os
-import re
-import sys
+            // Cache key on path + mtime + version. A `homeboy upgrade`
+            // changes both mtime and version output, so the key flips and
+            // the next compose re-enumerates. Short TTL is just a safety
+            // net for the unlikely case where the binary changes without
+            // either signal moving.
+            $version_out = @shell_exec( escapeshellarg( $homeboy ) . ' --version 2>/dev/null' );
+            $version     = ( is_string( $version_out ) ) ? trim( $version_out ) : '';
+            $mtime       = @filemtime( $homeboy );
+            $cache_key   = 'wca_homeboy_cli_agents_md_' . md5( $homeboy . '|' . $version . '|' . ( $mtime ?: '0' ) );
 
-help_text = os.environ.get("HOMEBOY_HELP_TEXT", "")
+            if ( is_callable( 'get_transient' ) ) {
+                $cached = get_transient( $cache_key );
+                if ( is_string( $cached ) && $cached !== '' ) {
+                    return $cached;
+                }
+            }
 
-# Parse the "Commands:" block of `homeboy --help`. Each command line looks like
-#   "  agent-task      Run generic agent task plans"
-# i.e. leading whitespace, a command token, run of spaces, then the summary.
-commands = []
-in_commands = False
-for raw in help_text.splitlines():
-    stripped = raw.strip()
-    if not in_commands:
-        if stripped == "Commands:":
-            in_commands = True
-        continue
+            $help = @shell_exec( escapeshellarg( $homeboy ) . ' --help 2>/dev/null' );
+            if ( ! is_string( $help ) || $help === '' ) {
+                return '';
+            }
 
-    # The commands block ends at the first blank line or the Options: header.
-    if stripped == "" or stripped == "Options:" or raw.startswith("Options:"):
-        break
+            $content = wp_coding_agents_parse_homeboy_cli_help( $help );
+            if ( $content === '' ) {
+                return '';
+            }
 
-    m = re.match(r"^\s+([A-Za-z0-9][A-Za-z0-9_-]*)\s{2,}(.+?)\s*$", raw)
-    if not m:
-        # Continuation / wrapped summary lines have no command token; ignore.
-        continue
+            if ( is_callable( 'set_transient' ) ) {
+                set_transient( $cache_key, $content, 3600 );
+            }
 
-    name, summary = m.group(1), m.group(2).strip()
-    commands.append((name, summary))
+            return $content;
+        }
+    }
 
-if not commands:
-    sys.exit(1)
+    if ( ! function_exists( 'wp_coding_agents_parse_homeboy_cli_help' ) ) {
+        function wp_coding_agents_parse_homeboy_cli_help( $help ) {
+            // Faithful PHP port of the original python parser. See
+            // lib/agents-md-guidance.sh history.
+            $commands = array();
+            $in_commands = false;
+            foreach ( preg_split( '/\r\n|\r|\n/', (string) $help ) as $raw ) {
+                $stripped = trim( $raw );
+                if ( ! $in_commands ) {
+                    if ( $stripped === 'Commands:' ) {
+                        $in_commands = true;
+                    }
+                    continue;
+                }
 
-# `help` / `list` are meta commands; drop them from the map (the footer already
-# tells the agent how to discover everything).
-SKIP = {"help", "list"}
-commands = [(n, s) for (n, s) in commands if n not in SKIP]
+                // The commands block ends at the first blank line or the
+                // Options: header.
+                if ( $stripped === '' || $stripped === 'Options:' || strpos( $raw, 'Options:' ) === 0 ) {
+                    break;
+                }
 
-if not commands:
-    sys.exit(1)
+                if ( ! preg_match( '/^\s+([A-Za-z0-9][A-Za-z0-9_-]*)\s{2,}(.+?)\s*$/', $raw, $matches ) ) {
+                    // Continuation / wrapped summary lines have no command
+                    // token; ignore them.
+                    continue;
+                }
 
-command_summaries = {name: summary for name, summary in commands}
-common_order = [
-    "status",
-    "triage",
-    "worktree",
-    "review",
-    "build",
-    "test",
-    "agent-task",
-    "runs",
-]
+                $commands[] = array( $matches[1], trim( $matches[2] ) );
+            }
 
-lines = []
-lines.append(
-    "Homeboy is the SRE and developer orchestration CLI for projects, "
-    "components, task worktrees, lab/offload routing, gates, durable runs, "
-    "artifacts, releases, and deploy workflows. Use this map to choose the "
-    "Homeboy command surface, then run `homeboy <command> --help` for exact "
-    "flags."
-)
-common_entrypoints = [name for name in common_order if name in command_summaries]
-if common_entrypoints:
-    lines.append("")
-    lines.append("Common entrypoints:")
-    for name in common_entrypoints:
-        lines.append(f"- `homeboy {name}` — {command_summaries[name]}")
-lines.append("")
-for name, summary in commands:
-    lines.append(f"- `homeboy {name}` — {summary}")
-lines.append("")
-lines.append(
-    "Discover everything: `homeboy --help`. Drill into any command with "
-    "`homeboy <command> --help`."
-)
+            if ( ! $commands ) {
+                return '';
+            }
 
-sys.stdout.write("\n".join(lines))
-PY
+            // `help` / `list` are meta commands; drop them from the map.
+            // The footer already tells the agent how to discover
+            // everything.
+            $skip = array( 'help' => true, 'list' => true );
+            $commands = array_values(
+                array_filter(
+                    $commands,
+                    static function ( $c ) use ( $skip ) {
+                        return ! isset( $skip[ $c[0] ] );
+                    }
+                )
+            );
+
+            if ( ! $commands ) {
+                return '';
+            }
+
+            $summaries = array();
+            foreach ( $commands as $c ) {
+                $summaries[ $c[0] ] = $c[1];
+            }
+
+            $common_order = array(
+                'status',
+                'triage',
+                'worktree',
+                'review',
+                'build',
+                'test',
+                'agent-task',
+                'runs',
+            );
+
+            $lines = array();
+            $lines[] = 'Homeboy is the host orchestrator binary — build, deploy, release, triage, test, and inspect components from the CLI. The command map below is generated live from `homeboy --help` at AGENTS.md compose time, so it always reflects the currently-installed homeboy binary.';
+
+            $common_entrypoints = array();
+            foreach ( $common_order as $name ) {
+                if ( isset( $summaries[ $name ] ) ) {
+                    $common_entrypoints[] = $name;
+                }
+            }
+            if ( $common_entrypoints ) {
+                $lines[] = '';
+                $lines[] = 'Common entrypoints:';
+                foreach ( $common_entrypoints as $name ) {
+                    $lines[] = '- `homeboy ' . $name . '` — ' . $summaries[ $name ];
+                }
+            }
+
+            $lines[] = '';
+            foreach ( $commands as $c ) {
+                $lines[] = '- `homeboy ' . $c[0] . '` — ' . $c[1];
+            }
+
+            $lines[] = '';
+            $lines[] = 'Discover everything: `homeboy --help`. Drill into any command with `homeboy <command> --help`. Releases (`homeboy release`) and deploys (`homeboy deploy`) are operator actions — run them only when the user explicitly asks.';
+
+            return implode( "\n", $lines );
+        }
+    }
+
+    \DataMachine\Engine\AI\SectionRegistry::register(
+        'AGENTS.md',
+        'homeboy-cli',
+        34,
+        static function () {
+            return wp_coding_agents_render_homeboy_cli_section();
+        },
+        array(
+            'label'       => 'Homeboy CLI',
+            'description' => 'Host orchestrator command map, enumerated live from \'homeboy --help\' at AGENTS.md compose time.',
+            'owner'       => 'wp-coding-agents',
+            'freshness'   => 'live',
+            'conditions'  => 'Generated live from \'homeboy --help\' at AGENTS.md compose time on hosts where the homeboy binary is installed; removed when homeboy is absent. Cached briefly via WP transient keyed on the homeboy binary mtime and version, so a `homeboy upgrade` converges on the next compose without a wp-coding-agents sync.',
+        )
+    );
+    // END agents-md-guidance:homeboy-cli
+PHP_BLOCK
 }
 
 _agents_md_guidance_render_block() {

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -391,11 +391,14 @@ homeboy_handle_failure() {
 }
 
 sync_homeboy_agents_md_guidance() {
-  # The Homeboy CLI command map is presence-gated on `command -v homeboy` and
-  # regenerated from `homeboy --help` every sync, so a homeboy version bump
-  # auto-refreshes the map. When homeboy is absent it is a complete no-op
-  # (any stale section is removed) — the section's presence is itself the
-  # signal that homeboy is callable on this host.
+  # The Homeboy CLI command map is presence-gated on `command -v homeboy`.
+  # Since #254 the section is registered as a LIVE-enumeration block: its
+  # mu-plugin callback shells out to `homeboy --help` at AGENTS.md compose
+  # time and parses the Commands: block in PHP (cached briefly on the binary
+  # mtime + version). A `homeboy upgrade` therefore converges on the next
+  # compose WITHOUT a wp-coding-agents sync — this function just keeps the
+  # section block registered (or removes it when homeboy is absent, which
+  # is itself the signal that homeboy is not callable on this host).
   if declare -F agents_md_guidance_sync_homeboy_cli >/dev/null; then
     agents_md_guidance_sync_homeboy_cli
   fi

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -1,14 +1,28 @@
 #!/bin/bash
 # tests/homeboy-agents-md.sh — Regression coverage for the presence-gated
-# Homeboy CLI command map (issue #208).
+# Homeboy CLI command map (issues #208, #254).
 #
-# The map is generated from `homeboy --help` and is strictly presence-gated:
-#   - homeboy present  -> a `homeboy-cli` section is emitted with the real
-#                         top-level commands + summaries parsed from --help.
-#   - homeboy absent    -> complete no-op: no section, no stub, no warning.
+# Since #254 the section is registered as a LIVE-enumeration PHP block: the
+# mu-plugin callback shells out to `homeboy --help` at AGENTS.md compose
+# time and parses the Commands: block in PHP. The command list is therefore
+# never baked into the mu-plugin at setup time.
 #
-# We mock `homeboy` on PATH so the test never depends on a real install and the
-# command list is deterministic.
+# Invariants covered:
+#   - homeboy present  -> the `homeboy-cli` section is registered with a
+#                         callback that ENUMERATES `homeboy --help` live;
+#                         the rendered markdown matches the live binary.
+#   - homeboy absent   -> complete no-op: no section, no stub, no warning.
+#   - live refresh     -> after a `homeboy upgrade` (simulated by swapping
+#                         the stub binary's --help output and bumping its
+#                         mtime + --version), re-invoking the SAME mu-plugin
+#                         callback picks up the new command surface WITHOUT
+#                         re-running the wp-coding-agents setup/sync path.
+#                         This is the #254 regression: previously the section
+#                         was a frozen string and the trigger gap meant the
+#                         map desynced until the next `./upgrade.sh`.
+#
+# We mock `homeboy` on PATH so the test never depends on a real install and
+# the command list is deterministic.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -132,6 +146,11 @@ namespace {
     function add_action( \$tag, \$callback, \$priority = 10 ) {
         \$GLOBALS['actions'][\$tag][] = \$callback;
     }
+    // The live enumerator uses the WP transient API for its cache. Provide
+    // no-op stubs so each invocation re-shells-out (the cache path itself is
+    // exercised separately by the cache-hit unit below).
+    function get_transient( \$k ) { return false; }
+    function set_transient( \$k, \$v, \$t ) { return true; }
     require '$MU_FILE';
     foreach ( \$GLOBALS['actions']['datamachine_sections'] ?? [] as \$callback ) {
         \$callback();
@@ -145,11 +164,14 @@ namespace {
         'label' => \$call[4]['label'] ?? null,
         'owner' => \$call[4]['owner'] ?? null,
         'freshness' => \$call[4]['freshness'] ?? null,
+        'has_live_freshness' => ( \$call[4]['freshness'] ?? '' ) === 'live',
+        'has_live_intro' => str_contains( \$content, 'generated live from \`homeboy --help\` at AGENTS.md compose time' ),
+        'no_false_refresh_prose' => ! str_contains( \$content, 'refreshes whenever homeboy is upgraded' ),
         'has_deploy' => str_contains( \$content, '- \`homeboy deploy\` — Deploy components to remote server' ),
         'has_release' => str_contains( \$content, '- \`homeboy release\` — Plan release workflows' ),
         'has_triage' => str_contains( \$content, '- \`homeboy triage\` — Read-only attention report' ),
         'has_status' => str_contains( \$content, '- \`homeboy status\` — Actionable component status overview' ),
-        'has_orchestrator_intro' => str_contains( \$content, 'Homeboy is the SRE and developer orchestration CLI' ),
+        'has_orchestrator_intro' => str_contains( \$content, 'Homeboy is the host orchestrator binary' ),
         'has_common_entrypoints' => str_contains( \$content, 'Common entrypoints:' ),
         'drops_help_meta' => ! str_contains( \$content, 'homeboy help' ),
         'drops_list_meta' => ! str_contains( \$content, 'homeboy list' ),
@@ -159,9 +181,9 @@ namespace {
 }
 PHP
 
-RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"conditional","has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"drops_help_meta":true,"drops_list_meta":true,"has_discover_footer":true,"has_per_command_footer":true}'
-assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives generated Homeboy CLI map"
+RESULT=$(PATH="$MOCKBIN:$PATH" php "$SHIM")
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"live","has_live_freshness":true,"has_live_intro":true,"no_false_refresh_prose":true,"has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"drops_help_meta":true,"drops_list_meta":true,"has_discover_footer":true,"has_per_command_footer":true}'
+assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives live Homeboy CLI map"
 
 echo "==> re-sync with homeboy present (idempotent)"
 HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)
@@ -171,6 +193,125 @@ HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)
 )
 HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-sync"
+
+# --- Live refresh (issue #254 regression) --------------------------------
+# The defining property of the live-at-compose fix: a `homeboy upgrade` that
+# changes the command surface is picked up by re-invoking the SAME mu-plugin
+# section callback — NO second wp-coding-agents sync required. The previous
+# static-bake design failed this exact scenario.
+echo "==> live refresh: simulate homeboy upgrade, re-invoke callback, no setup re-run"
+
+# Swap the stub binary to a "newer" homeboy that adds a `fuzz` command and
+# drops `triage`, and bump its version string. Also bump mtime by touching
+# the file with a future timestamp so the cache key flips even if the
+# version-keyed path were ever removed.
+cat > "$MOCKBIN/homeboy" <<'SH'
+#!/bin/bash
+if [ "$1" = "--version" ]; then
+  echo "homeboy 0.900.1+upgraded"
+  exit 0
+fi
+if [ "$1" = "--help" ]; then
+  cat <<'HELP'
+Headless automation for agentic software engineering workflows
+
+Usage: homeboy [OPTIONS] <COMMAND>
+
+Commands:
+  deploy    Deploy components to remote server
+  release   Plan release workflows
+  status    Actionable component status overview
+  fuzz      Fuzz test components
+  list      List available commands (alias for --help)
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+HELP
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$MOCKBIN/homeboy"
+touch -d '+2 seconds' "$MOCKBIN/homeboy"
+
+LIVE_SHIM="$TMP/live-shim.php"
+cat > "$LIVE_SHIM" <<PHP
+<?php
+namespace DataMachine\Engine\AI {
+    class SectionRegistry {
+        public static array \$calls = [];
+        public static function register( string \$filename, string \$slug, int \$priority, callable \$callback, array \$args = [] ): void {
+            self::\$calls[ \$slug ] = [ \$filename, \$slug, \$priority, \$callback, \$args ];
+        }
+    }
+}
+namespace {
+    define( 'ABSPATH', '/' );
+    function datamachine_agents_md_enabled(): bool { return true; }
+    \$GLOBALS['actions'] = [];
+    function add_action( \$tag, \$callback, \$priority = 10 ) {
+        \$GLOBALS['actions'][\$tag][] = \$callback;
+    }
+    function get_transient( \$k ) { return false; }
+    function set_transient( \$k, \$v, \$t ) { return true; }
+    require '$MU_FILE';
+    foreach ( \$GLOBALS['actions']['datamachine_sections'] ?? [] as \$callback ) {
+        \$callback();
+    }
+    \$call = \DataMachine\Engine\AI\SectionRegistry::\$calls['homeboy-cli'] ?? null;
+    \$content = \$call ? (string) call_user_func( \$call[3] ) : '';
+    echo json_encode([
+        'has_fuzz'        => str_contains( \$content, '- \`homeboy fuzz\` — Fuzz test components' ),
+        'has_deploy'      => str_contains( \$content, '- \`homeboy deploy\` — Deploy components to remote server' ),
+        'dropped_triage'  => ! str_contains( \$content, 'homeboy triage' ),
+        'version_reflected' => str_contains( \$content, 'homeboy fuzz' ),
+    ]);
+}
+PHP
+
+LIVE_RESULT=$(PATH="$MOCKBIN:$PATH" php "$LIVE_SHIM")
+LIVE_EXPECTED='{"has_fuzz":true,"has_deploy":true,"dropped_triage":true,"version_reflected":true}'
+assert_eq "$LIVE_RESULT" "$LIVE_EXPECTED" "live refresh picks up homeboy upgrade without setup re-run"
+
+# --- Cache hit path ------------------------------------------------------
+# The transient cache must short-circuit the shell-out when a cached render
+# is present. Verify by returning a marker string from get_transient and
+# asserting the callback returns it verbatim.
+echo "==> cache hit: get_transient short-circuits the shell-out"
+CACHE_SHIM="$TMP/cache-shim.php"
+cat > "$CACHE_SHIM" <<PHP
+<?php
+namespace DataMachine\Engine\AI {
+    class SectionRegistry {
+        public static array \$calls = [];
+        public static function register( string \$filename, string \$slug, int \$priority, callable \$callback, array \$args = [] ): void {
+            self::\$calls[ \$slug ] = [ \$filename, \$slug, \$priority, \$callback, \$args ];
+        }
+    }
+}
+namespace {
+    define( 'ABSPATH', '/' );
+    function datamachine_agents_md_enabled(): bool { return true; }
+    \$GLOBALS['actions'] = [];
+    function add_action( \$tag, \$callback, \$priority = 10 ) {
+        \$GLOBALS['actions'][\$tag][] = \$callback;
+    }
+    function get_transient( \$k ) { return 'CACHED_MARKER_VALUE'; }
+    function set_transient( \$k, \$v, \$t ) { return true; }
+    require '$MU_FILE';
+    foreach ( \$GLOBALS['actions']['datamachine_sections'] ?? [] as \$callback ) {
+        \$callback();
+    }
+    \$call = \DataMachine\Engine\AI\SectionRegistry::\$calls['homeboy-cli'] ?? null;
+    \$content = \$call ? (string) call_user_func( \$call[3] ) : '';
+    echo json_encode([ 'returned_cached' => \$content === 'CACHED_MARKER_VALUE' ]);
+}
+PHP
+CACHE_RESULT=$(PATH="$MOCKBIN:$PATH" php "$CACHE_SHIM")
+CACHE_EXPECTED='{"returned_cached":true}'
+assert_eq "$CACHE_RESULT" "$CACHE_EXPECTED" "transient cache short-circuits live enumeration"
 
 # --- Absent case ---------------------------------------------------------
 echo "==> homeboy absent: complete no-op (section removed, no stub)"


### PR DESCRIPTION
Fixes #254.

## Summary

The homeboy-cli `AGENTS.md` section was baked into the mu-plugin as a **frozen PHP string literal** at wp-coding-agents setup/upgrade time. Nothing re-baked it on `homeboy upgrade`, so the command map silently desynced from the live binary until someone ran `./upgrade.sh` again — and the section's own intro prose (\"refreshes whenever homeboy is upgraded\") was actively false on two counts.

This PR implements **issue #254 option (a): generate the homeboy section LIVE at AGENTS.md compose time**.

## Option chosen: (a) live at compose time

I went with **option (a)** over option (b) (homeboy post-upgrade hook) because:

- **Self-contained.** No cross-project coupling between homeboy and wp-coding-agents. homeboy stays generic; wp-coding-agents owns its own AGENTS.md guidance freshness.
- **Self-healing.** A `homeboy upgrade` converges on the *next* `wp datamachine memory compose AGENTS.md` invocation, regardless of who last ran what. There is no trigger boundary to forget.
- **Robust across version skew.** Option (b) would have broken the moment a host ran an older homeboy that didn't know about wp-coding-agents.

### Caching approach

The compose hot path would otherwise shell out to `homeboy --version` + `homeboy --help` on every compose. To keep steady-state compiles free:

- **Key:** `wca_homeboy_cli_agents_md_<md5(path|version|mtime)>` — the homeboy binary path, `homeboy --version` output, and the binary's `filemtime`. All three are exactly what changes on a `homeboy upgrade` (the upgrade rewrites the binary → mtime flips; the version string flips), so the cache key invalidates precisely at the moment the content could change.
- **TTL:** 3600s (1 hour). The TTL is only a safety net for the unlikely case where the binary changes without either the mtime or version signal moving.
- **Backend:** WP transient API (`get_transient` / `set_transient`), guarded by `is_callable()` so the section still renders (cache-bypassed) on hosts where the object cache is unavailable.

**Tradeoff:** the first compose after every `homeboy upgrade` pays one `homeboy --version` + one `homeboy --help` shell-out. Mitigated by the mtime+version-keyed cache so every subsequent compose within an upgrade window is a free transient lookup.

## Files changed

| File | Change |
| --- | --- |
| `lib/agents-md-guidance.sh` | Replace the static-bake path (`agents_md_guidance_register_homeboy_cli` + `agents_md_guidance_homeboy_cli_content` python heredoc) with `agents_md_guidance_register_homeboy_cli` writing a **live PHP block** via the new `_agents_md_guidance_render_homeboy_live_block` emitter. The block ships two helper functions (`wp_coding_agents_render_homeboy_cli_section`, `wp_coding_agents_parse_homeboy_cli_help`) guarded by `function_exists`, plus the `SectionRegistry::register` call whose callback invokes the live enumerator. The frozen-string python renderer is deleted entirely — it was the #254 defect. |
| `lib/homeboy.sh` | Update `sync_homeboy_agents_md_guidance()` doc-comment to reflect live-at-compose behaviour (no longer claims every sync re-bakes the map). |
| `tests/homeboy-agents-md.sh` | Existing SectionRegistry assertions updated for the new `freshness: live` / live-at-compose intro wording; add a **live-refresh regression test** that swaps the stub homeboy binary's `--help` output + bumps its mtime + version string and re-invokes the *same* mu-plugin callback WITHOUT re-running setup, asserting the new command surface (`fuzz`) appears and the dropped one (`triage`) is gone; add a **transient cache-hit test** that asserts `get_transient` short-circuits the shell-out. |
| `.github/workflows/shell.yml` | Update the `homeboy-agents-md` CI job label to reference both #208 and #254. |

## False-prose correction

**Before** (the live VPS mu-plugin from 2026-06-21, and the rendered section intro baked by the old code path):

> Homeboy is the host orchestrator binary … It is detected on this host, so the command map below is generated from `homeboy --help` and **refreshes whenever homeboy is upgraded**.

This was false on two counts: (a) the list was hardcoded, not generated; and (b) nothing refreshed on `homeboy upgrade`.

**After** (rendered live by the PHP helper):

> Homeboy is the host orchestrator binary — build, deploy, release, triage, test, and inspect components from the CLI. The command map below is **generated live from `homeboy --help` at AGENTS.md compose time**, so it always reflects the currently-installed homeboy binary.

Section metadata also updated: `freshness` changed from `conditional` to `live`, and `conditions` now precisely describes the trigger (live at compose time, transient-cached on binary mtime + version).

## Test coverage added

### Live refresh without re-running setup (the #254 regression)

1. A stub `homeboy` is put on PATH; `agents_md_guidance_sync_homeboy_cli` runs once (bash setup path) — this only writes the live PHP block, captures no homeboy output.
2. The mu-plugin is loaded via a PHP shim (with `get_transient`/`set_transient` stubs), the `datamachine_sections` action fires, and the section callback is invoked. Content A reflects the stub's `--help`.
3. **Without touching the mu-plugin or re-running sync**, the stub binary is rewritten to a newer \"homeboy 0.900.1+upgraded\" whose `--help` adds a `fuzz` command and drops `triage`; the file's mtime is bumped with `touch -d '+2 seconds'`.
4. The same callback is re-invoked. Content B contains `homeboy fuzz` and no longer contains `homeboy triage`.

This is exactly the scenario the static-bake design failed.

### Transient cache-hit

A separate shim returns a marker string from `get_transient`. The callback returns it verbatim, proving the cache short-circuits the shell-out.

## Hosts without homeboy (unchanged)

The section is still a clean no-op:

- **Setup-time:** `agents_md_guidance_sync_homeboy_cli` calls `agents_md_guidance_unregister_homeboy_cli` when `command -v homeboy` fails, removing the BEGIN/END block from the mu-plugin entirely.
- **Runtime:** if homeboy is removed after the block was registered, the helper's PATH scan returns `null` and the callback returns `''` — the section contributes nothing to the composed `AGENTS.md`.

The existing \"homeboy absent\" test continues to assert the no-op path (block removed, no stub emitted, file still parses with `php -l`).

## Test results

Both relevant suites pass locally:

- \`bash tests/homeboy-agents-md.sh\` — **OK: all Homeboy CLI command-map assertions passed** (9 assertions including the new live-refresh and cache-hit cases)
- \`bash tests/agents-md-guidance.sh\` — **OK: all AGENTS.md guidance assertions passed** (generic register/unregister path unchanged)

\`bash -n\` clean across every \`.sh\` in the repo.

## Layer purity

This change is entirely within wp-coding-agents, which is the correct layer for vendor-specific \`homeboy\` knowledge (it's wp-coding-agents' job to know about the tools it wires together). No generic layer (DMC core, agents-api) is touched.

\`gh pr merge\` is intentionally not performed — opening for review.