### PR TITLE
fix: prune AGENTS.md upgrade backups

### DIFF
--- a/lib/agents-md-backups.sh
+++ b/lib/agents-md-backups.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# AGENTS.md backup retention helpers.
+
+agents_md_prune_backups() {
+  local site_path="$1"
+  local keep="${AGENTS_MD_BACKUP_KEEP:-5}"
+  local max_age_days="${AGENTS_MD_BACKUP_MAX_AGE_DAYS:-30}"
+
+  if [ -z "$site_path" ] || [ ! -d "$site_path" ]; then
+    return 0
+  fi
+
+  case "$keep" in
+    ''|*[!0-9]*) keep=5 ;;
+  esac
+  case "$max_age_days" in
+    ''|*[!0-9]*) max_age_days=30 ;;
+  esac
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    _agents_md_backup_log "  Would prune AGENTS.md backups in $site_path (keep latest $keep, prune older than ${max_age_days}d)"
+    return 0
+  fi
+
+  local output pruned
+  output=$(AGENTS_MD_BACKUP_DIR="$site_path" AGENTS_MD_BACKUP_KEEP="$keep" AGENTS_MD_BACKUP_MAX_AGE_DAYS="$max_age_days" python3 <<'PY'
+import os
+import re
+import time
+
+directory = os.environ.get("AGENTS_MD_BACKUP_DIR", "")
+keep = int(os.environ.get("AGENTS_MD_BACKUP_KEEP", "5"))
+max_age_days = int(os.environ.get("AGENTS_MD_BACKUP_MAX_AGE_DAYS", "30"))
+pattern = re.compile(r"^AGENTS\.md\.backup\.(\d{8}-\d{6})$")
+
+try:
+    names = os.listdir(directory)
+except OSError:
+    print("0")
+    raise SystemExit(0)
+
+backups = []
+for name in names:
+    match = pattern.match(name)
+    if not match:
+        continue
+    path = os.path.join(directory, name)
+    try:
+        stat = os.stat(path)
+    except OSError:
+        continue
+    if not os.path.isfile(path):
+        continue
+    backups.append((match.group(1), path, stat.st_mtime))
+
+backups.sort(key=lambda item: item[0], reverse=True)
+protected = {path for _stamp, path, _mtime in backups[:keep]}
+threshold = time.time() - (max_age_days * 86400)
+pruned = 0
+
+for _stamp, path, mtime in backups[keep:]:
+    if path in protected or mtime >= threshold:
+        continue
+    try:
+        os.remove(path)
+        pruned += 1
+    except OSError:
+        pass
+
+print(str(pruned))
+PY
+  ) || {
+    _agents_md_backup_warn "  Could not prune AGENTS.md backups"
+    return 0
+  }
+
+  pruned="${output##*$'\n'}"
+  case "$pruned" in
+    ''|*[!0-9]*) pruned=0 ;;
+  esac
+
+  if [ "$pruned" -gt 0 ]; then
+    _agents_md_backup_log "  Pruned $pruned old AGENTS.md backup(s) (kept latest $keep; max age ${max_age_days}d)"
+  fi
+}
+
+_agents_md_backup_log() {
+  if declare -F log >/dev/null 2>&1; then
+    log "$1"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+_agents_md_backup_warn() {
+  if declare -F warn >/dev/null 2>&1; then
+    warn "$1"
+  else
+    printf '%s\n' "$1" >&2
+  fi
+}

--- a/tests/agents-md-backup-retention.sh
+++ b/tests/agents-md-backup-retention.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# tests/agents-md-backup-retention.sh — AGENTS.md backup retention coverage.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/agents-md-backups.sh"
+
+log() { :; }
+warn() { echo "WARN: $1" >&2; }
+
+make_backup() {
+  local name="$1" touch_time="$2"
+  printf 'backup %s\n' "$name" > "$TMP/$name"
+  touch -t "$touch_time" "$TMP/$name"
+}
+
+make_backup AGENTS.md.backup.20240101-000000 202001010000
+make_backup AGENTS.md.backup.20240102-000000 202001010000
+make_backup AGENTS.md.backup.20240103-000000 202001010000
+make_backup AGENTS.md.backup.20240104-000000 202001010000
+make_backup AGENTS.md.backup.20230101-000000 "$(date +%Y%m%d%H%M)"
+make_backup AGENTS.md.backup.notes 202001010000
+
+AGENTS_MD_BACKUP_KEEP=2 AGENTS_MD_BACKUP_MAX_AGE_DAYS=30 DRY_RUN=false agents_md_prune_backups "$TMP"
+
+FAILED=0
+
+assert_exists() {
+  local file="$1" label="$2"
+  if [ -e "$TMP/$file" ]; then
+    echo "  ok   $label"
+  else
+    echo "  FAIL $label"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_missing() {
+  local file="$1" label="$2"
+  if [ ! -e "$TMP/$file" ]; then
+    echo "  ok   $label"
+  else
+    echo "  FAIL $label"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "==> AGENTS.md backup retention"
+assert_missing AGENTS.md.backup.20240101-000000 "old backup outside latest keep pruned"
+assert_missing AGENTS.md.backup.20240102-000000 "second old backup outside latest keep pruned"
+assert_exists AGENTS.md.backup.20240103-000000 "latest keep backup preserved"
+assert_exists AGENTS.md.backup.20240104-000000 "newest keep backup preserved"
+assert_exists AGENTS.md.backup.20230101-000000 "recent backup outside latest keep preserved"
+assert_exists AGENTS.md.backup.notes "non-managed backup-like file preserved"
+
+echo
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAILED: $FAILED assertion(s)"
+  exit 1
+fi
+echo "OK: AGENTS.md backup retention assertions passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature agents-md-guidance; do
+for lib in common detect wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature agents-md-guidance agents-md-backups; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -225,6 +225,10 @@ DEFAULT TOUCHES:
     bridges) and migrates "agent.build.prompt" to top-level "instructions"
     (fixes Anthropic Claude Max OAuth). Never removes user-added plugins.
     Preserves all other keys. Writes a .backup.<ts> alongside.
+  - AGENTS.md.backup.* — prunes old generated backups after successful
+    AGENTS.md regeneration. Defaults: keep latest 5 and remove older extras
+    after 30 days. Override with AGENTS_MD_BACKUP_KEEP and
+    AGENTS_MD_BACKUP_MAX_AGE_DAYS.
 
 OPT-IN TOUCHES:
   - opencode.json (--repair-opencode-json) — full reconcile. In addition
@@ -766,6 +770,7 @@ regenerate_agents_md() {
       fi
       UPDATED_ITEMS+=("AGENTS.md")
     fi
+    agents_md_prune_backups "$SITE_PATH"
   else
     warn "  datamachine memory compose failed — AGENTS.md unchanged"
     # Restore from backup if compose wrote a partial file


### PR DESCRIPTION
## Summary
- prune wp-coding-agents-owned AGENTS.md.backup.* files after successful AGENTS.md regeneration
- keep the latest 5 backups by default and remove older extras after 30 days
- add override env vars: AGENTS_MD_BACKUP_KEEP and AGENTS_MD_BACKUP_MAX_AGE_DAYS
- add regression coverage for backup retention behavior

## Tests
- bash tests/agents-md-backup-retention.sh
- bash tests/agents-md-guidance.sh
- bash tests/homeboy-agents-md.sh
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Implemented creator-owned AGENTS.md backup pruning and regression coverage.