### PR TITLE
Add Data Machine worker heartbeat service

### DIFF
--- a/bridges/_dispatch.sh
+++ b/bridges/_dispatch.sh
@@ -255,11 +255,16 @@ _preserve_systemd_umask() {
 adopt_service_identity_from_units() {
   [ "${LOCAL_MODE:-false}" = true ] && return 0
   [ "${SERVICE_USER_FORCED:-false}" = true ] && return 0
-  declare -F bridge_systemd_units >/dev/null 2>&1 || return 0
-
   local unit_dir="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
   local unit unit_user unit_home
-  for unit in $(bridge_systemd_units); do
+  local units=""
+  if declare -F bridge_systemd_units >/dev/null 2>&1; then
+    units="$(bridge_systemd_units)"
+  fi
+  if declare -F datamachine_worker_systemd_units >/dev/null 2>&1; then
+    units="$units $(datamachine_worker_systemd_units)"
+  fi
+  for unit in $units; do
     [ -f "$unit_dir/$unit" ] || continue
     unit_user=$(_systemd_unit_user "$unit_dir/$unit") || continue
 

--- a/services/datamachine-worker.sh
+++ b/services/datamachine-worker.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Data Machine queue heartbeat service. Runs a bounded worker pass regularly so
+# headless WordPress installs do not depend on HTTP-triggered WP-Cron traffic.
+
+datamachine_worker_systemd_units() { echo "datamachine-worker.service datamachine-worker.timer"; }
+datamachine_worker_launchd_label() { echo "com.wp.datamachine-worker"; }
+
+_datamachine_worker_command() {
+  printf '%s' "cd \"$SITE_PATH\" && $WP_CMD datamachine worker run --once"
+}
+
+datamachine_worker_render_systemd_service() {
+  cat <<EOF
+[Unit]
+Description=Data Machine queue worker heartbeat (wp-coding-agents)
+After=network.target
+
+[Service]
+Type=oneshot
+User=$SERVICE_USER
+WorkingDirectory=$SITE_PATH
+Environment=HOME=$SERVICE_HOME
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/bin/sh -lc '$(_datamachine_worker_command)'
+EOF
+}
+
+datamachine_worker_render_systemd_timer() {
+  cat <<'EOF'
+[Unit]
+Description=Run Data Machine queue worker heartbeat every two minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+Unit=datamachine-worker.service
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+datamachine_worker_render_launchd() {
+  local label="$1"
+  local log_dir="$SERVICE_HOME/.datamachine"
+  [ "$label" = "com.wp.datamachine-worker" ] || return 1
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$label</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>-lc</string>
+        <string>$(_datamachine_worker_command)</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$SITE_PATH</string>
+    <key>StartInterval</key>
+    <integer>120</integer>
+    <key>StandardOutPath</key>
+    <string>$log_dir/datamachine-worker.log</string>
+    <key>StandardErrorPath</key>
+    <string>$log_dir/datamachine-worker.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>$SERVICE_HOME</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>
+EOF
+}
+
+datamachine_worker_install() {
+  if [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
+    local label plist_dir plist
+    label="$(datamachine_worker_launchd_label)"
+    plist_dir="$HOME/Library/LaunchAgents"
+    plist="$plist_dir/$label.plist"
+    run_cmd mkdir -p "$plist_dir" "$SERVICE_HOME/.datamachine"
+    write_file "$plist" "$(datamachine_worker_render_launchd "$label")"
+    if [ "$DRY_RUN" = false ]; then
+      launchctl bootout "gui/$(id -u)" "$plist" 2>/dev/null || true
+      launchctl bootstrap "gui/$(id -u)" "$plist"
+    fi
+    log "Data Machine worker heartbeat: $label"
+    return
+  fi
+
+  if [ "$LOCAL_MODE" = true ]; then
+    warn "Data Machine worker heartbeat requires launchd or systemd; local manual mode is not supervised."
+    return
+  fi
+
+  write_file "/etc/systemd/system/datamachine-worker.service" "$(datamachine_worker_render_systemd_service)"
+  write_file "/etc/systemd/system/datamachine-worker.timer" "$(datamachine_worker_render_systemd_timer)"
+  if [ "$DRY_RUN" = false ]; then
+    systemctl daemon-reload
+    systemctl enable --now datamachine-worker.timer
+  fi
+}
+
+datamachine_worker_update() {
+  if [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
+    local label plist
+    label="$(datamachine_worker_launchd_label)"
+    plist="$HOME/Library/LaunchAgents/$label.plist"
+    [ -f "$plist" ] || return 0
+    write_file "$plist" "$(datamachine_worker_render_launchd "$label")"
+    if [ "$DRY_RUN" = false ]; then
+      launchctl bootout "gui/$(id -u)" "$plist" 2>/dev/null || true
+      launchctl bootstrap "gui/$(id -u)" "$plist"
+    fi
+    return
+  fi
+  [ "$LOCAL_MODE" = true ] && return 0
+  _smart_update_systemd_unit /etc/systemd/system/datamachine-worker.service "$(datamachine_worker_render_systemd_service)" datamachine-worker.service
+  _smart_update_systemd_unit /etc/systemd/system/datamachine-worker.timer "$(datamachine_worker_render_systemd_timer)" datamachine-worker.timer
+  if [ "$DRY_RUN" = false ]; then
+    systemctl restart datamachine-worker.timer
+  fi
+}

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,7 @@ done
 # "drop a file in bridges/" — no edit here.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/bridges/_dispatch.sh"
+source "$SCRIPT_DIR/services/datamachine-worker.sh"
 
 # Discover available runtimes from runtimes/ directory
 AVAILABLE_RUNTIMES=()
@@ -415,4 +416,5 @@ runtime_merge_mcp_servers
 install_skills
 cli_transport_install
 install_chat_bridge
+datamachine_worker_install
 print_summary

--- a/tests/__snapshots__/datamachine-worker/launchd
+++ b/tests/__snapshots__/datamachine-worker/launchd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wp.datamachine-worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>-lc</string>
+        <string>cd "/var/www/site" && wp datamachine worker run --once</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/var/www/site</string>
+    <key>StartInterval</key>
+    <integer>120</integer>
+    <key>StandardOutPath</key>
+    <string>/home/chubes/.datamachine/datamachine-worker.log</string>
+    <key>StandardErrorPath</key>
+    <string>/home/chubes/.datamachine/datamachine-worker.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/home/chubes</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/__snapshots__/datamachine-worker/systemd-service
+++ b/tests/__snapshots__/datamachine-worker/systemd-service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Data Machine queue worker heartbeat (wp-coding-agents)
+After=network.target
+
+[Service]
+Type=oneshot
+User=chubes
+WorkingDirectory=/var/www/site
+Environment=HOME=/home/chubes
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/bin/sh -lc 'cd "/var/www/site" && wp datamachine worker run --once'

--- a/tests/__snapshots__/datamachine-worker/systemd-timer
+++ b/tests/__snapshots__/datamachine-worker/systemd-timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Data Machine queue worker heartbeat every two minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+Unit=datamachine-worker.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export SITE_PATH=/var/www/site SERVICE_USER=chubes SERVICE_HOME=/home/chubes
+export WP_CMD=wp LOCAL_MODE=false PLATFORM=linux DRY_RUN=false
+source "$SCRIPT_DIR/services/datamachine-worker.sh"
+
+service="$(datamachine_worker_render_systemd_service)"
+timer="$(datamachine_worker_render_systemd_timer)"
+plist="$(datamachine_worker_render_launchd com.wp.datamachine-worker)"
+
+snapshot_dir="$SCRIPT_DIR/tests/__snapshots__/datamachine-worker"
+diff -u "$snapshot_dir/systemd-service" <(printf '%s\n' "$service")
+diff -u "$snapshot_dir/systemd-timer" <(printf '%s\n' "$timer")
+diff -u "$snapshot_dir/launchd" <(printf '%s\n' "$plist")
+
+grep -q '^User=chubes$' <<< "$service"
+grep -q 'wp datamachine worker run --once' <<< "$service"
+grep -q '^OnUnitActiveSec=2min$' <<< "$timer"
+grep -q '<integer>120</integer>' <<< "$plist"
+grep -q 'com.wp.datamachine-worker' <<< "$plist"
+echo "PASS: tests/datamachine-worker.sh"

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -234,7 +234,9 @@ fi
 exit 0
 SH
 chmod +x "$MOCKBIN/homeboy"
-touch -d '+2 seconds' "$MOCKBIN/homeboy"
+# BSD/macOS touch does not support GNU's `-d`; a fixed future timestamp is
+# sufficient to make the binary mtime cache key differ on every platform.
+touch -t 203001010000 "$MOCKBIN/homeboy"
 
 LIVE_SHIM="$TMP/live-shim.php"
 cat > "$LIVE_SHIM" <<PHP

--- a/tests/kimaki-launchd-start.sh
+++ b/tests/kimaki-launchd-start.sh
@@ -32,6 +32,7 @@ chmod +x "$TMP/bin/kimaki"
 TEST_TMP="$TMP" \
 PATH="$TMP/bin:/usr/bin:/bin" \
 KIMAKI_DATA_DIR="$TMP/data" \
+KIMAKI_CONFIG_DIR="" \
   "$SCRIPT_DIR/bridges/kimaki/launchd-start.sh" "$TMP/bin/kimaki" --data-dir "$TMP/data" --auto-restart
 
 if ! grep -q -- '-TERM -f opencode-ai/bin/.*serve' "$TMP/pkill.log"; then

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -75,6 +75,7 @@ done
 # render templates, sync, systemd/launchd update, and summary blocks.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/bridges/_dispatch.sh"
+source "$SCRIPT_DIR/services/datamachine-worker.sh"
 
 # Discover available runtimes
 AVAILABLE_RUNTIMES=()
@@ -1034,6 +1035,11 @@ update_chat_bridge_launchd() {
   bridge_update_launchd
 }
 
+update_datamachine_worker_service() {
+  _run_filter_active systemd || return 0
+  datamachine_worker_update
+}
+
 # ============================================================================
 # Phase 7: Remove legacy opencode-claude-auth wrapper, if any
 #
@@ -1206,5 +1212,6 @@ sync_runtime_signature
 sync_runtime_instructions
 update_chat_bridge_systemd
 update_chat_bridge_launchd
+update_datamachine_worker_service
 remove_legacy_opencode_wrapper_phase
 print_summary


### PR DESCRIPTION
## Problem
Headless local installs receive no HTTP traffic, leaving WP-Cron and the Data Machine Action Scheduler queue overdue indefinitely.

## Fix
- Add a managed Data Machine worker heartbeat service that runs `wp datamachine worker run --once` every two minutes.
- Install and refresh a macOS launchd agent or VPS systemd service/timer alongside the existing managed services.
- Preserve existing systemd service identities during upgrades, including installations without a chat bridge.
- Add deterministic service-template snapshots and make two existing shell tests portable to the local macOS environment.

## How to test
1. From a fresh checkout, run `for test in tests/*.sh; do bash "$test" || exit 1; done`.
2. On macOS, run `EXISTING_WP=/path/to/site ./setup.sh --local`, then run `launchctl print gui/$(id -u)/com.wp.datamachine-worker`.
3. Confirm `~/Library/LaunchAgents/com.wp.datamachine-worker.plist` invokes `wp datamachine worker run --once` with a 120-second `StartInterval`.
4. On a VPS install, run `systemctl status datamachine-worker.timer` and confirm it schedules `datamachine-worker.service` every two minutes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (Opus 4.5) via Kimaki/OpenCode subagent
- **Used for:** Implementation and tests for issue #262