### PR TITLE
Configure Homeboy's DMC worktree result mapping

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -109,7 +109,7 @@ homeboy_dmc_command_json() {
 
   case "$action" in
     list)
-      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree list --format=json "${wp_flags[@]}"
+      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree list --with-status --format=json "${wp_flags[@]}"
       ;;
     cleanup_preview)
       homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --dry-run --format=json "${wp_flags[@]}"
@@ -121,7 +121,7 @@ homeboy_dmc_command_json() {
 }
 
 homeboy_dmc_worktree_provider_json() {
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"list":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
     "$(homeboy_dmc_command_json list)" \
     "$(homeboy_dmc_command_json cleanup_preview)" \
     "$(homeboy_dmc_command_json cleanup_apply)"

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -43,6 +43,31 @@ assert_not_contains() {
   fi
 }
 
+assert_provider_mapping() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+line = open(sys.argv[1], encoding="utf-8").read().strip()
+_, payload = line.split("|", 1)
+try:
+    provider = json.loads(payload)
+except json.JSONDecodeError as error:
+    raise SystemExit(f"FAIL: provider config is not valid JSON: {error}: {payload!r}")
+expected = {
+    "items": "$",
+    "handle": "$.handle",
+    "path": "$.path",
+    "branch": "$.branch",
+    "dirty": "$.safety.dirty",
+    "unpushed": "$.safety.unpushed",
+    "primary": "$.safety.primary",
+}
+if provider.get("list_result_mapping") != expected:
+    raise SystemExit("FAIL: provider list_result_mapping does not match the DMC safety output")
+PY
+}
+
 FAKE_BIN="$TMP/bin"
 mkdir -p "$FAKE_BIN"
 
@@ -80,7 +105,7 @@ DRY_RUN=true
 configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 
 assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
-assert_contains "\"list\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"list\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--with-status\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 if [ -f "$HOMEBOY_CONFIG_LOG" ]; then
@@ -94,6 +119,7 @@ configure_homeboy_dmc_worktree_provider > "$TMP/apply.log"
 
 assert_contains "wp datamachine-code workspace worktree list --format=json --path=$SITE_PATH" "$STUDIO_LOG"
 assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
+assert_provider_mapping "$HOMEBOY_CONFIG_LOG"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
 
 HOMEBOY_MODE="disabled"


### PR DESCRIPTION
Fixes #265

## Dependency
Depends on Extra-Chill/data-machine-code#893, which adds the DMC `safety` fields mapped here.

## What changed
- Adds `--with-status` to the DMC list command configured for Homeboy.
- Adds the explicit `list_result_mapping` required by Homeboy's command-provider contract.
- Verifies the serialized provider JSON and DMC mapping with the existing provider test.

## Provider contract verification
Verified against [Homeboy's worktree provider source](https://github.com/Extra-Chill/homeboy/blob/main/src/core/worktree_providers.rs): Homeboy parses each selector with `serde_json_path`, queries it against the list response, requires exactly one result, then requires `items` to be an array. Therefore `items: "$"` is valid for DMC's top-level JSON array; all remaining selectors run per array item.

## Config
```json
{
  "list_result_mapping": {
    "items": "$",
    "handle": "$.handle",
    "path": "$.path",
    "branch": "$.branch",
    "dirty": "$.safety.dirty",
    "unpushed": "$.safety.unpushed",
    "primary": "$.safety.primary"
  }
}
```

## How to test
1. On a fresh checkout, run `bash tests/homeboy-dmc-provider.sh`.
2. Confirm it reports `OK: Homeboy DMC worktree provider config respects dry-run and optional skips`.
3. Inspect the generated config in the test fixture: its list command contains `--with-status`, and `list_result_mapping` matches the JSON above.
4. After Extra-Chill/data-machine-code#893 is installed, run the installer in a non-production environment and inspect the configured DMC provider with `homeboy config get /worktree_providers/dmc`.
5. Confirm the configured list command and mapping match the provider contract above.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 via OpenCode
- **Used for:** Implemented the safety-field addition and tests under orchestrator direction