### PR TITLE
Configure targeted DMC worktree resolution

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -108,6 +108,9 @@ homeboy_dmc_command_json() {
   done < <(homeboy_dmc_wp_flags)
 
   case "$action" in
+    resolve)
+      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree get '{handle}' --format=json "${wp_flags[@]}"
+      ;;
     list)
       homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree list --with-status --format=json "${wp_flags[@]}"
       ;;
@@ -121,7 +124,8 @@ homeboy_dmc_command_json() {
 }
 
 homeboy_dmc_worktree_provider_json() {
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"resolve":%s,"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
+    "$(homeboy_dmc_command_json resolve)" \
     "$(homeboy_dmc_command_json list)" \
     "$(homeboy_dmc_command_json cleanup_preview)" \
     "$(homeboy_dmc_command_json cleanup_apply)"

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -105,6 +105,7 @@ DRY_RUN=true
 configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 
 assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
+assert_contains "\"resolve\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{handle}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"list\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--with-status\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"


### PR DESCRIPTION
Fixes #272. Configures Homeboy `commands.resolve` to call DMC `workspace worktree get {handle}`, retaining the full list command for inventory. Verification: `bash tests/homeboy-dmc-provider.sh` passed. Depends on Extra-Chill/homeboy#7909 and Extra-Chill/data-machine-code#894.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** GPT-5.6 Sol via OpenCode\n- **Used for:** Installer configuration and regression coverage under Chris Huber direction.