### PR TITLE
Generate live Homeboy configuration pointers in AGENTS.md

### DIFF
--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -456,6 +456,7 @@ _agents_md_guidance_render_homeboy_live_block() {
             }
 
             $lines[] = '';
+            $lines[] = 'For agent work, use `homeboy agent-task cook` for one issue or reviewable PR, `homeboy agent-task fanout cook-batch` for multiple independent issues, `homeboy agent-task loop` for a named repeating workflow, and `homeboy agent-task controller` for workflows with explicit actions, events, waits, or policy state.';
             $lines[] = 'Inspect live configuration with `homeboy config show`. Discover current agent-task providers with `homeboy agent-task providers`.';
             $lines[] = 'Discover everything: `homeboy --help`. Drill into a command with `homeboy <command> --help`, including `homeboy config --help` and `homeboy agent-task --help`. Releases (`homeboy release`) and deploys (`homeboy deploy`) are operator actions — run them only when the user explicitly asks.';
 

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -456,7 +456,8 @@ _agents_md_guidance_render_homeboy_live_block() {
             }
 
             $lines[] = '';
-            $lines[] = 'Discover everything: `homeboy --help`. Drill into any command with `homeboy <command> --help`. Releases (`homeboy release`) and deploys (`homeboy deploy`) are operator actions — run them only when the user explicitly asks.';
+            $lines[] = 'Inspect live configuration with `homeboy config show`. Discover current agent-task providers with `homeboy agent-task providers`.';
+            $lines[] = 'Discover everything: `homeboy --help`. Drill into a command with `homeboy <command> --help`, including `homeboy config --help` and `homeboy agent-task --help`. Releases (`homeboy release`) and deploys (`homeboy deploy`) are operator actions — run them only when the user explicitly asks.';
 
             return implode( "\n", $lines );
         }

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -86,6 +86,10 @@ MOCKBIN="$TMP/bin"
 mkdir -p "$MOCKBIN"
 cat > "$MOCKBIN/homeboy" <<'SH'
 #!/bin/bash
+if [ "$1" = "agent-task" ] && [ "$2" = "providers" ]; then
+  echo "codebox-provider-snapshot"
+  exit 0
+fi
 if [ "$1" = "--help" ]; then
   cat <<'HELP'
 Headless automation for agentic software engineering workflows
@@ -175,14 +179,19 @@ namespace {
         'has_common_entrypoints' => str_contains( \$content, 'Common entrypoints:' ),
         'drops_help_meta' => ! str_contains( \$content, 'homeboy help' ),
         'drops_list_meta' => ! str_contains( \$content, 'homeboy list' ),
+        'has_config_show' => str_contains( \$content, 'Inspect live configuration with \`homeboy config show\`' ),
+        'has_agent_task_providers' => str_contains( \$content, '\`homeboy agent-task providers\`' ),
+        'does_not_render_provider_snapshot' => ! str_contains( \$content, 'codebox-provider-snapshot' ),
         'has_discover_footer' => str_contains( \$content, 'Discover everything: \`homeboy --help\`' ),
         'has_per_command_footer' => str_contains( \$content, 'homeboy <command> --help' ),
+        'has_config_help' => str_contains( \$content, '\`homeboy config --help\`' ),
+        'has_agent_task_help' => str_contains( \$content, '\`homeboy agent-task --help\`' ),
     ]);
 }
 PHP
 
 RESULT=$(PATH="$MOCKBIN:$PATH" php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"live","has_live_freshness":true,"has_live_intro":true,"no_false_refresh_prose":true,"has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"drops_help_meta":true,"drops_list_meta":true,"has_discover_footer":true,"has_per_command_footer":true}'
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"live","has_live_freshness":true,"has_live_intro":true,"no_false_refresh_prose":true,"has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"drops_help_meta":true,"drops_list_meta":true,"has_config_show":true,"has_agent_task_providers":true,"does_not_render_provider_snapshot":true,"has_discover_footer":true,"has_per_command_footer":true,"has_config_help":true,"has_agent_task_help":true}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives live Homeboy CLI map"
 
 echo "==> re-sync with homeboy present (idempotent)"

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -179,6 +179,7 @@ namespace {
         'has_common_entrypoints' => str_contains( \$content, 'Common entrypoints:' ),
         'drops_help_meta' => ! str_contains( \$content, 'homeboy help' ),
         'drops_list_meta' => ! str_contains( \$content, 'homeboy list' ),
+        'has_agent_task_workflow_selection' => str_contains( \$content, 'use \`homeboy agent-task cook\` for one issue or reviewable PR, \`homeboy agent-task fanout cook-batch\` for multiple independent issues, \`homeboy agent-task loop\` for a named repeating workflow, and \`homeboy agent-task controller\` for workflows with explicit actions, events, waits, or policy state' ),
         'has_config_show' => str_contains( \$content, 'Inspect live configuration with \`homeboy config show\`' ),
         'has_agent_task_providers' => str_contains( \$content, '\`homeboy agent-task providers\`' ),
         'does_not_render_provider_snapshot' => ! str_contains( \$content, 'codebox-provider-snapshot' ),
@@ -191,7 +192,7 @@ namespace {
 PHP
 
 RESULT=$(PATH="$MOCKBIN:$PATH" php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"live","has_live_freshness":true,"has_live_intro":true,"no_false_refresh_prose":true,"has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"drops_help_meta":true,"drops_list_meta":true,"has_config_show":true,"has_agent_task_providers":true,"does_not_render_provider_snapshot":true,"has_discover_footer":true,"has_per_command_footer":true,"has_config_help":true,"has_agent_task_help":true}'
+EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":34,"label":"Homeboy CLI","owner":"wp-coding-agents","freshness":"live","has_live_freshness":true,"has_live_intro":true,"no_false_refresh_prose":true,"has_deploy":true,"has_release":true,"has_triage":true,"has_status":true,"has_orchestrator_intro":true,"has_common_entrypoints":true,"drops_help_meta":true,"drops_list_meta":true,"has_agent_task_workflow_selection":true,"has_config_show":true,"has_agent_task_providers":true,"does_not_render_provider_snapshot":true,"has_discover_footer":true,"has_per_command_footer":true,"has_config_help":true,"has_agent_task_help":true}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives live Homeboy CLI map"
 
 echo "==> re-sync with homeboy present (idempotent)"


### PR DESCRIPTION
## Summary
Point generated Homeboy guidance at authoritative live configuration and provider discovery commands.

## What changed
- Add concise config, provider, and command-help pointers without embedding mutable provider snapshots.

## How to test
1. Run `bash tests/homeboy-agents-md.sh`; expect All Homeboy command-map assertions pass.

## Compatibility
No compatibility impact; this changes generated guidance text only.

## Evidence
- Base unchanged since verification: main remains at d6856212fb9082525c409cc66318dcb01994f0de.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/wp-coding-agents/issues/286
- Verified finalization base: main at d6856212fb9082525c409cc66318dcb01994f0de
- generated-guidance: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** AI-assisted
- **Model:** openai/gpt-5.6-terra
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/wp-coding-agents#286
