### PR TITLE
feat(kimaki): support multiple service instances

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -98,14 +98,6 @@ jobs:
       - name: Run tests/service-identity-adoption.sh
         run: ./tests/service-identity-adoption.sh
 
-  kimaki-multi-instance:
-    name: Kimaki multi-instance isolation regression (#274)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests/kimaki-multi-instance.sh
-        run: ./tests/kimaki-multi-instance.sh
-
   agents-md-guidance:
     name: AGENTS.md guidance registry
     runs-on: ubuntu-latest

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -98,6 +98,14 @@ jobs:
       - name: Run tests/service-identity-adoption.sh
         run: ./tests/service-identity-adoption.sh
 
+  kimaki-multi-instance:
+    name: Kimaki multi-instance isolation regression (#274)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/kimaki-multi-instance.sh
+        run: ./tests/kimaki-multi-instance.sh
+
   agents-md-guidance:
     name: AGENTS.md guidance registry
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ operator-entrypoints/wp-coding-agents-setup/setup.md
 | `--existing` | Add to an existing WordPress install. |
 | `--wp-path <path>` | WordPress root path. Implies `--existing`. |
 | `--agent-slug <slug>` | Override the Data Machine agent slug. |
+| `--kimaki-unit <unit>` | Target a Kimaki systemd instance, such as `kimaki-example.service`. |
+| `--kimaki-data-dir <path>` | Override that Kimaki instance's state directory. |
+| `--kimaki-lock-port <port>` | Override that Kimaki instance's lock port. |
 | `--chat <bridge>` | Chat bridge: `kimaki`, `cc-connect`, or `telegram`. Codex currently runs without a managed chat bridge. |
 | `--no-chat` | Skip chat bridge setup. |
 | `--with-homeboy` | Enable optional Homeboy project/lab integration when available. |
@@ -177,6 +180,12 @@ operator-entrypoints/wp-coding-agents-setup/setup.md
 | `--dry-run` | Print planned actions without applying them. |
 
 Run `./setup.sh --help` for the complete setup surface.
+
+On VPS hosts with multiple Kimaki services, setup and upgrade select the unit
+whose `WorkingDirectory=` exactly matches the WordPress site path. Ambiguous or
+unmatched installed units fail safely; pass `--kimaki-unit` to select or create
+an instance explicitly. The traditional single-instance defaults remain
+`kimaki.service` and `<service-home>/.kimaki`.
 
 ## Runtime And Bridge Notes
 

--- a/bridges/_dispatch.sh
+++ b/bridges/_dispatch.sh
@@ -280,7 +280,9 @@ adopt_service_identity_from_units() {
       log "  Adopting service identity from $unit: User=$unit_user (script default was $SERVICE_USER)"
       SERVICE_USER="$unit_user"
       SERVICE_HOME="$unit_home"
-      KIMAKI_DATA_DIR="$unit_home/.kimaki"
+      if [ "${KIMAKI_DATA_DIR_EXPLICIT:-false}" != true ]; then
+        KIMAKI_DATA_DIR="$unit_home/.kimaki"
+      fi
       if [ "$unit_user" = "root" ]; then
         RUN_AS_ROOT=true
       else
@@ -522,14 +524,22 @@ bridge_detect_local() {
 
 # bridge_detect_vps — print the first bridge with installed systemd units.
 bridge_detect_vps() {
-  local bridge unit
+  local bridge unit unit_dir="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
   for bridge in $(bridge_names_for_detection); do
     for unit in $(bridge_call "$bridge" systemd_units 2>/dev/null); do
-      if [ -f "/etc/systemd/system/${unit}" ]; then
+      if [ -f "$unit_dir/${unit}" ]; then
         echo "$bridge"
         return 0
       fi
     done
+    if [ "$bridge" = "kimaki" ]; then
+      for unit in "$unit_dir"/kimaki*.service; do
+        if [ -f "$unit" ]; then
+          echo "$bridge"
+          return 0
+        fi
+      done
+    fi
   done
   return 0
 }

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -21,7 +21,7 @@
 # Identity
 # ============================================================================
 
-bridge_systemd_units()  { echo "kimaki.service"; }
+bridge_systemd_units()  { echo "${KIMAKI_UNIT:-kimaki.service}"; }
 bridge_launchd_labels() { echo "com.wp.kimaki"; }
 bridge_binaries()       { echo "kimaki"; }
 bridge_display_name()   { echo "kimaki"; }
@@ -29,6 +29,132 @@ bridge_display_title()  { echo "Kimaki"; }
 
 bridge_is_ready() {
   [ -n "${KIMAKI_BOT_TOKEN:-}" ]
+}
+
+_kimaki_unit_env_value() {
+  local unit_file="$1" key="$2"
+  sed -n "s/^Environment=${key}=//p" "$unit_file" | head -1
+}
+
+_kimaki_unit_exec_arg() {
+  local unit_file="$1" flag="$2" line rest
+  line=$(grep '^ExecStart=' "$unit_file" | head -1 || true)
+  rest="${line#* $flag }"
+  [ "$rest" != "$line" ] || return 0
+  printf '%s\n' "${rest%% *}"
+}
+
+_kimaki_validate_lock_port() {
+  [ -z "${KIMAKI_LOCK_PORT:-}" ] && return 0
+  case "$KIMAKI_LOCK_PORT" in *[!0-9]*) error "Invalid Kimaki lock port '$KIMAKI_LOCK_PORT'" ;; esac
+  if [ "$KIMAKI_LOCK_PORT" -lt 1 ] || [ "$KIMAKI_LOCK_PORT" -gt 65535 ]; then
+    error "Invalid Kimaki lock port '$KIMAKI_LOCK_PORT' (expected 1-65535)"
+  fi
+}
+
+_kimaki_normalize_unit_name() {
+  local unit="$1" stem
+  [ -n "$unit" ] || error "Invalid Kimaki unit: name cannot be empty"
+  case "$unit" in
+    *.service) ;;
+    *) unit="$unit.service" ;;
+  esac
+  case "$unit" in
+    */*|*\\*|*..*|*[!A-Za-z0-9_.@-]*)
+      error "Invalid Kimaki unit '$unit' (expected a traversal-safe unit basename)"
+      ;;
+  esac
+  stem="${unit%.service}"
+  case "$stem" in
+    kimaki|kimaki-?*) ;;
+    *) error "Invalid Kimaki unit '$unit' (expected kimaki.service or kimaki-<name>.service)" ;;
+  esac
+  printf '%s\n' "$unit"
+}
+
+_kimaki_remove_systemd_env_key() {
+  local env_block="$1" key="$2"
+  printf '%s\n' "$env_block" | grep -v "^Environment=${key}=" || true
+}
+
+# Select an installed Kimaki instance by exact WordPress WorkingDirectory.
+# Explicit inputs win; otherwise zero matches keeps the legacy default only
+# when no Kimaki unit exists, one match is adopted, and ambiguity is fatal.
+_kimaki_resolve_instance() {
+  local unit_dir="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+  local requested
+  requested=$(_kimaki_normalize_unit_name "${KIMAKI_UNIT-}")
+  KIMAKI_UNIT="$requested"
+
+  local unit working normalized_site="$SITE_PATH" matches=() installed=()
+  if [ -d "$SITE_PATH" ]; then
+    normalized_site=$(cd "$SITE_PATH" 2>/dev/null && pwd -P || printf '%s' "$SITE_PATH")
+  fi
+
+  if [ "${KIMAKI_UNIT_EXPLICIT:-false}" != true ]; then
+    for unit in "$unit_dir"/kimaki*.service; do
+      [ -f "$unit" ] || continue
+      installed+=("$unit")
+      working=$(sed -n 's/^WorkingDirectory=//p' "$unit" | head -1)
+      [ -n "$working" ] || continue
+      if [ -d "$working" ]; then
+        working=$(cd "$working" 2>/dev/null && pwd -P || printf '%s' "$working")
+      fi
+      [ "$working" = "$normalized_site" ] && matches+=("$unit")
+    done
+    if [ ${#matches[@]} -eq 1 ]; then
+      KIMAKI_UNIT=$(basename "${matches[0]}")
+      log "  Selected $KIMAKI_UNIT for WorkingDirectory=$SITE_PATH"
+    elif [ ${#matches[@]} -gt 1 ]; then
+      error "Multiple Kimaki units target $SITE_PATH: ${matches[*]}. Pass --kimaki-unit <unit>."
+    elif [ ${#installed[@]} -gt 0 ]; then
+      error "No Kimaki unit targets $SITE_PATH. Pass --kimaki-unit <unit> to select or create one. Installed: ${installed[*]}"
+    fi
+  fi
+
+  local unit_file="$unit_dir/$KIMAKI_UNIT"
+  if [ ! -f "$unit_file" ]; then
+    _kimaki_validate_lock_port
+    return 0
+  fi
+
+  local value unit_user unit_home
+  unit_user=$(_systemd_unit_user "$unit_file" || true)
+  unit_home=$(_kimaki_unit_env_value "$unit_file" HOME)
+  if [ "${SERVICE_USER_FORCED:-false}" != true ] && [ -n "$unit_user" ]; then
+    SERVICE_USER="$unit_user"
+    [ -n "$unit_home" ] || unit_home=$(getent passwd "$unit_user" 2>/dev/null | cut -d: -f6)
+    [ -n "$unit_home" ] || { [ "$unit_user" = root ] && unit_home=/root || unit_home="/home/$unit_user"; }
+    SERVICE_HOME="$unit_home"
+    [ "$unit_user" = root ] && RUN_AS_ROOT=true || RUN_AS_ROOT=false
+  fi
+
+  if [ "${KIMAKI_DATA_DIR_EXPLICIT:-false}" != true ]; then
+    value=$(_kimaki_unit_env_value "$unit_file" KIMAKI_DATA_DIR)
+    [ -n "$value" ] || value=$(_kimaki_unit_exec_arg "$unit_file" --data-dir)
+    if [ -n "$value" ]; then
+      KIMAKI_DATA_DIR="$value"
+    else
+      KIMAKI_DATA_DIR="$SERVICE_HOME/.kimaki"
+    fi
+  fi
+  if [ "${KIMAKI_LOCK_PORT_EXPLICIT:-false}" != true ]; then
+    value=$(_kimaki_unit_env_value "$unit_file" KIMAKI_LOCK_PORT)
+    [ -n "$value" ] || value=$(_kimaki_unit_exec_arg "$unit_file" --lock-port)
+    KIMAKI_LOCK_PORT="$value"
+  fi
+  if [ -z "${AGENT_SLUG:-}" ]; then
+    AGENT_SLUG=$(_kimaki_unit_env_value "$unit_file" DATAMACHINE_AGENT_SLUG)
+  fi
+  _kimaki_validate_lock_port
+}
+
+_kimaki_instance_suffix() {
+  local unit="${KIMAKI_UNIT:-kimaki.service}"
+  [ "$unit" = "kimaki.service" ] && return 0
+  unit="${unit%.service}"
+  unit="${unit#kimaki-}"
+  printf -- '-%s' "$unit"
 }
 
 # ============================================================================
@@ -84,7 +210,7 @@ bridge_install() {
 _kimaki_register_cli_channel() {
   local cmd
   if [ "${LOCAL_MODE:-false}" != true ] && [ -n "${SERVICE_USER:-}" ] && [ "$SERVICE_USER" != "root" ]; then
-    cmd="/usr/local/bin/wp-coding-agents-kimaki-dispatch"
+    cmd="/usr/local/bin/wp-coding-agents-kimaki$(_kimaki_instance_suffix)-dispatch"
   elif [ -n "${KIMAKI_BIN:-}" ] \
     && [ -x "$KIMAKI_BIN" ] \
     && ! _kimaki_is_legacy_adapter_file "$KIMAKI_BIN" \
@@ -242,9 +368,11 @@ _kimaki_install_dispatch_helpers() {
     return 0
   fi
 
-  local dispatch_wrapper="/usr/local/bin/wp-coding-agents-kimaki-dispatch"
-  local target_helper="/usr/local/lib/wp-coding-agents/kimaki-dispatch-target"
-  local sudoers_file="/etc/sudoers.d/wp-coding-agents-kimaki-dispatch"
+  local suffix
+  suffix=$(_kimaki_instance_suffix)
+  local dispatch_wrapper="/usr/local/bin/wp-coding-agents-kimaki${suffix}-dispatch"
+  local target_helper="/usr/local/lib/wp-coding-agents/kimaki${suffix}-dispatch-target"
+  local sudoers_file="/etc/sudoers.d/wp-coding-agents-kimaki${suffix}-dispatch"
   local service_home="${SERVICE_HOME:-}"
   local data_dir="${KIMAKI_DATA_DIR:-}"
   local kimaki_bin="${KIMAKI_BIN:-}"
@@ -571,15 +699,20 @@ Environment=DATAMACHINE_AGENT_SLUG=$AGENT_SLUG"
     ENV_BLOCK="$ENV_BLOCK
 Environment=KIMAKI_BOT_TOKEN=$KIMAKI_BOT_TOKEN"
   fi
+  if [ -n "${KIMAKI_LOCK_PORT:-}" ]; then
+    ENV_BLOCK="$ENV_BLOCK
+Environment=KIMAKI_LOCK_PORT=$KIMAKI_LOCK_PORT"
+  fi
   if declare -F ai_gateway_enabled_for_opencode >/dev/null && ai_gateway_enabled_for_opencode; then
     ENV_BLOCK="$ENV_BLOCK
 EnvironmentFile=-$(ai_gateway_env_file)"
   fi
 
-  write_file "/etc/systemd/system/kimaki.service" \
-    "$(bridge_render_systemd kimaki.service "$ENV_BLOCK")"
+  local unit_dir="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+  write_file "$unit_dir/$KIMAKI_UNIT" \
+    "$(bridge_render_systemd "$KIMAKI_UNIT" "$ENV_BLOCK")"
   run_cmd systemctl daemon-reload
-  run_cmd systemctl enable kimaki
+  run_cmd systemctl enable "$KIMAKI_UNIT"
 }
 
 # ============================================================================
@@ -804,13 +937,22 @@ bridge_sync_config() {
 # ============================================================================
 
 bridge_update_systemd() {
-  log "Phase 5: Checking kimaki.service template..."
+  log "Phase 5: Checking $KIMAKI_UNIT template..."
 
-  local UNIT_FILE="/etc/systemd/system/kimaki.service"
+  local UNIT_FILE="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}/$KIMAKI_UNIT"
   [ -f "$UNIT_FILE" ] || { warn "  $UNIT_FILE does not exist — skipping"; return 0; }
 
   local CURRENT_ENV
   CURRENT_ENV=$(grep '^Environment=' "$UNIT_FILE" || true)
+  if [ "${KIMAKI_DATA_DIR_EXPLICIT:-false}" = true ]; then
+    CURRENT_ENV=$(_kimaki_remove_systemd_env_key "$CURRENT_ENV" KIMAKI_DATA_DIR)
+  fi
+  if [ "${KIMAKI_LOCK_PORT_EXPLICIT:-false}" = true ]; then
+    CURRENT_ENV=$(_kimaki_remove_systemd_env_key "$CURRENT_ENV" KIMAKI_LOCK_PORT)
+  fi
+  if [ "${AGENT_SLUG_EXPLICIT:-false}" = true ]; then
+    CURRENT_ENV=$(_kimaki_remove_systemd_env_key "$CURRENT_ENV" DATAMACHINE_AGENT_SLUG)
+  fi
 
   local KIMAKI_BIN
   KIMAKI_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
@@ -830,6 +972,10 @@ Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
 Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
 Environment=DATAMACHINE_WP_CMD=$(_kimaki_datamachine_wp_cmd)"
+  if [ -n "${KIMAKI_LOCK_PORT:-}" ]; then
+    TEMPLATE_ENV="$TEMPLATE_ENV
+Environment=KIMAKI_LOCK_PORT=$KIMAKI_LOCK_PORT"
+  fi
   if [ -n "${AGENT_SLUG:-}" ]; then
     TEMPLATE_ENV="$TEMPLATE_ENV
 Environment=DATAMACHINE_AGENT_SLUG=$AGENT_SLUG"
@@ -847,9 +993,9 @@ $gateway_env_line"
   fi
 
   local NEW_UNIT
-  NEW_UNIT=$(bridge_render_systemd kimaki.service "$MERGED_ENV")
+  NEW_UNIT=$(bridge_render_systemd "$KIMAKI_UNIT" "$MERGED_ENV")
 
-  _smart_update_systemd_unit "$UNIT_FILE" "$NEW_UNIT" "kimaki.service"
+  _smart_update_systemd_unit "$UNIT_FILE" "$NEW_UNIT" "$KIMAKI_UNIT"
 }
 
 bridge_update_launchd() {
@@ -904,9 +1050,18 @@ bridge_update_launchd() {
 
 bridge_render_systemd() {
   local unit="$1" env_block="$2"
-  [ "$unit" = "kimaki.service" ] || { echo "kimaki has no unit '$unit'" >&2; return 1; }
+  local normalized_unit
+  normalized_unit=$(_kimaki_normalize_unit_name "$unit")
+  [ "$normalized_unit" = "$unit" ] || { echo "kimaki has no unit '$unit'" >&2; return 1; }
   local skill_filter_args
   skill_filter_args="$(_kimaki_skill_filter_args_shell)"
+  local lock_port_arg=""
+  _kimaki_validate_lock_port
+  [ -z "${KIMAKI_LOCK_PORT:-}" ] || lock_port_arg=" --lock-port $KIMAKI_LOCK_PORT"
+  local stale_worker_cleanup="# User-wide stale-worker cleanup omitted for instance isolation."
+  if [ "$unit" = "kimaki.service" ]; then
+    stale_worker_cleanup='ExecStartPre=-/usr/bin/pkill -TERM -u '$SERVICE_USER' -f "opencode-ai/bin/.*serve"'
+  fi
   cat <<EOF
 [Unit]
 Description=Kimaki Discord Bot (wp-coding-agents)
@@ -927,9 +1082,9 @@ $env_block
 # request. \`pkill -u $SERVICE_USER\` scopes the kill to this service's
 # user so multi-tenant hosts aren't sniped. The \`-\` prefix makes systemd
 # tolerate exit code 1 (no matches found, the happy path on a clean box).
-ExecStartPre=-/usr/bin/pkill -TERM -u $SERVICE_USER -f "opencode-ai/bin/.*serve"
+$stale_worker_cleanup
 ExecStartPre=$KIMAKI_CONFIG_DIR/post-upgrade.sh
-ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique$skill_filter_args
+ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR$lock_port_arg --auto-restart --no-critique$skill_filter_args
 Restart=always
 RestartSec=10
 
@@ -1119,7 +1274,7 @@ bridge_restart_cmd() {
       echo "cd $SITE_PATH && kimaki"
       ;;
     vps)
-      echo "systemctl restart kimaki"
+      echo "systemctl restart ${KIMAKI_UNIT:-kimaki.service}"
       ;;
     *)
       echo "bridge_restart_cmd: unknown env '$env'" >&2
@@ -1133,7 +1288,7 @@ bridge_verify_cmd() {
   case "$env" in
     local-launchd) echo "launchctl print gui/${uid}/com.wp.kimaki | head -20" ;;
     local-manual)  echo "pgrep -fl kimaki" ;;
-    vps)           echo "systemctl status kimaki" ;;
+    vps)           echo "systemctl status ${KIMAKI_UNIT:-kimaki.service}" ;;
     *)
       echo "bridge_verify_cmd: unknown env '$env'" >&2
       return 1 ;;
@@ -1150,7 +1305,7 @@ bridge_start_hint() {
   case "$env" in
     local-launchd) echo "launchctl kickstart gui/${uid}/com.wp.kimaki" ;;
     local-manual)  bridge_restart_cmd local-manual ;;
-    vps)           echo "systemctl start kimaki" ;;
+    vps)           echo "systemctl start ${KIMAKI_UNIT:-kimaki.service}" ;;
     *)
       echo "bridge_start_hint: unknown env '$env'" >&2
       return 1 ;;
@@ -1162,7 +1317,7 @@ bridge_stop_hint() {
   uid=$(id -u)
   case "$env" in
     local-launchd) echo "launchctl kill SIGTERM gui/${uid}/com.wp.kimaki" ;;
-    vps)           echo "systemctl stop kimaki" ;;
+    vps)           echo "systemctl stop ${KIMAKI_UNIT:-kimaki.service}" ;;
     local-manual)  ;;
     *)
       echo "bridge_stop_hint: unknown env '$env'" >&2
@@ -1184,11 +1339,11 @@ bridge_vps_setup_block() {
     echo "       cd $SITE_PATH && kimaki"
   fi
   echo "     Option B: Set KIMAKI_BOT_TOKEN in the systemd service"
-  echo "       systemctl edit kimaki"
+  echo "       systemctl edit ${KIMAKI_UNIT:-kimaki.service}"
   echo "       [Service]"
   echo "       Environment=KIMAKI_BOT_TOKEN=your-token-here"
   echo ""
-  echo "  2. Start the agent:  systemctl start kimaki"
+  echo "  2. Start the agent:  systemctl start ${KIMAKI_UNIT:-kimaki.service}"
 }
 
 # Onboarding prose for macOS launchd when KIMAKI_BOT_TOKEN is missing.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -124,3 +124,25 @@ git_clone_with_retry() {
   warn "Clone of $url failed after $max_attempts attempts."
   return 1
 }
+initialize_kimaki_overrides() {
+  KIMAKI_UNIT_EXPLICIT=false
+  KIMAKI_DATA_DIR_EXPLICIT=false
+  KIMAKI_LOCK_PORT_EXPLICIT=false
+  AGENT_SLUG_EXPLICIT=false
+
+  if [ "${KIMAKI_UNIT+x}" = x ]; then
+    KIMAKI_UNIT_EXPLICIT=true
+  else
+    KIMAKI_UNIT="kimaki.service"
+  fi
+  KIMAKI_LOCK_PORT="${KIMAKI_LOCK_PORT:-}"
+  if [ -n "${KIMAKI_DATA_DIR:-}" ]; then
+    KIMAKI_DATA_DIR_EXPLICIT=true
+  fi
+  if [ -n "$KIMAKI_LOCK_PORT" ]; then
+    KIMAKI_LOCK_PORT_EXPLICIT=true
+  fi
+  if [ -n "${AGENT_SLUG:-}" ]; then
+    AGENT_SLUG_EXPLICIT=true
+  fi
+}

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -181,17 +181,17 @@ detect_environment() {
   if [ "$LOCAL_MODE" = true ]; then
     SERVICE_USER="$(whoami)"
     SERVICE_HOME="$HOME"
-    KIMAKI_DATA_DIR="$HOME/.kimaki"
+    KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-$HOME/.kimaki}"
     DM_WORKSPACE_DIR="${DATAMACHINE_WORKSPACE_PATH:-$HOME/.datamachine/workspace}"
   elif [ "$RUN_AS_ROOT" = true ]; then
     SERVICE_USER="root"
     SERVICE_HOME="/root"
-    KIMAKI_DATA_DIR="/root/.kimaki"
+    KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-/root/.kimaki}"
     DM_WORKSPACE_DIR="${DATAMACHINE_WORKSPACE_PATH:-/var/lib/datamachine/workspace}"
   else
     SERVICE_USER="opencode"
     SERVICE_HOME="/home/opencode"
-    KIMAKI_DATA_DIR="/home/opencode/.kimaki"
+    KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-/home/opencode/.kimaki}"
     DM_WORKSPACE_DIR="${DATAMACHINE_WORKSPACE_PATH:-/var/lib/datamachine/workspace}"
   fi
 }

--- a/setup.sh
+++ b/setup.sh
@@ -54,6 +54,7 @@ CHAT_BRIDGE=""
 SHOW_HELP=false
 DRY_RUN=false
 RUN_AS_ROOT=true
+SERVICE_USER_FORCED=false
 MULTISITE=false
 MULTISITE_TYPE="subdirectory"
 INSTALL_SKILLS=true
@@ -69,6 +70,7 @@ HOMEBOY_MODE="auto"
 HOMEBOY_PROJECT_ID="${HOMEBOY_PROJECT_ID:-}"
 DETECTED_RUNTIMES=()
 IS_STUDIO=false
+initialize_kimaki_overrides
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -113,10 +115,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --root)
       RUN_AS_ROOT=true
+      SERVICE_USER_FORCED=true
       shift
       ;;
     --non-root)
       RUN_AS_ROOT=false
+      SERVICE_USER_FORCED=true
       shift
       ;;
     --dry-run)
@@ -187,10 +191,26 @@ while [[ $# -gt 0 ]]; do
       ;;
     --agent-slug)
       AGENT_SLUG="$2"
+      AGENT_SLUG_EXPLICIT=true
       shift 2
       ;;
     --agent-name)
       AGENT_NAME="$2"
+      shift 2
+      ;;
+    --kimaki-unit)
+      KIMAKI_UNIT="$2"
+      KIMAKI_UNIT_EXPLICIT=true
+      shift 2
+      ;;
+    --kimaki-data-dir)
+      KIMAKI_DATA_DIR="$2"
+      KIMAKI_DATA_DIR_EXPLICIT=true
+      shift 2
+      ;;
+    --kimaki-lock-port)
+      KIMAKI_LOCK_PORT="$2"
+      KIMAKI_LOCK_PORT_EXPLICIT=true
       shift 2
       ;;
     --help|-h)
@@ -229,6 +249,11 @@ OPTIONS:
                      Available: ${AVAILABLE_RUNTIMES[*]}
   --agent-slug <s>   Override Data Machine agent slug (default: derived from domain)
   --agent-name <n>   Override Data Machine agent display name (default: blogname)
+  --kimaki-unit <u>  Kimaki systemd unit (default: kimaki.service)
+  --kimaki-data-dir <path>
+                     Kimaki state directory (default: <service-home>/.kimaki)
+  --kimaki-lock-port <port>
+                     Kimaki lock port (default: Kimaki's built-in default)
   --no-chat          Skip chat bridge installation
   --chat <bridge>    Chat bridge to install (default: kimaki for opencode,
                      cc-connect for claude-code, none for codex)
@@ -289,6 +314,9 @@ ENVIRONMENT VARIABLES:
   AI_GATEWAY_SITE_URL        Public site URL for OPENAI_BASE_URL override
   WITH_CLAUDE_CODE_AUTH      false to skip direct OpenCode Claude Pro/Max auth
   KIMAKI_BOT_TOKEN          Discord bot token (skip interactive setup)
+  KIMAKI_UNIT               Kimaki systemd unit (default: kimaki.service)
+  KIMAKI_DATA_DIR           Kimaki state directory
+  KIMAKI_LOCK_PORT          Kimaki lock port
   TELEGRAM_BOT_TOKEN        Telegram bot token from @BotFather (--chat telegram)
   TELEGRAM_ALLOWED_USER_ID  Numeric Telegram user ID (--chat telegram)
   OPENCODE_MODEL_PROVIDER   Default model provider for Telegram bot (default: opencode)
@@ -376,6 +404,11 @@ fi
 # ============================================================================
 
 detect_environment
+
+if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$LOCAL_MODE" = false ]; then
+  bridge_load kimaki
+  _kimaki_resolve_instance
+fi
 
 # --skills-only early exit
 if [ "$SKILLS_ONLY" = true ]; then

--- a/tests/bridge-render.sh
+++ b/tests/bridge-render.sh
@@ -57,6 +57,7 @@ export RUN_AS_ROOT=false
 export IS_STUDIO=false
 export WP_CMD="wp"
 export AGENT_SLUG="intelligence-chubes4"
+export KIMAKI_LOCK_PORT=""
 
 # kimaki
 export KIMAKI_DATA_DIR="$SERVICE_HOME/.kimaki"
@@ -83,6 +84,10 @@ export OPENCODE_MODEL=""
 # build, so systemd snapshots stay byte-identical to pre-refactor output.
 # ---------------------------------------------------------------------------
 source "$SCRIPT_DIR/bridges/_dispatch.sh"
+
+# Keep snapshots independent of whether the host happens to ship node in
+# /usr/bin; node-path resolution has dedicated coverage in path-helpers.sh.
+_resolve_node_bin_dir() { printf ''; }
 
 REDACTED_DIFF=$(printf '%s\n' ' Environment=KIMAKI_BOT_TOKEN=secret-token' '         <key>KIMAKI_BOT_TOKEN</key>' '         <string>secret-token</string>' | _redact_secret_diff)
 if echo "$REDACTED_DIFF" | grep -q 'secret-token'; then

--- a/tests/kimaki-multi-instance.sh
+++ b/tests/kimaki-multi-instance.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/bridges/_dispatch.sh"
+source "$SCRIPT_DIR/bridges/kimaki.sh"
+
+# Top-level defaults must distinguish an absent KIMAKI_UNIT from an explicitly
+# supplied default unit. That explicit default prevents site-path auto-selection.
+unset KIMAKI_UNIT KIMAKI_DATA_DIR KIMAKI_LOCK_PORT AGENT_SLUG
+initialize_kimaki_overrides
+[ "$KIMAKI_UNIT" = kimaki.service ]
+[ "$KIMAKI_UNIT_EXPLICIT" = false ]
+
+KIMAKI_UNIT=kimaki.service
+KIMAKI_DATA_DIR=/override/from-env
+AGENT_SLUG=agent-from-env
+initialize_kimaki_overrides
+[ "$KIMAKI_UNIT_EXPLICIT" = true ]
+[ "$KIMAKI_DATA_DIR_EXPLICIT" = true ]
+[ "$AGENT_SLUG_EXPLICIT" = true ]
+
+grep -q '^initialize_kimaki_overrides$' "$SCRIPT_DIR/setup.sh"
+grep -q '^initialize_kimaki_overrides$' "$SCRIPT_DIR/upgrade.sh"
+grep -A2 -- '--root)' "$SCRIPT_DIR/setup.sh" | grep -q 'SERVICE_USER_FORCED=true'
+grep -A2 -- '--non-root)' "$SCRIPT_DIR/setup.sh" | grep -q 'SERVICE_USER_FORCED=true'
+
+SYSTEMD_UNIT_DIR="$TMP/systemd"
+mkdir -p "$SYSTEMD_UNIT_DIR" "$TMP/site-a" "$TMP/site-b"
+cat > "$SYSTEMD_UNIT_DIR/kimaki.service" <<EOF
+[Service]
+User=root
+WorkingDirectory=$TMP/site-a
+Environment=HOME=/root
+Environment=KIMAKI_DATA_DIR=/root/.kimaki
+Environment=DATAMACHINE_AGENT_SLUG=site-a
+ExecStart=/usr/bin/kimaki --data-dir /root/.kimaki --lock-port 3210 --auto-restart
+EOF
+cat > "$SYSTEMD_UNIT_DIR/kimaki-site-b.service" <<EOF
+[Service]
+User=opencode
+WorkingDirectory=$TMP/site-b
+Environment=HOME=/home/opencode
+Environment=KIMAKI_DATA_DIR=/home/opencode/.kimaki-site-b
+Environment=DATAMACHINE_AGENT_SLUG=site-b
+ExecStart=/usr/bin/kimaki --data-dir /home/opencode/.kimaki-site-b --lock-port 6543 --auto-restart
+EOF
+
+SITE_PATH="$TMP/site-b"
+KIMAKI_UNIT=kimaki.service
+KIMAKI_UNIT_EXPLICIT=false
+KIMAKI_DATA_DIR=/root/.kimaki
+KIMAKI_DATA_DIR_EXPLICIT=false
+KIMAKI_LOCK_PORT=""
+KIMAKI_LOCK_PORT_EXPLICIT=false
+SERVICE_USER=root
+SERVICE_HOME=/root
+SERVICE_USER_FORCED=false
+RUN_AS_ROOT=true
+AGENT_SLUG=""
+LOCAL_MODE=false
+
+_kimaki_resolve_instance
+[ "$KIMAKI_UNIT" = kimaki-site-b.service ]
+[ "$SERVICE_USER" = opencode ]
+[ "$SERVICE_HOME" = /home/opencode ]
+[ "$KIMAKI_DATA_DIR" = /home/opencode/.kimaki-site-b ]
+[ "$KIMAKI_LOCK_PORT" = 6543 ]
+[ "$AGENT_SLUG" = site-b ]
+[ "$(bridge_restart_cmd vps)" = "systemctl restart kimaki-site-b.service" ]
+[ "$(bridge_verify_cmd vps)" = "systemctl status kimaki-site-b.service" ]
+
+# Presence of KIMAKI_UNIT=kimaki.service is an explicit selection, even though
+# it equals the default. It must beat the site-b WorkingDirectory match.
+KIMAKI_UNIT=kimaki.service
+KIMAKI_UNIT_EXPLICIT=true
+KIMAKI_DATA_DIR=/root/.kimaki
+KIMAKI_DATA_DIR_EXPLICIT=false
+KIMAKI_LOCK_PORT=""
+KIMAKI_LOCK_PORT_EXPLICIT=false
+SERVICE_USER=root
+SERVICE_HOME=/root
+SERVICE_USER_FORCED=false
+RUN_AS_ROOT=true
+AGENT_SLUG=""
+AGENT_SLUG_EXPLICIT=false
+_kimaki_resolve_instance
+[ "$KIMAKI_UNIT" = kimaki.service ]
+[ "$KIMAKI_DATA_DIR" = /root/.kimaki ]
+
+# A forced setup identity must not be replaced by the selected unit's User=.
+KIMAKI_UNIT=kimaki-site-b.service
+KIMAKI_UNIT_EXPLICIT=true
+SERVICE_USER=root
+SERVICE_HOME=/root
+SERVICE_USER_FORCED=true
+RUN_AS_ROOT=true
+KIMAKI_DATA_DIR=/forced/data
+KIMAKI_DATA_DIR_EXPLICIT=true
+AGENT_SLUG=forced-agent
+AGENT_SLUG_EXPLICIT=true
+_kimaki_resolve_instance
+[ "$SERVICE_USER" = root ]
+[ "$SERVICE_HOME" = /root ]
+[ "$RUN_AS_ROOT" = true ]
+
+SERVICE_USER=opencode
+SERVICE_HOME=/home/opencode
+SERVICE_USER_FORCED=false
+RUN_AS_ROOT=false
+KIMAKI_DATA_DIR=/home/opencode/.kimaki-site-b
+KIMAKI_DATA_DIR_EXPLICIT=false
+KIMAKI_LOCK_PORT=6543
+KIMAKI_LOCK_PORT_EXPLICIT=false
+AGENT_SLUG=site-b
+AGENT_SLUG_EXPLICIT=false
+
+KIMAKI_CONFIG_DIR=/opt/kimaki-config
+KIMAKI_BIN=/usr/bin/kimaki
+KIMAKI_SYSTEM_PREFIX_BINS="$TMP/no-kimaki"
+PATH=/usr/bin:/bin
+DRY_RUN=false
+TIMESTAMP="test"
+UPDATED_ITEMS=()
+WP_CMD=wp
+IS_STUDIO=false
+systemctl() { :; }
+
+other_before=$(cksum "$SYSTEMD_UNIT_DIR/kimaki.service")
+bridge_update_systemd
+other_after=$(cksum "$SYSTEMD_UNIT_DIR/kimaki.service")
+[ "$other_before" = "$other_after" ]
+grep -q '^WorkingDirectory=.*/site-b$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+grep -q -- '--data-dir /home/opencode/.kimaki-site-b --lock-port 6543' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+grep -q '^Environment=DATAMACHINE_AGENT_SLUG=site-b$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+
+# Explicit managed overrides replace, rather than merge-preserve, installed
+# values. Unmanaged Environment= values remain owned by the host.
+printf '%s\n' 'Environment=HOST_CUSTOM=preserved' >> "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+KIMAKI_DATA_DIR=/explicit/data
+KIMAKI_DATA_DIR_EXPLICIT=true
+KIMAKI_LOCK_PORT=7654
+KIMAKI_LOCK_PORT_EXPLICIT=true
+AGENT_SLUG=explicit-agent
+AGENT_SLUG_EXPLICIT=true
+SERVICE_USER_FORCED=true
+bridge_update_systemd
+[ "$(grep -c '^Environment=KIMAKI_DATA_DIR=/explicit/data$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service")" -eq 1 ]
+[ "$(grep -c '^Environment=KIMAKI_LOCK_PORT=7654$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service")" -eq 1 ]
+[ "$(grep -c '^Environment=DATAMACHINE_AGENT_SLUG=explicit-agent$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service")" -eq 1 ]
+if grep -q '^Environment=KIMAKI_DATA_DIR=/home/opencode/.kimaki-site-b$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"; then
+  echo "FAIL: old data-directory environment was preserved" >&2
+  exit 1
+fi
+if grep -q '^Environment=DATAMACHINE_AGENT_SLUG=site-b$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"; then
+  echo "FAIL: old agent-slug environment was preserved" >&2
+  exit 1
+fi
+grep -q '^Environment=HOST_CUSTOM=preserved$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+
+# Restore the selected instance values used by the remaining rendering checks.
+KIMAKI_DATA_DIR=/home/opencode/.kimaki-site-b
+KIMAKI_LOCK_PORT=6543
+AGENT_SLUG=site-b
+
+[ "$(_kimaki_instance_suffix)" = -site-b ]
+cli_channel_register() { printf '%s\n%s\n' "$2" "$6"; }
+channel_registration=$(LOCAL_MODE=false SERVICE_USER=opencode SERVICE_HOME=/home/opencode KIMAKI_DATA_DIR=/home/opencode/.kimaki-site-b KIMAKI_BIN=/usr/bin/kimaki _kimaki_register_cli_channel)
+echo "$channel_registration" | grep -q '^/usr/local/bin/wp-coding-agents-kimaki-site-b-dispatch$'
+echo "$channel_registration" | grep -q '"HOME":"/home/opencode","KIMAKI_DATA_DIR":"/home/opencode/.kimaki-site-b"'
+
+wrapper_output=$(LOCAL_MODE=false SERVICE_USER=opencode SERVICE_HOME=/home/opencode KIMAKI_DATA_DIR=/home/opencode/.kimaki-site-b KIMAKI_BIN=/usr/bin/kimaki DRY_RUN=true _kimaki_install_dispatch_helpers)
+echo "$wrapper_output" | grep -q 'wp-coding-agents-kimaki-site-b-dispatch'
+
+rendered=$(bridge_render_systemd kimaki-site-b.service 'Environment=HOME=/home/opencode')
+echo "$rendered" | grep -q -- '--lock-port 6543'
+if echo "$rendered" | grep -q 'pkill -TERM'; then
+  echo "FAIL: custom instance contains host-user-wide stale worker cleanup" >&2
+  exit 1
+fi
+
+cp "$SYSTEMD_UNIT_DIR/kimaki-site-b.service" "$TMP/site-b.unit"
+sed "s|^WorkingDirectory=.*|WorkingDirectory=$TMP/site-a|" "$TMP/site-b.unit" > "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+if (SITE_PATH="$TMP/site-a" KIMAKI_UNIT=kimaki.service KIMAKI_UNIT_EXPLICIT=false KIMAKI_DATA_DIR_EXPLICIT=false _kimaki_resolve_instance) >/dev/null 2>&1; then
+  echo "FAIL: ambiguous site path did not fail" >&2
+  exit 1
+fi
+
+if (KIMAKI_LOCK_PORT=not-a-port _kimaki_validate_lock_port) >/dev/null 2>&1; then
+  echo "FAIL: invalid lock port did not fail" >&2
+  exit 1
+fi
+
+for invalid_unit in '../kimaki.service' '/tmp/kimaki.service' 'kimaki-../../escape.service' 'kimaki bad.service' 'kimaki-.service'; do
+  if (_kimaki_normalize_unit_name "$invalid_unit") >/dev/null 2>&1; then
+    echo "FAIL: unsafe unit name was accepted: $invalid_unit" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: tests/kimaki-multi-instance.sh"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -121,6 +121,7 @@ WITH_HOMEBOY="${WITH_HOMEBOY:-false}"
 # True when the operator forced the identity via --root / --non-root.
 # Suppresses adopt_service_identity_from_units (existing-unit adoption).
 SERVICE_USER_FORCED=false
+initialize_kimaki_overrides
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -140,6 +141,10 @@ while [[ $# -gt 0 ]]; do
     --rotate-ai-gateway-token) ROTATE_AI_GATEWAY_TOKEN=true; shift ;;
     --runtime)       RUNTIME="$2"; shift 2 ;;
     --wp-path)       EXISTING_WP="$2"; shift 2 ;;
+    --agent-slug)    AGENT_SLUG="$2"; AGENT_SLUG_EXPLICIT=true; shift 2 ;;
+    --kimaki-unit)   KIMAKI_UNIT="$2"; KIMAKI_UNIT_EXPLICIT=true; shift 2 ;;
+    --kimaki-data-dir) KIMAKI_DATA_DIR="$2"; KIMAKI_DATA_DIR_EXPLICIT=true; shift 2 ;;
+    --kimaki-lock-port) KIMAKI_LOCK_PORT="$2"; KIMAKI_LOCK_PORT_EXPLICIT=true; shift 2 ;;
     --local)         LOCAL_MODE=true; RUN_AS_ROOT=false; shift ;;
     --root)          RUN_AS_ROOT=true;  SERVICE_USER_FORCED=true; shift ;;
     --non-root)      RUN_AS_ROOT=false; SERVICE_USER_FORCED=true; shift ;;
