### PR TITLE
fix: normalize ownership + group-write on service files written into the web tree

### DIFF
--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -85,7 +85,7 @@ add_action( 'datamachine_sections', function () {
 } );
 PHP
 
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
   log "  Wrote AGENTS.md guidance mu-plugin scaffold: $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("created $file")
@@ -135,7 +135,7 @@ agents_md_guidance_register() {
   fi
 
   mv "$tmp" "$file"
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
   log "  Registered AGENTS.md guidance section '$section_id' in $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("AGENTS.md guidance: $section_id")
@@ -168,7 +168,7 @@ agents_md_guidance_unregister() {
   tmp=$(mktemp "${file}.XXXXXX")
   _agents_md_guidance_rewrite "$file" "$section_id" "" > "$tmp"
   mv "$tmp" "$file"
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
   log "  Unregistered AGENTS.md guidance section '$section_id' from $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("AGENTS.md guidance removed: $section_id")
@@ -261,7 +261,7 @@ agents_md_guidance_register_homeboy_cli() {
   fi
 
   mv "$tmp" "$file"
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
   log "  Registered live AGENTS.md guidance section 'homeboy-cli' in $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("AGENTS.md guidance: homeboy-cli (live)")

--- a/lib/cli-channel.sh
+++ b/lib/cli-channel.sh
@@ -111,9 +111,12 @@ cli_channel_ensure_mu_plugin_file() {
 
   mkdir -p "$dir"
 
-  # Write the scaffold, then force mode 0644 regardless of the caller's
-  # umask (root cron/systemd contexts default to 0077 which strips the
-  # world-read bit PHP-FPM needs — see issue #133).
+  # Write the scaffold, then normalize mode/group regardless of the
+  # caller's umask or identity (root cron/systemd contexts default to
+  # umask 0077, which strips the world-read bit PHP-FPM needs — issue
+  # #133 — and root/opencode/www-data writers each leave a different
+  # owner, which without a shared group-writable mode breaks the next
+  # writer — issue #258).
   cat > "$file" <<'PHP'
 <?php
 /**
@@ -170,7 +173,7 @@ add_filter( 'wp_coding_agents_cli_channels', 'wp_coding_agents_register_cli_chan
 add_filter( 'datamachine_code_cli_channels', 'wp_coding_agents_register_cli_channels' );
 PHP
 
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
 
   log "  Wrote CLI-channel mu-plugin scaffold: $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
@@ -353,9 +356,10 @@ cli_channel_register() {
   fi
 
   mv "$tmp" "$file"
-  # Self-heal legacy 0600 files written before the umask fix in #133.
-  # mktemp creates with mode 0600 so mv preserves that — force 0644.
-  chmod 0644 "$file"
+  # mktemp creates the tmp file at mode 0600, so mv preserves that, and mv
+  # also preserves the tmp file's own owner rather than the destination's —
+  # self-heal both mode and group on every write (issue #133, issue #258).
+  service_file_normalize_perms "$file"
   log "  Registered CLI channel '$name' in $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("CLI channel: $name")
@@ -392,7 +396,7 @@ cli_channel_unregister() {
   tmp=$(mktemp "${file}.XXXXXX")
   _cli_channel_rewrite "$file" "$name" "" > "$tmp"
   mv "$tmp" "$file"
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
   log "  Unregistered CLI channel '$name' from $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("CLI channel removed: $name")

--- a/lib/cli-transport.sh
+++ b/lib/cli-transport.sh
@@ -29,12 +29,12 @@ cli_transport_install() {
 
   mkdir -p "$dir"
   if [ -f "$file" ] && cmp -s "$template" "$file"; then
-    chmod 0644 "$file"
+    service_file_normalize_perms "$file"
     return 0
   fi
 
   cp "$template" "$file"
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
   log "  Synced CLI transport mu-plugin: $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("CLI transport runtime")

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -30,6 +30,60 @@ write_file() {
   fi
 }
 
+# service_file_normalize_perms <file>
+#
+# Normalize ownership/mode of a service file wp-coding-agents just wrote
+# under the web tree (mu-plugins, AGENTS.md + backups, runtime plugins,
+# installed skills). These files are written by whichever identity ran
+# setup/upgrade — root (cron/systemd, VPS upgrades), the service user
+# (opencode, local dev), or www-data (WP-CLI fallback) — and then need to
+# be *rewritten* by a different one of those identities on the next sync.
+# Forcing 0644 (see issue #133) fixed the world-read bit PHP-FPM needs, but
+# left files non-group-writable, so the next writer (a different uid than
+# the last one) hits EACCES instead of relying on group membership.
+#
+# Fix: force 0664 (rw for owner+group, r for other) and chgrp to the
+# webroot group, derived from the file's parent directory rather than
+# hardcoded — sites vary in which group owns the web tree, and this stays
+# correct without wp-coding-agents needing to know or assume "www-data".
+# Failures are swallowed (non-root callers who aren't in the target group
+# can't chgrp; that's fine, the mode fix alone still helps).
+service_file_normalize_perms() {
+  local file="$1"
+  [ -n "$file" ] && [ -e "$file" ] || return 0
+
+  local dir group
+  dir="$(dirname -- "$file")"
+  # GNU stat first (Linux); BSD/macOS stat as fallback for local dev mode.
+  group="$(stat -c '%G' "$dir" 2>/dev/null || stat -f '%Sg' "$dir" 2>/dev/null || true)"
+
+  chmod 0664 "$file" 2>/dev/null || true
+  if [ -n "$group" ]; then
+    chgrp "$group" "$file" 2>/dev/null || true
+  fi
+}
+
+# service_dir_normalize_perms <dir>
+#
+# Recursive counterpart to service_file_normalize_perms, for directory
+# trees wp-coding-agents copies into the web tree wholesale (installed
+# skills). Normalizes every file and dir under <dir> to the group owning
+# <dir>'s parent, with dirs getting the execute bit (0775) files 0664.
+service_dir_normalize_perms() {
+  local target="$1"
+  [ -n "$target" ] && [ -d "$target" ] || return 0
+
+  local parent group
+  parent="$(dirname -- "$target")"
+  group="$(stat -c '%G' "$parent" 2>/dev/null || stat -f '%Sg' "$parent" 2>/dev/null || true)"
+
+  find "$target" -type d -exec chmod 0775 {} + 2>/dev/null || true
+  find "$target" -type f -exec chmod 0664 {} + 2>/dev/null || true
+  if [ -n "$group" ]; then
+    chgrp -R "$group" "$target" 2>/dev/null || true
+  fi
+}
+
 # Robust git clone for setup-time plugin/skill deps:
 #   - Pins HTTP/1.1 to dodge intermittent GitHub HTTP/2 500s seen during
 #     fresh setup runs.

--- a/lib/runtime-signature.sh
+++ b/lib/runtime-signature.sh
@@ -107,9 +107,12 @@ runtime_signature_ensure_mu_plugin_file() {
 
   mkdir -p "$dir"
 
-  # Write the scaffold, then force mode 0644 regardless of the caller's
-  # umask (root cron/systemd contexts default to 0077 which strips the
-  # world-read bit PHP-FPM needs — see issue #133).
+  # Write the scaffold, then normalize mode/group regardless of the
+  # caller's umask or identity (root cron/systemd contexts default to
+  # umask 0077, which strips the world-read bit PHP-FPM needs — issue
+  # #133 — and root/opencode/www-data writers each leave a different
+  # owner, which without a shared group-writable mode breaks the next
+  # writer — issue #258).
   cat > "$file" <<'PHP'
 <?php
 /**
@@ -157,7 +160,7 @@ add_filter( 'datamachine_code_worktree_runtime_signatures', function ( $signatur
 } );
 PHP
 
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
 
   log "  Wrote runtime-signature mu-plugin scaffold: $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
@@ -278,9 +281,10 @@ runtime_signature_register() {
   fi
 
   mv "$tmp" "$file"
-  # Self-heal legacy 0600 files written before the umask fix in #133.
-  # mktemp creates with mode 0600 so mv preserves that — force 0644.
-  chmod 0644 "$file"
+  # mktemp creates the tmp file at mode 0600, so mv preserves that, and mv
+  # also preserves the tmp file's own owner rather than the destination's —
+  # self-heal both mode and group on every write (issue #133, issue #258).
+  service_file_normalize_perms "$file"
   log "  Registered runtime signature '$runtime_id' in $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("runtime signature: $runtime_id")
@@ -318,7 +322,7 @@ runtime_signature_unregister() {
   tmp=$(mktemp "${file}.XXXXXX")
   _runtime_signature_rewrite "$file" "$runtime_id" "" > "$tmp"
   mv "$tmp" "$file"
-  chmod 0644 "$file"
+  service_file_normalize_perms "$file"
   log "  Unregistered runtime signature '$runtime_id' from $file"
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("runtime signature removed: $runtime_id")

--- a/lib/skills.sh
+++ b/lib/skills.sh
@@ -42,6 +42,12 @@ install_skills_from_local_repo() {
     if [ -f "$skill_dir/SKILL.md" ] && is_wp_coding_agents_skill "$skill_name"; then
       rm -rf "$SKILLS_DIR/$skill_name"
       cp -r "$skill_dir" "$SKILLS_DIR/$skill_name"
+      # Skills dirs live under the web tree (.claude/skills, .opencode/skills,
+      # .agents/skills) and get rewritten across setup/upgrade runs that may
+      # each run as a different identity (root, opencode, www-data) — same
+      # multi-writer problem as the mu-plugins, just for a directory tree
+      # instead of a single file.
+      service_dir_normalize_perms "$SKILLS_DIR/$skill_name"
       log "  Installed upgrade skill: $skill_name"
       copied=$((copied + 1))
     fi

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -133,6 +133,7 @@ print(content[:si] + block + content[ei:], end='')
   CLAUDE_MD=$(echo "$CLAUDE_MD" | sed '/^$/N;/^\n$/d')
 
   write_file "$SITE_PATH/CLAUDE.md" "$CLAUDE_MD"
+  service_file_normalize_perms "$SITE_PATH/CLAUDE.md"
   log "Generated CLAUDE.md at $SITE_PATH/CLAUDE.md"
 }
 
@@ -161,6 +162,7 @@ runtime_install_hooks() {
   mkdir -p "$hooks_dir"
   cp "$hook_src" "$hook_dst"
   chmod +x "$hook_dst"
+  service_file_normalize_perms "$hook_dst"
   log "Installed hook: $hook_dst"
 
   # Persist the configured agent slug so the SessionStart hook scopes its @
@@ -170,6 +172,7 @@ runtime_install_hooks() {
   local hook_env="$hooks_dir/dm-agent-sync.env"
   if [ -n "${AGENT_SLUG:-}" ]; then
     printf 'DM_AGENT_SLUG=%s\n' "$AGENT_SLUG" > "$hook_env"
+    service_file_normalize_perms "$hook_env"
     log "Wrote hook agent scope: $hook_env (DM_AGENT_SLUG=$AGENT_SLUG)"
   fi
 
@@ -229,6 +232,7 @@ runtime_install_hooks() {
     ')
 
   echo "$settings" | jq . > "$settings_file"
+  service_file_normalize_perms "$settings_file"
 
   log "Configured settings.json: SessionStart hook, workspace permissions (dir + allow rules), autoMemoryEnabled=false"
 }
@@ -246,6 +250,7 @@ runtime_generate_instructions() {
   if [ "$DRY_RUN" = false ]; then
     sync_homeboy_availability
     if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
+      service_file_normalize_perms "$SITE_PATH/AGENTS.md"
       log "AGENTS.md composed from SectionRegistry"
       return
     fi
@@ -269,6 +274,7 @@ runtime_generate_instructions() {
   agents_md=$(sed "s|{{WP_CLI_CMD}}|$WP_CLI_DISPLAY|g" "$agents_tmpl")
 
   write_file "$SITE_PATH/AGENTS.md" "$agents_md"
+  service_file_normalize_perms "$SITE_PATH/AGENTS.md"
   log "Generated AGENTS.md at $SITE_PATH/AGENTS.md"
 }
 

--- a/runtimes/codex.sh
+++ b/runtimes/codex.sh
@@ -104,6 +104,7 @@ runtime_generate_instructions() {
   if [ "$DRY_RUN" = false ]; then
     sync_homeboy_availability
     if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
+      service_file_normalize_perms "$SITE_PATH/AGENTS.md"
       log "AGENTS.md composed from SectionRegistry"
       _codex_sync_override
       return
@@ -130,6 +131,7 @@ runtime_generate_instructions() {
     local agents_md
     agents_md=$(sed "s|{{WP_CLI_CMD}}|$wp_cli_display|g" "$agents_tmpl")
     write_file "$SITE_PATH/AGENTS.md" "$agents_md"
+    service_file_normalize_perms "$SITE_PATH/AGENTS.md"
     _codex_sync_override
   fi
 }

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -48,7 +48,7 @@ opencode_install_claude_code_auth_plugin() {
 
   mkdir -p "$plugins_dir"
   cp "$source_path" "$plugin_path"
-  chmod 644 "$plugin_path"
+  service_file_normalize_perms "$plugin_path"
   UPDATED_ITEMS+=("OpenCode Claude Code auth plugin ($plugin_path)")
 }
 
@@ -295,6 +295,7 @@ runtime_generate_config() {
     echo -e "${BLUE}[dry-run]${NC} Would write to $SITE_PATH/opencode.json"
   else
     echo -e "$OPENCODE_JSON" > "$SITE_PATH/opencode.json"
+    service_file_normalize_perms "$SITE_PATH/opencode.json"
   fi
 }
 
@@ -380,6 +381,7 @@ runtime_generate_instructions() {
   if [ "$DRY_RUN" = false ]; then
     sync_homeboy_availability
     if wp_cmd datamachine memory compose AGENTS.md 2>/dev/null; then
+      service_file_normalize_perms "$SITE_PATH/AGENTS.md"
       log "AGENTS.md composed from SectionRegistry"
       _opencode_symlink_claude_md
       return
@@ -405,6 +407,7 @@ runtime_generate_instructions() {
     echo -e "${BLUE}[dry-run]${NC} Would symlink CLAUDE.md → AGENTS.md (Claude-model context)"
   else
     sed "s|{{WP_CLI_CMD}}|$wp_cli_display|g" "$agents_tmpl" > "$SITE_PATH/AGENTS.md"
+    service_file_normalize_perms "$SITE_PATH/AGENTS.md"
     _opencode_symlink_claude_md
   fi
 }
@@ -440,6 +443,7 @@ runtime_merge_mcp_servers() {
   jq --argjson mcp "$MCP_SERVERS" '.mcp = $mcp' "$SITE_PATH/opencode.json" \
     > "$SITE_PATH/opencode.json.tmp" \
     && mv "$SITE_PATH/opencode.json.tmp" "$SITE_PATH/opencode.json"
+  service_file_normalize_perms "$SITE_PATH/opencode.json"
 }
 
 runtime_install_hooks() {

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -71,15 +71,29 @@ file_mode() {
   fi
 }
 
-assert_mode_0644() {
+assert_mode_0664() {
   local file="$1" name="$2" got
   got=$(file_mode "$file")
-  if [ "$got" = "644" ]; then
+  if [ "$got" = "664" ]; then
     echo "  ok   $name"
   else
     echo "  FAIL $name"
     echo "    got:  $got"
-    echo "    want: 644"
+    echo "    want: 664"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_group() {
+  local file="$1" name="$2" got want
+  got=$(stat -c %G "$file" 2>/dev/null || stat -f %Sg "$file")
+  want=$(stat -c %G "$(dirname "$file")" 2>/dev/null || stat -f %Sg "$(dirname "$file")")
+  if [ "$got" = "$want" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "    got:  $got"
+    echo "    want: $want (parent dir's group)"
     FAILED=$((FAILED + 1))
   fi
 }
@@ -103,7 +117,8 @@ echo "==> register generic guidance"
 )
 
 assert_php_lint "$MU_FILE" "guidance mu-plugin parses with php -l"
-assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after fresh write under umask 077"
+assert_mode_0664 "$MU_FILE" "mu-plugin mode 0664 after fresh write under umask 077"
+assert_group "$MU_FILE" "mu-plugin group after fresh write"
 
 if grep -q "BEGIN agents-md-guidance:sample-guidance" "$MU_FILE"; then
   echo "  ok   sample guidance block present"
@@ -199,7 +214,8 @@ assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives generic guidance secti
 echo "==> unregister generic guidance"
 chmod 0600 "$MU_FILE"
 agents_md_guidance_unregister "sample-guidance"
-assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
+assert_mode_0664 "$MU_FILE" "mu-plugin mode 0664 after unregister"
+assert_group "$MU_FILE" "mu-plugin group after unregister"
 if grep -q "BEGIN agents-md-guidance:sample-guidance" "$MU_FILE"; then
   echo "  FAIL sample guidance block still present after unregister"
   FAILED=$((FAILED + 1))

--- a/tests/cli-channel-perms.sh
+++ b/tests/cli-channel-perms.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
-# tests/cli-channel-perms.sh — Regression coverage for issue #133 in
-# lib/cli-channel.sh.
+# tests/cli-channel-perms.sh — Regression coverage for issue #133 and
+# issue #258 in lib/cli-channel.sh.
 #
 # The mu-plugin file written by cli_channel_ensure_mu_plugin_file /
-# cli_channel_register must land at mode 0644 regardless of the caller's
-# umask, because PHP-FPM (running as www-data) needs world-read to load it.
-# Root cron/systemd contexts default to umask 0077 → 0600, which broke
-# every install that ran setup.sh / upgrade.sh from a daemon context.
+# cli_channel_register must land at mode 0664 and be group-owned by its
+# parent directory's group, regardless of the caller's umask or identity.
+# PHP-FPM (www-data) needs world-read to load it (#133: root cron/systemd
+# contexts default to umask 0077 → 0600, breaking every daemon-context
+# install). Group-writable + group-inherited (#258) is needed on top of
+# that because root (upgrade), the service user (opencode, member of the
+# webroot group), and www-data all write this file across different runs —
+# 0644 with a mismatched owner locks the next writer out entirely.
 #
-# Asserts the three write paths each produce mode 0644:
+# Asserts the three write paths each produce mode 0664 + inherited group:
 #   1. Fresh scaffold (cli_channel_ensure_mu_plugin_file)
 #   2. Subsequent register replacing/inserting a block (mktemp + mv)
 #   3. Unregister removing a block (mktemp + mv)
 #
-# Also asserts the self-heal behavior: if a legacy file is mode 0600
-# (left by a pre-#133 install), the next register call must restore 0644.
+# Also asserts the self-heal behavior: if a legacy file is mode 0600 or
+# owned by a different group (left by a pre-fix install or an upgrade that
+# ran as a different identity than the last write), the next register call
+# must restore 0664 + the parent dir's group.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -46,9 +52,10 @@ if [ "$VERBOSE" = false ]; then
 fi
 
 MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-channels.php"
+DIR_GROUP="$(stat -c %G "$TMP/wp-content/mu-plugins" 2>/dev/null || stat -f %Sg "$TMP/wp-content/mu-plugins")"
 FAILED=0
 
-assert_mode_0644() {
+assert_mode_0664() {
   local file="$1" name="$2"
   local got
   if stat -c %a "$file" >/dev/null 2>&1; then
@@ -56,12 +63,26 @@ assert_mode_0644() {
   else
     got=$(stat -f %Lp "$file")
   fi
-  if [ "$got" = "644" ]; then
+  if [ "$got" = "664" ]; then
     echo "  ok   $name"
   else
     echo "  FAIL $name"
     echo "    got:  $got"
-    echo "    want: 644"
+    echo "    want: 664"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_group() {
+  local file="$1" name="$2"
+  local got
+  got=$(stat -c %G "$file" 2>/dev/null || stat -f %Sg "$file")
+  if [ "$got" = "$DIR_GROUP" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "    got:  $got"
+    echo "    want: $DIR_GROUP (parent dir's group)"
     FAILED=$((FAILED + 1))
   fi
 }
@@ -74,7 +95,8 @@ echo "==> register kimaki (fresh scaffold, umask 077)"
     "/usr/local/bin/kimaki" \
     '["send","--channel","{recipient}","--prompt","{message}"]'
 )
-assert_mode_0644 "$MU_FILE" "fresh scaffold lands as 0644 under umask 077"
+assert_mode_0664 "$MU_FILE" "fresh scaffold lands as 0664 under umask 077"
+assert_group "$MU_FILE" "fresh scaffold inherits parent dir group"
 
 # --- 2. Sibling register exercises mktemp + mv path; self-heal from 0600 ---
 echo "==> simulate legacy 0600 file and verify self-heal on next register"
@@ -85,16 +107,18 @@ chmod 0600 "$MU_FILE"
     "/usr/local/bin/opencode-telegram" \
     '["dispatch","--chat","{recipient}","--text","{message}"]'
 )
-assert_mode_0644 "$MU_FILE" "mu-plugin self-healed to 0644 after sibling register"
+assert_mode_0664 "$MU_FILE" "mu-plugin self-healed to 0664 after sibling register"
+assert_group "$MU_FILE" "mu-plugin self-healed group after sibling register"
 
-# --- 3. Unregister also lands as 0644 --------------------------------------
+# --- 3. Unregister also lands as 0664 --------------------------------------
 echo "==> unregister opencode-telegram"
 chmod 0600 "$MU_FILE"
 (
   umask 077
   cli_channel_unregister "opencode-telegram"
 )
-assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
+assert_mode_0664 "$MU_FILE" "mu-plugin mode 0664 after unregister"
+assert_group "$MU_FILE" "mu-plugin group after unregister"
 
 # --- Done ------------------------------------------------------------------
 echo

--- a/tests/cli-transport-install.sh
+++ b/tests/cli-transport-install.sh
@@ -23,17 +23,29 @@ warn() { echo "WARN: $1" >&2; }
 MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-cli-transport.php"
 FAILED=0
 
-assert_mode_0644() {
+assert_mode_0664() {
   local got
   if stat -c %a "$MU_FILE" >/dev/null 2>&1; then
     got=$(stat -c %a "$MU_FILE")
   else
     got=$(stat -f %Lp "$MU_FILE")
   fi
-  if [ "$got" = "644" ]; then
-    echo "  ok   transport mu-plugin mode 0644"
+  if [ "$got" = "664" ]; then
+    echo "  ok   transport mu-plugin mode 0664"
   else
-    echo "  FAIL transport mu-plugin mode got $got, want 644"
+    echo "  FAIL transport mu-plugin mode got $got, want 664"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_group() {
+  local got want
+  got=$(stat -c %G "$MU_FILE" 2>/dev/null || stat -f %Sg "$MU_FILE")
+  want=$(stat -c %G "$(dirname "$MU_FILE")" 2>/dev/null || stat -f %Sg "$(dirname "$MU_FILE")")
+  if [ "$got" = "$want" ]; then
+    echo "  ok   transport mu-plugin group matches parent dir ($want)"
+  else
+    echo "  FAIL transport mu-plugin group got $got, want $want (parent dir's group)"
     FAILED=$((FAILED + 1))
   fi
 }
@@ -57,11 +69,25 @@ else
   echo "  ok   transport mu-plugin matches template"
 fi
 
-assert_mode_0644
+assert_mode_0664
+assert_group
 
+# Legacy-mode self-heal: content unchanged, mode drifted back to 0600.
 chmod 0600 "$MU_FILE"
 cli_transport_install
-assert_mode_0644
+assert_mode_0664
+assert_group
+
+# Live-bug regression (see issue #258): content unchanged but a *different*
+# writer identity left the file with mismatched ownership (observed live:
+# root:www-data / opencode:www-data / www-data:www-data across 4 sibling
+# mu-plugins from the same installer, none group-writable). The
+# content-unchanged short-circuit in cli_transport_install must still
+# normalize mode/group, not just skip out early once cmp -s matches.
+chmod 0644 "$MU_FILE"
+cli_transport_install
+assert_mode_0664
+assert_group
 
 if [ "$FAILED" -gt 0 ]; then
   echo "FAILED: $FAILED assertion(s)"

--- a/tests/opencode-local-plugin-path.sh
+++ b/tests/opencode-local-plugin-path.sh
@@ -28,6 +28,8 @@ log() { :; }
 warn() { printf '%s\n' "$*" >&2; }
 
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/runtimes/opencode.sh"
 
 runtime_generate_config

--- a/tests/opencode-wrapper-removal.sh
+++ b/tests/opencode-wrapper-removal.sh
@@ -70,6 +70,8 @@ TMPDIR_TEST="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
 # shellcheck disable=SC1091
+source lib/common.sh
+# shellcheck disable=SC1091
 source runtimes/opencode.sh
 UPDATED_ITEMS=()
 

--- a/tests/runtime-signature.sh
+++ b/tests/runtime-signature.sh
@@ -99,23 +99,39 @@ file_mode() {
   fi
 }
 
-assert_mode_0644() {
+assert_mode_0664() {
   local file="$1" name="$2"
   local got
   got=$(file_mode "$file")
-  if [ "$got" = "644" ]; then
+  if [ "$got" = "664" ]; then
     echo "  ok   $name"
   else
     echo "  FAIL $name"
     echo "    got:  $got"
-    echo "    want: 644"
+    echo "    want: 664"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_group() {
+  local file="$1" name="$2"
+  local got want
+  got=$(stat -c %G "$file" 2>/dev/null || stat -f %Sg "$file")
+  want=$(stat -c %G "$(dirname "$file")" 2>/dev/null || stat -f %Sg "$(dirname "$file")")
+  if [ "$got" = "$want" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "    got:  $got"
+    echo "    want: $want (parent dir's group)"
     FAILED=$((FAILED + 1))
   fi
 }
 
 # --- 1. Fresh scaffold + register opencode ---------------------------------
 # Use a hostile umask (matches root cron/systemd default 0077) to prove the
-# helper forces 0644 regardless of caller umask — see issue #133.
+# helper forces 0664 + the parent dir's group regardless of caller umask —
+# see issue #133 (world-read) and issue #258 (group-write / multi-writer).
 echo "==> register opencode (fresh scaffold, umask 077)"
 (
   umask 077
@@ -124,7 +140,8 @@ echo "==> register opencode (fresh scaffold, umask 077)"
 )
 assert_file_exists "$MU_FILE" "mu-plugin created"
 assert_php_lint "$MU_FILE" "scaffold parses with php -l"
-assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after fresh write under umask 077"
+assert_mode_0664 "$MU_FILE" "mu-plugin mode 0664 after fresh write under umask 077"
+assert_group "$MU_FILE" "mu-plugin group after fresh write"
 
 if grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
   echo "  ok   opencode block present"
@@ -149,7 +166,8 @@ chmod 0600 "$MU_FILE"
 runtime_signature_register "kimaki" \
   '{"session_id":"KIMAKI_SESSION_ID","thread_id":"KIMAKI_THREAD_ID","thread_url":"KIMAKI_THREAD_URL"}'
 assert_php_lint "$MU_FILE" "two-runtime file parses with php -l"
-assert_mode_0644 "$MU_FILE" "mu-plugin mode self-healed to 0644 after sibling register"
+assert_mode_0664 "$MU_FILE" "mu-plugin mode self-healed to 0664 after sibling register"
+assert_group "$MU_FILE" "mu-plugin group self-healed after sibling register"
 
 if grep -q "BEGIN runtime:kimaki" "$MU_FILE" && grep -q "BEGIN runtime:opencode" "$MU_FILE"; then
   echo "  ok   both runtime blocks present"
@@ -191,7 +209,8 @@ else
   FAILED=$((FAILED + 1))
 fi
 assert_php_lint "$MU_FILE" "post-unregister file parses with php -l"
-assert_mode_0644 "$MU_FILE" "mu-plugin mode 0644 after unregister"
+assert_mode_0664 "$MU_FILE" "mu-plugin mode 0664 after unregister"
+assert_group "$MU_FILE" "mu-plugin group after unregister"
 
 # --- 6. Filter-shape end-to-end (php execution) ----------------------------
 echo "==> apply_filters returns the expected shape"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -495,7 +495,7 @@ upgrade_install_opencode_claude_code_auth_plugin() {
   fi
 
   cp "$source_path" "$plugin_path"
-  chmod 644 "$plugin_path"
+  service_file_normalize_perms "$plugin_path"
   UPDATED_ITEMS+=("OpenCode Claude Code auth plugin ($plugin_path)")
 }
 
@@ -639,6 +639,12 @@ for item in data:
     --backup-suffix "$TIMESTAMP" 2>&1) && repair_rc=0 || repair_rc=$?
   [ -z "$MANAGED_INSTRUCTIONS_FILE" ] || rm -f "$MANAGED_INSTRUCTIONS_FILE"
 
+  # repair-opencode-json.py writes both the target file and its own backup
+  # via plain Python open() — inherits the caller's umask/identity same as
+  # every other service-file writer in this repo. Normalize both.
+  service_file_normalize_perms "$OPENCODE_JSON_FILE"
+  service_file_normalize_perms "${OPENCODE_JSON_FILE}.backup.$TIMESTAMP"
+
   local repair_status prompt_migration instruction_sync
   repair_status=$(echo "$repair_out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('status','?'))" 2>/dev/null || echo "parse-error")
   prompt_migration=$(echo "$repair_out" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('prompt_migration','?'))" 2>/dev/null || echo "?")
@@ -752,13 +758,19 @@ regenerate_agents_md() {
   # Backup existing (compose writes in-place to the registered location)
   if [ -f "$AGENTS_MD" ]; then
     cp "$AGENTS_MD" "$BACKUP"
+    service_file_normalize_perms "$BACKUP"
     log "  Backup: $BACKUP"
   fi
 
   # `datamachine memory compose AGENTS.md` writes in-place to the registered
   # composable file path. It does NOT accept an arbitrary output path —
-  # the filename must be a registered MemoryFileRegistry entry.
+  # the filename must be a registered MemoryFileRegistry entry. Compose runs
+  # as the wp-coding-agents caller's identity (root during upgrade, opencode
+  # during local dev), so normalize afterward the same way every other
+  # service-file writer does — otherwise the identity that ran this upgrade
+  # is the only one that can write AGENTS.md until the next normalize.
   if (cd "$SITE_PATH" && $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG >/dev/null 2>&1); then
+    service_file_normalize_perms "$AGENTS_MD"
     if [ -f "$BACKUP" ] && cmp -s "$BACKUP" "$AGENTS_MD"; then
       log "  AGENTS.md unchanged"
       rm -f "$BACKUP" 2>/dev/null || true
@@ -776,6 +788,7 @@ regenerate_agents_md() {
     # Restore from backup if compose wrote a partial file
     if [ -f "$BACKUP" ] && [ -f "$AGENTS_MD" ] && ! cmp -s "$BACKUP" "$AGENTS_MD"; then
       cp "$BACKUP" "$AGENTS_MD"
+      service_file_normalize_perms "$AGENTS_MD"
       warn "  Restored AGENTS.md from backup"
     fi
   fi
@@ -910,6 +923,7 @@ sync_claude_code_runtime() {
       echo -e "${BLUE}[dry-run]${NC} Would (back up and) regenerate CLAUDE.md from template"
     elif [ -f "$claude_md" ]; then
       cp "$claude_md" "$claude_md.backup.$TIMESTAMP"
+      service_file_normalize_perms "$claude_md.backup.$TIMESTAMP"
       rm -f "$claude_md"
       log "  CLAUDE.md was missing the DM memory block — backed up to $claude_md.backup.$TIMESTAMP"
       UPDATED_ITEMS+=("CLAUDE.md regenerated")


### PR DESCRIPTION
Closes #258.

## Problem

Every setup/upgrade writer that touches `wp-content/mu-plugins/*.php` (and
sibling service files under the web tree: `AGENTS.md`, `CLAUDE.md`,
`opencode.json`, installed skill dirs, the Claude Code SessionStart hook +
`settings.json`) forces mode `0644` after writing (issue #133's fix for the
world-read bit stripped by a hostile root cron/systemd umask), but never
normalizes *ownership* or adds group-write. On a live install where
setup/upgrade has run as different identities over time — root via
cron/systemd-triggered upgrades, the service user via local dev, `www-data`
via a WP-CLI fallback — each writer leaves the file owned by whoever ran
that particular sync, with no group-write bit for the next writer identity
to rely on. Live evidence on extrachill.com (see #258): four sibling
mu-plugin files from the same installer, three different owners, none
group-writable.

## Fix

Adds two helpers to `lib/common.sh`:

- `service_file_normalize_perms <file>` — `chmod 0664` + `chgrp` to the
  file's **parent directory's group** (derived via `stat`, not hardcoded to
  `www-data` — different hosts use different webroot groups, so this stays
  correct across installs without wp-coding-agents needing an opinion about
  the target server's naming convention). Both operations are best-effort
  (`|| true`) — a caller that isn't in the target group still gets the mode
  fix even if the `chgrp` fails.
- `service_dir_normalize_perms <dir>` — recursive counterpart for the
  skills-directory case (whole trees copied via `cp -r`): `0775` for dirs,
  `0664` for files, group inherited from the parent.

Wires both into every write site under the web tree that previously called
bare `chmod 0644`:

- `lib/agents-md-guidance.sh` — 4 sites (scaffold, register, unregister,
  homeboy-cli live section).
- `lib/cli-channel.sh` — 3 sites (scaffold, register, unregister).
- `lib/cli-transport.sh` — 2 sites, **including the content-unchanged
  short-circuit** (`cmp -s` match → early return), which previously let
  ownership drift persist silently across no-op syncs forever. Now it
  self-heals mode/group every time, not just when content changes.
- `lib/runtime-signature.sh` — 3 sites (scaffold, register, unregister).
- `lib/skills.sh` — installed skill directory trees, via the new
  `service_dir_normalize_perms`.
- `upgrade.sh` — `AGENTS.md` regeneration + its `.backup.<ts>` sidecar, the
  `opencode.json` repair path (`lib/repair-opencode-json.py` writes via
  plain Python `open()`, same umask/identity inheritance bug) + its own
  backup, the Claude Code `CLAUDE.md` regeneration backup, and the OpenCode
  Claude Code auth plugin sync.
- `runtimes/opencode.sh` — `opencode.json` (initial write + MCP merge),
  `AGENTS.md` (both compose-output write paths), the Claude Code auth
  plugin file.
- `runtimes/claude-code.sh` — `CLAUDE.md`, `AGENTS.md` (compose output),
  the SessionStart hook script + its `dm-agent-sync.env` sidecar,
  `.claude/settings.json`.
- `runtimes/codex.sh` — `AGENTS.md` (both the template-fallback and
  compose-output write paths).

Left alone (correctly root-owned / single-identity, not part of the
web-tree multi-writer surface, per issue #258's scoping): systemd/launchd
unit files, the kimaki sudoers/dispatch-wrapper install, secrets files
(`wp-ai-gateway.env`, credentials file — intentionally `0600`
single-owner), and anything under `/opt/kimaki-config` or `~/.kimaki`
(outside the web tree).

## Tests

Updated the three existing perms regression tests to assert the new
contract (`0664` + parent-dir-inherited group instead of bare `0644`):
`tests/cli-channel-perms.sh`, `tests/runtime-signature.sh`,
`tests/agents-md-guidance.sh`. Added an ownership-mismatch regression case
to `tests/cli-transport-install.sh` that reproduces the exact live bug
(content matches, ownership doesn't — the content-unchanged short-circuit
must still normalize).

Also fixed two pre-existing test-harness gaps
(`tests/opencode-local-plugin-path.sh`,
`tests/opencode-wrapper-removal.sh`) that sourced `runtimes/opencode.sh`
directly without `lib/common.sh` — harmless before this change since
`chmod` is a builtin, but the new `service_file_normalize_perms` call now
requires it, so both tests needed the missing `source lib/common.sh` (this
mirrors how `upgrade.sh`/`setup.sh` always source `common` before any
runtime file in production; the test harness gap was latent, not a real
production bug).

Full suite: `for f in tests/*.sh; do bash "$f"; done` — all 28 pass. The
one pre-existing failure (`tests/bridge-render.sh`, a PATH-ordering
snapshot drift on this host) reproduces identically on `main` before this
branch's changes and is unrelated (verified via `git stash`).

## Notes / judgment calls

- `0664`/`0775` chosen over honoring the caller's raw umask, matching the
  existing forced-`0644` precedent from #133 — service files need a
  predictable mode regardless of caller umask, not umask-dependent
  behavior.
- Group derivation is `stat -c %G "$(dirname "$file")"` (with a BSD/macOS
  `stat -f %Sg` fallback for local dev) rather than a `SERVICE_USER`- or
  `www-data`-keyed lookup, per the "derive from target dir, don't hardcode"
  guidance in the issue — this also means the fix does something sane on
  hosts that don't use `www-data` as the webroot group at all.
- Did not touch `lib/ai-gateway.sh`'s env file or `lib/summary.sh`'s
  credentials file — both are intentionally `0600` single-owner secrets,
  explicitly out of scope per the issue.