### PR TITLE
fix: resolve Studio CLI for Data Machine worker

### DIFF
--- a/services/datamachine-worker.sh
+++ b/services/datamachine-worker.sh
@@ -5,7 +5,51 @@
 datamachine_worker_systemd_units() { echo "datamachine-worker.service datamachine-worker.timer"; }
 datamachine_worker_launchd_label() { echo "com.wp.datamachine-worker"; }
 
+_datamachine_worker_shell_quote() {
+  local value="$1"
+  value=${value//\'/\'\\\'\'}
+  printf "'%s'" "$value"
+}
+
+_datamachine_worker_uses_studio() {
+  [ "${WP_CMD:-wp}" = "studio wp" ]
+}
+
+_datamachine_worker_resolve_studio_bin() {
+  local candidate="${STUDIO_BIN:-}"
+  local directory
+
+  if [ -z "$candidate" ]; then
+    candidate="$(command -v studio 2>/dev/null || true)"
+  fi
+
+  if [ -z "$candidate" ] || [ ! -f "$candidate" ] || [ ! -x "$candidate" ]; then
+    printf 'Data Machine worker requires an executable Studio CLI; install it or ensure studio is on PATH during setup/upgrade.\n' >&2
+    return 1
+  fi
+
+  case "$candidate" in
+    /*) printf '%s\n' "$candidate" ;;
+    *)
+      directory="$(cd "$(dirname "$candidate")" && pwd)" || return 1
+      printf '%s/%s\n' "$directory" "$(basename "$candidate")"
+      ;;
+  esac
+}
+
+datamachine_worker_prepare_command() {
+  _datamachine_worker_uses_studio || return 0
+  STUDIO_BIN="$(_datamachine_worker_resolve_studio_bin)" || return 1
+  export STUDIO_BIN
+}
+
 _datamachine_worker_command() {
+  if _datamachine_worker_uses_studio; then
+    [ -n "${STUDIO_BIN:-}" ] || datamachine_worker_prepare_command || return 1
+    printf 'cd "%s" && %s wp datamachine worker run --once' "$SITE_PATH" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")"
+    return
+  fi
+
   printf '%s' "cd \"$SITE_PATH\" && $WP_CMD datamachine worker run --once"
 }
 
@@ -78,6 +122,8 @@ EOF
 }
 
 datamachine_worker_install() {
+  datamachine_worker_prepare_command || return 1
+
   if [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
     local label plist_dir plist
     label="$(datamachine_worker_launchd_label)"
@@ -107,6 +153,8 @@ datamachine_worker_install() {
 }
 
 datamachine_worker_update() {
+  datamachine_worker_prepare_command || return 1
+
   if [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
     local label plist
     label="$(datamachine_worker_launchd_label)"

--- a/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
+++ b/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wp.datamachine-worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>-lc</string>
+        <string>cd "/var/www/site" && '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/var/www/site</string>
+    <key>StartInterval</key>
+    <integer>120</integer>
+    <key>StandardOutPath</key>
+    <string>/home/chubes/.datamachine/datamachine-worker.log</string>
+    <key>StandardErrorPath</key>
+    <string>/home/chubes/.datamachine/datamachine-worker.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/home/chubes</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -19,4 +19,33 @@ grep -q 'wp datamachine worker run --once' <<< "$service"
 grep -q '^OnUnitActiveSec=2min$' <<< "$timer"
 grep -q '<integer>120</integer>' <<< "$plist"
 grep -q 'com.wp.datamachine-worker' <<< "$plist"
+
+# launchd has a minimal PATH. Resolve a Studio CLI from a directory outside
+# that PATH and assert the command embeds its absolute, shell-quoted path.
+studio_root="/tmp/datamachine-worker-studio-path"
+studio_bin="$studio_root/studio tools/studio"
+[ ! -e "$studio_root" ] || {
+  echo "FAIL: test directory already exists: $studio_root" >&2
+  exit 1
+}
+mkdir -p "$(dirname "$studio_bin")"
+printf '#!/bin/sh\n' > "$studio_bin"
+chmod +x "$studio_bin"
+trap 'rm -r "$studio_root"' EXIT
+
+saved_path="$PATH"
+PATH="$(dirname "$studio_bin"):$saved_path"
+WP_CMD="studio wp"
+STUDIO_BIN="$studio_root/missing-studio"
+if datamachine_worker_prepare_command; then
+  echo "FAIL: missing Studio executable was accepted" >&2
+  exit 1
+fi
+unset STUDIO_BIN
+datamachine_worker_prepare_command
+studio_plist="$(datamachine_worker_render_launchd com.wp.datamachine-worker)"
+PATH="$saved_path"
+
+diff -u "$snapshot_dir/launchd-studio-absolute-path" <(printf '%s\n' "$studio_plist")
+grep -Fq "'$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
 echo "PASS: tests/datamachine-worker.sh"


### PR DESCRIPTION
## Summary
- Resolve the Studio CLI during worker install and upgrade when the site uses Studio WP-CLI.
- Render the validated absolute executable path into the worker service command with shell-safe quoting.
- Cover a Studio binary outside launchd PATH and unavailable executable handling.

Closes #267.

## How to test
1. Run `bash tests/datamachine-worker.sh`.
2. Run `for test_file in tests/*.sh; do bash "$test_file"; done`.
3. On a macOS Studio site where `command -v studio` is outside launchd PATH, run `./upgrade.sh --wp-path <site-path>` and inspect `~/Library/LaunchAgents/com.wp.datamachine-worker.plist`.
4. Confirm the worker command contains the absolute Studio executable path, then wait one 120-second interval and confirm the worker error log has no `studio: command not found` error.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via Kimaki/OpenCode subagent
- **Used for:** implementation and tests for issue #267