### PR TITLE
fix: support non-root carried plugin sync

### DIFF
--- a/lib/carried-plugins.sh
+++ b/lib/carried-plugins.sh
@@ -37,7 +37,7 @@ sync_carried_plugins() {
 
     if [ "$DRY_RUN" = true ]; then
       echo -e "${BLUE}[dry-run]${NC} mkdir -p $target_dir"
-      echo -e "${BLUE}[dry-run]${NC} rsync -a --delete $source_dir/ $target_dir/"
+      echo -e "${BLUE}[dry-run]${NC} rsync -a --no-owner --no-group --delete $source_dir/ $target_dir/"
       echo -e "${BLUE}[dry-run]${NC} $WP_CMD plugin activate $slug --path=$SITE_PATH $WP_ROOT_FLAG"
       continue
     fi
@@ -48,7 +48,7 @@ sync_carried_plugins() {
     fi
 
     mkdir -p "$target_dir"
-    rsync -a --delete "$source_dir/" "$target_dir/"
+    rsync -a --no-owner --no-group --delete "$source_dir/" "$target_dir/"
     activate_plugin "$slug"
     fix_ownership "$target_dir"
 

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -138,10 +138,16 @@ update_plugin_to_latest_tag() {
   fix_ownership "$plugin_dir"
 }
 
-# Set file ownership to www-data (no-op in local mode).
+# Normalize web-tree ownership or group permissions (no-op in local mode).
 fix_ownership() {
   if [ "$LOCAL_MODE" = false ]; then
-    run_cmd chown -R www-data:www-data "$1"
+    if [ "$(id -u)" -eq 0 ]; then
+      run_cmd chown -R www-data:www-data "$1"
+    elif [ "$DRY_RUN" = true ]; then
+      echo -e "${BLUE}[dry-run]${NC} normalize group-writable permissions for $1"
+    else
+      service_dir_normalize_perms "$1"
+    fi
   fi
 }
 

--- a/tests/carried-claude-code-plugin.sh
+++ b/tests/carried-claude-code-plugin.sh
@@ -47,7 +47,7 @@ RUNTIME=claude-code
 output="$(sync_carried_plugins)"
 
 case "$output" in
-  *"Syncing carried plugin: ai-provider-for-claude-code"*"wp plugin activate ai-provider-for-claude-code"*) ;;
+  *"Syncing carried plugin: ai-provider-for-claude-code"*"rsync -a --no-owner --no-group --delete"*"wp plugin activate ai-provider-for-claude-code"*) ;;
   *)
     printf 'Expected Claude Code carried plugin sync, got:\n%s\n' "$output" >&2
     exit 1


### PR DESCRIPTION
## Summary
- stop carried-plugin rsync from preserving source owner/group
- retain root ownership normalization for root-run upgrades
- use existing web-group permission normalization for supported non-root service identities

Closes #278

## Verification
- `bash tests/carried-claude-code-plugin.sh`
- `bash tests/service-identity-adoption.sh` (27 assertions)
- `bash tests/post-upgrade-restore.sh`
- `bash -n lib/carried-plugins.sh lib/wordpress.sh tests/carried-claude-code-plugin.sh`
- `git diff --check`

ShellCheck was unavailable on the host.