### PR TITLE
fix: omit directory times during carried sync

### DIFF
--- a/lib/carried-plugins.sh
+++ b/lib/carried-plugins.sh
@@ -37,7 +37,7 @@ sync_carried_plugins() {
 
     if [ "$DRY_RUN" = true ]; then
       echo -e "${BLUE}[dry-run]${NC} mkdir -p $target_dir"
-      echo -e "${BLUE}[dry-run]${NC} rsync -a --no-owner --no-group --delete $source_dir/ $target_dir/"
+      echo -e "${BLUE}[dry-run]${NC} rsync -a --no-owner --no-group --omit-dir-times --delete $source_dir/ $target_dir/"
       echo -e "${BLUE}[dry-run]${NC} $WP_CMD plugin activate $slug --path=$SITE_PATH $WP_ROOT_FLAG"
       continue
     fi
@@ -48,7 +48,7 @@ sync_carried_plugins() {
     fi
 
     mkdir -p "$target_dir"
-    rsync -a --no-owner --no-group --delete "$source_dir/" "$target_dir/"
+    rsync -a --no-owner --no-group --omit-dir-times --delete "$source_dir/" "$target_dir/"
     activate_plugin "$slug"
     fix_ownership "$target_dir"
 

--- a/tests/carried-claude-code-plugin.sh
+++ b/tests/carried-claude-code-plugin.sh
@@ -47,7 +47,7 @@ RUNTIME=claude-code
 output="$(sync_carried_plugins)"
 
 case "$output" in
-  *"Syncing carried plugin: ai-provider-for-claude-code"*"rsync -a --no-owner --no-group --delete"*"wp plugin activate ai-provider-for-claude-code"*) ;;
+  *"Syncing carried plugin: ai-provider-for-claude-code"*"rsync -a --no-owner --no-group --omit-dir-times --delete"*"wp plugin activate ai-provider-for-claude-code"*) ;;
   *)
     printf 'Expected Claude Code carried plugin sync, got:\n%s\n' "$output" >&2
     exit 1


### PR DESCRIPTION
## Summary
- stop non-root carried-plugin sync from setting timestamps on existing web-owned directories
- retain file timestamps while avoiding directory ownership conflicts
- extend the dry-run regression contract with `--omit-dir-times`

Closes #278

## Verification
- `bash tests/carried-claude-code-plugin.sh`
- `bash -n lib/carried-plugins.sh tests/carried-claude-code-plugin.sh`
- `git diff --check`