### PR TITLE
fix: allow non-root upgrade identity adoption

### DIFF
--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -31,6 +31,20 @@ detect_php_version() {
   fi
 }
 
+detect_root_requirement() {
+  if [ "${DRY_RUN:-false}" = true ] || [ "${LOCAL_MODE:-false}" = true ]; then
+    return 0
+  fi
+
+  if [ "${REQUIRE_ROOT_DURING_DETECT:-true}" != true ]; then
+    return 0
+  fi
+
+  if [ "$EUID" -ne 0 ]; then
+    error "Please run as root (sudo ./setup.sh). Use --local for local installs."
+  fi
+}
+
 detect_environment() {
   # Detect OS and platform
   PLATFORM="linux"
@@ -74,10 +88,10 @@ detect_environment() {
     fi
   fi
 
-  # Check root (not required in local mode)
-  if [ "$DRY_RUN" = false ] && [ "$LOCAL_MODE" = false ] && [ "$EUID" -ne 0 ]; then
-    error "Please run as root (sudo ./setup.sh). Use --local for local installs."
-  fi
+  # Check root when the caller requires root during detection. setup.sh uses
+  # the default. upgrade.sh defers this until after it can adopt the installed
+  # service identity from existing systemd units.
+  detect_root_requirement
 
   # WP-CLI flag: --allow-root on VPS, omit on local
   if [ "$LOCAL_MODE" = true ]; then

--- a/tests/service-identity-adoption.sh
+++ b/tests/service-identity-adoption.sh
@@ -12,12 +12,14 @@
 #   1. adopt_service_identity_from_units reads User= from the existing unit
 #      and re-derives SERVICE_USER / SERVICE_HOME / KIMAKI_DATA_DIR /
 #      RUN_AS_ROOT to match (root-default script + opencode unit → opencode).
-#   2. Adoption is a no-op when the unit already matches the script default.
-#   3. Adoption is skipped when SERVICE_USER_FORCED=true (--root/--non-root).
-#   4. Adoption is skipped in LOCAL_MODE (no systemd).
-#   5. _preserve_systemd_umask carries an existing UMask= line into the
+#   2. upgrade.sh can defer the root check until after adoption, while setup.sh
+#      keeps the root check during detection.
+#   3. Adoption is a no-op when the unit already matches the script default.
+#   4. Adoption is skipped when SERVICE_USER_FORCED=true (--root/--non-root).
+#   5. Adoption is skipped in LOCAL_MODE (no systemd).
+#   6. _preserve_systemd_umask carries an existing UMask= line into the
 #      re-rendered env block, and is a no-op when the unit has none.
-#   6. End-to-end: a re-render after adoption keeps User=opencode and
+#   7. End-to-end: a re-render after adoption keeps User=opencode and
 #      UMask=0002 — the exact production diff from #204 must NOT appear.
 set -eu
 
@@ -50,6 +52,8 @@ export PLATFORM="linux"
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/detect.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/bridges/_dispatch.sh"
 
@@ -95,6 +99,22 @@ assert "SERVICE_USER adopted from unit"        "$([ "$SERVICE_USER" = "opencode"
 assert "RUN_AS_ROOT flipped to false"          "$([ "$RUN_AS_ROOT" = "false" ]; echo $?)"
 assert "SERVICE_HOME re-derived"               "$([ "$SERVICE_HOME" != "/root" ]; echo $?)"
 assert "KIMAKI_DATA_DIR re-derived"            "$([ "$KIMAKI_DATA_DIR" != "/root/.kimaki" ]; echo $?)"
+
+# ---------------------------------------------------------------------------
+echo "==> root gate: upgrade can defer detection-time root requirement"
+DRY_RUN=false
+LOCAL_MODE=false
+REQUIRE_ROOT_DURING_DETECT=false
+if [ "$EUID" -ne 0 ]; then
+  assert "non-root upgrade detection gate deferred" "$(detect_root_requirement; echo $?)"
+  if (REQUIRE_ROOT_DURING_DETECT=true detect_root_requirement) >/dev/null 2>&1; then
+    assert "non-root setup detection gate enforced" 1
+  else
+    assert "non-root setup detection gate enforced" 0
+  fi
+else
+  assert "root upgrade detection gate deferred" "$(detect_root_requirement; echo $?)"
+fi
 
 # ---------------------------------------------------------------------------
 echo "==> adoption: no-op when unit matches script default"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -107,6 +107,7 @@ INSTALL_DATA_MACHINE=true
 INSTALL_CHAT=true
 INSTALL_SKILLS=true
 RUN_AS_ROOT=true
+REQUIRE_ROOT_DURING_DETECT=false
 MULTISITE=false
 MULTISITE_TYPE="subdirectory"
 MODE="existing"
@@ -337,6 +338,10 @@ fi
 # the root-homed-path dispatch trap (#198/#93) all over again. See #204.
 # --root / --non-root force an explicit identity and skip adoption.
 adopt_service_identity_from_units
+
+if [ "$DRY_RUN" = false ] && [ "$LOCAL_MODE" = false ] && [ "$RUN_AS_ROOT" = true ] && [ "$EUID" -ne 0 ]; then
+  error "Please run as root (sudo ./upgrade.sh), or use --non-root for installs whose service and WordPress files are writable by the current user."
+fi
 
 log "Runtime:     $RUNTIME"
 log "Chat bridge: ${CHAT_BRIDGE:-none detected}"
@@ -981,6 +986,12 @@ update_chat_bridge_systemd() {
 
   if [ -z "$CHAT_BRIDGE" ]; then
     log "Phase 6: Skipping (no chat bridge detected)"
+    return 0
+  fi
+
+  if [ "$EUID" -ne 0 ]; then
+    warn "Phase 6: Skipping systemd unit refresh because upgrade is running non-root"
+    warn "  Re-run as root when unit templates need refreshing; the service will not be restarted automatically."
     return 0
   fi
 


### PR DESCRIPTION
## Summary
- defer the Linux root check in upgrade.sh until after existing systemd service identity adoption
- keep setup.sh's detection-time root requirement intact
- skip systemd unit refresh when a non-root upgrade cannot write systemd files

## Tests
- bash tests/service-identity-adoption.sh
- bash tests/agents-md-guidance.sh
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed the non-root upgrade failure, implemented the root-check/adoption fix, and added regression coverage.