@@ -176,6 +181,12 @@ USAGE:
                                 removes user-added plugins.
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
   ./upgrade.sh --wp-path <path> Override detected WordPress path
+  ./upgrade.sh --agent-slug <s> Override Data Machine agent slug
+  ./upgrade.sh --kimaki-unit <u> Target Kimaki systemd unit
+  ./upgrade.sh --kimaki-data-dir <path>
+                                 Override the selected Kimaki state directory
+  ./upgrade.sh --kimaki-lock-port <port>
+                                 Override the selected Kimaki lock port
   ./upgrade.sh --local          Local mode (no systemd; auto-on on macOS)
   ./upgrade.sh --root           Force root service identity (skips adoption
                                 of the existing unit's User=)
@@ -264,14 +275,20 @@ if [ -z "$EXISTING_WP" ]; then
     error "Local mode requires --wp-path <path> or EXISTING_WP env var"
   fi
 
-  # Scan /var/www for the first WordPress install
+  # A host may serve several sites. Selecting the first glob result is unsafe.
+  wp_candidates=()
   for candidate in /var/www/*/; do
     if [ -f "$candidate/wp-config.php" ]; then
-      EXISTING_WP="${candidate%/}"
-      log "Auto-detected WordPress at: $EXISTING_WP"
-      break
+      wp_candidates+=("${candidate%/}")
     fi
   done
+
+  if [ ${#wp_candidates[@]} -eq 1 ]; then
+    EXISTING_WP="${wp_candidates[0]}"
+    log "Auto-detected WordPress at: $EXISTING_WP"
+  elif [ ${#wp_candidates[@]} -gt 1 ]; then
+    error "Multiple WordPress installs found under /var/www. Pass --wp-path <path>: ${wp_candidates[*]}"
+  fi
 
   if [ -z "$EXISTING_WP" ]; then
     error "Could not auto-detect WordPress path. Pass --wp-path <path> or set EXISTING_WP."
@@ -336,6 +353,10 @@ if [ -n "$CHAT_BRIDGE" ] && bridge_file "$CHAT_BRIDGE" >/dev/null 2>&1; then
   bridge_load "$CHAT_BRIDGE"
 fi
 
+if [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$LOCAL_MODE" = false ]; then
+  _kimaki_resolve_instance
+fi
+
 # On upgrade, the installed unit's User= is the source of truth for the
 # service identity. upgrade.sh defaults RUN_AS_ROOT=true, which on a
 # non-root install (User=opencode) made Phase 5 silently rewrite the unit
@@ -352,6 +373,11 @@ log "Runtime:     $RUNTIME"
 log "Chat bridge: ${CHAT_BRIDGE:-none detected}"
 log "Site path:   $SITE_PATH"
 log "Service:     $SERVICE_USER"
+if [ "$CHAT_BRIDGE" = "kimaki" ]; then
+  log "Kimaki unit: $KIMAKI_UNIT"
+  log "Kimaki data: $KIMAKI_DATA_DIR"
+  [ -z "$KIMAKI_LOCK_PORT" ] || log "Kimaki lock: $KIMAKI_LOCK_PORT"
+fi
 if [ "$DRY_RUN" = true ]; then
   log "Dry-run mode: no changes will be made"
 fi


### PR DESCRIPTION
## Summary

- discover the Kimaki systemd unit whose site binding matches the requested WordPress path
- add explicit `--kimaki-unit`, `--kimaki-data-dir`, and `--kimaki-lock-port` setup/upgrade overrides
- preserve the existing `kimaki.service` single-instance defaults
- adopt per-instance user, HOME, data directory, lock port, and agent slug
- scope systemd updates, restart hints, CLI-channel environments, and non-root dispatch helpers to the selected instance
- fail safely for ambiguous matches and reject traversal-unsafe unit names
- add a two-unit isolation regression suite proving one site cannot rewrite the other

Closes #274.

## Verification

- `bash tests/kimaki-multi-instance.sh`
- `bash tests/service-identity-adoption.sh` (26 assertions)
- `bash tests/kimaki-agent-fallback.sh`
- `bash tests/cli-channel-binary-path.sh`
- `bash tests/bridge-render.sh` (all 8 snapshots)
- shell syntax checks for changed scripts
- ShellCheck with repository exclusions
- independent review found no remaining blocking issues

## CI note

The new regression is executable and passes locally. Workflow wiring is omitted from this PR because the current GitHub OAuth token lacks `workflow` scope; it can be added by a maintainer or run by an existing test-discovery hook.