### PR TITLE
Drive WP-Cron from the worker heartbeat

### DIFF
--- a/services/datamachine-worker.sh
+++ b/services/datamachine-worker.sh
@@ -46,11 +46,11 @@ datamachine_worker_prepare_command() {
 _datamachine_worker_command() {
   if _datamachine_worker_uses_studio; then
     [ -n "${STUDIO_BIN:-}" ] || datamachine_worker_prepare_command || return 1
-    printf 'cd "%s" && %s wp datamachine worker run --once' "$SITE_PATH" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")"
+    printf 'cd "%s" && %s wp cron event run --due-now && %s wp datamachine worker run --once' "$SITE_PATH" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")"
     return
   fi
 
-  printf '%s' "cd \"$SITE_PATH\" && $WP_CMD datamachine worker run --once"
+  printf '%s' "cd \"$SITE_PATH\" && $WP_CMD cron event run --due-now && $WP_CMD datamachine worker run --once"
 }
 
 datamachine_worker_render_systemd_service() {

--- a/tests/__snapshots__/datamachine-worker/launchd
+++ b/tests/__snapshots__/datamachine-worker/launchd
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>cd "/var/www/site" && wp datamachine worker run --once</string>
+        <string>cd "/var/www/site" && wp cron event run --due-now && wp datamachine worker run --once</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
+++ b/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>cd "/var/www/site" && '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
+        <string>cd "/var/www/site" && '/tmp/datamachine-worker-studio-path/studio tools/studio' wp cron event run --due-now && '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/__snapshots__/datamachine-worker/systemd-service
+++ b/tests/__snapshots__/datamachine-worker/systemd-service
@@ -8,4 +8,4 @@ User=chubes
 WorkingDirectory=/var/www/site
 Environment=HOME=/home/chubes
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
-ExecStart=/bin/sh -lc 'cd "/var/www/site" && wp datamachine worker run --once'
+ExecStart=/bin/sh -lc 'cd "/var/www/site" && wp cron event run --due-now && wp datamachine worker run --once'

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -15,6 +15,7 @@ diff -u "$snapshot_dir/systemd-timer" <(printf '%s\n' "$timer")
 diff -u "$snapshot_dir/launchd" <(printf '%s\n' "$plist")
 
 grep -q '^User=chubes$' <<< "$service"
+grep -q 'wp cron event run --due-now' <<< "$service"
 grep -q 'wp datamachine worker run --once' <<< "$service"
 grep -q '^OnUnitActiveSec=2min$' <<< "$timer"
 grep -q '<integer>120</integer>' <<< "$plist"
@@ -47,5 +48,5 @@ studio_plist="$(datamachine_worker_render_launchd com.wp.datamachine-worker)"
 PATH="$saved_path"
 
 diff -u "$snapshot_dir/launchd-studio-absolute-path" <(printf '%s\n' "$studio_plist")
-grep -Fq "'$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
+grep -Fq "'$studio_bin' wp cron event run --due-now && '$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
 echo "PASS: tests/datamachine-worker.sh"


### PR DESCRIPTION
## Summary
- run due WP-Cron events before each bounded Data Machine worker pass
- apply the scheduler chain to both launchd and systemd service templates
- cover generic WP-CLI and absolute Studio CLI commands in snapshots

Fixes #270.

## How to test
1. Run `bash tests/datamachine-worker.sh`.
2. Install or upgrade wp-coding-agents on a headless local site.
3. Leave the site unopened and wait one 120-second service interval.
4. Confirm overdue WP-Cron events advance, Action Scheduler drains due actions, and pending Data Machine jobs progress.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.6 Sol via Kimaki/OpenCode
- **Used for:** Implementation, tests, and live runtime diagnosis for issue #270