### PR TITLE
fix: support evolving Kimaki prompt signatures

### DIFF
--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -190,9 +190,9 @@ if (source.includes(marker)) {
   process.exit(0)
 }
 
-const needle = 'export function getOpencodeSystemMessage({ sessionId, channelId, guildId, threadId, channelTopic, agents, userId, }) {\n'
-const managedReturn = `export function getOpencodeSystemMessage({ sessionId, channelId, guildId, threadId, channelTopic, agents, userId, }) {
-    // ${marker}. Keep this small; Data Machine AGENTS.md owns managed runtime policy.
+const signature = /^export function getOpencodeSystemMessage\(\{[^\n]*\}\) \{\n/m
+const match = source.match(signature)
+const managedReturn = `${match?.[0] ?? ''}    // ${marker}. Keep this small; Data Machine AGENTS.md owns managed runtime policy.
     return \`## Kimaki Discord Bridge
 
 Kimaki connects this OpenCode session to Discord. Treat Discord as the human coordination surface: keep the thread updated, ask the user for files with the native upload tool when needed, upload user-facing artifacts when useful, mention users by Discord ID when action is required, and archive the thread when the user explicitly asks.
@@ -207,12 +207,12 @@ For Kimaki bridge failures, inspect $HOME/.kimaki/kimaki.log. The log is reset e
 \`;
 `
 
-if (!source.includes(needle)) {
+if (!match) {
   console.error(`function signature not found in ${file}`)
   process.exit(2)
 }
 
-fs.writeFileSync(file, source.replace(needle, managedReturn), 'utf8')
+fs.writeFileSync(file, source.replace(signature, managedReturn), 'utf8')
 NODE
   local patch_exit=$?
   if [[ "$patch_exit" -eq 0 ]]; then

--- a/tests/kimaki-system-message-patch.sh
+++ b/tests/kimaki-system-message-patch.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/config/plugins" "$TMP/config/skills" "$TMP/live-skills" "$TMP/dist"
+touch "$TMP/config/plugins/dm-context-filter.ts" "$TMP/config/plugins/dm-agent-sync.ts"
+
+for parameters in \
+  'sessionId, channelId, guildId, threadId, channelTopic, agents, userId,' \
+  'sessionId, channelId, guildId, threadId, channelTopic, agents, userId, parentSessionId,'
+do
+  cat > "$TMP/dist/system-message.js" <<EOF
+export function getOpencodeSystemMessage({ $parameters }) {
+    return 'original';
+}
+EOF
+
+  KIMAKI_DIST_DIR="$TMP/dist" \
+  KIMAKI_SKILLS_DIR="$TMP/live-skills" \
+  KIMAKI_SKILL_SOURCE_DIR="$TMP/config/skills" \
+  KIMAKI_PLUGIN_SOURCE_DIR="$TMP/config/plugins" \
+    "$ROOT/bridges/kimaki/post-upgrade.sh" >/dev/null
+
+  if ! grep -qF 'wp-coding-agents managed Kimaki system prompt patch' "$TMP/dist/system-message.js"; then
+    echo "FAIL: system prompt patch did not support parameters: $parameters"
+    exit 1
+  fi
+done
+
+echo "PASS: Kimaki system prompt patch supports known signatures"


### PR DESCRIPTION
## Summary
- preserve Kimaki's current `getOpencodeSystemMessage()` declaration instead of matching a fixed parameter list
- support the `parentSessionId` parameter added in Kimaki 0.22
- cover both known signatures with a focused regression test

## Verification
- `bash tests/kimaki-system-message-patch.sh`
- `bash tests/post-upgrade-restore.sh`
- `bash -n bridges/kimaki/post-upgrade.sh tests/kimaki-system-message-patch.sh`

Fixes #284.