### PR TITLE
fix: back up Kimaki config in writable state

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -741,7 +741,11 @@ bridge_sync_config() {
   else
     KIMAKI_CONFIG_DIR="/opt/kimaki-config"
     KIMAKI_PLUGINS_DIR="/opt/kimaki-config/plugins"
-    BACKUP_DIR="/opt/kimaki-config.backup.$TIMESTAMP"
+    if [ "$(id -u)" -eq 0 ]; then
+      BACKUP_DIR="/opt/kimaki-config.backup.$TIMESTAMP"
+    else
+      BACKUP_DIR="${KIMAKI_DATA_DIR}/backups/kimaki-config.$TIMESTAMP"
+    fi
     log "Phase 2: Syncing /opt/kimaki-config..."
   fi
 


### PR DESCRIPTION
## Summary
- keep root-run VPS backups beside `/opt/kimaki-config`
- store non-root VPS backups under `$KIMAKI_DATA_DIR/backups`
- preserve the live root-owned config while allowing supported service-user upgrades to proceed

Refs #278

## Verification
- `bash -n bridges/kimaki.sh`
- `bash tests/bridge-render.sh`
- `bash tests/kimaki-multi-instance.sh`
- `git diff --check`