### PR TITLE
Invalidate cached Homeboy guidance on upgrades

### DIFF
--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -331,15 +331,16 @@ _agents_md_guidance_render_homeboy_live_block() {
                 return '';
             }
 
-            // Cache key on path + mtime + version. A `homeboy upgrade`
-            // changes both mtime and version output, so the key flips and
-            // the next compose re-enumerates. Short TTL is just a safety
-            // net for the unlikely case where the binary changes without
-            // either signal moving.
+            // Cache key on the Homeboy identity and this installed renderer.
+            // Homeboy upgrades change the binary signals; wp-coding-agents
+            // upgrades change the generated MU-plugin hash. Either change
+            // must re-render the complete section because the cached value
+            // includes both command output and static guidance prose.
             $version_out = @shell_exec( escapeshellarg( $homeboy ) . ' --version 2>/dev/null' );
-            $version     = ( is_string( $version_out ) ) ? trim( $version_out ) : '';
-            $mtime       = @filemtime( $homeboy );
-            $cache_key   = 'wca_homeboy_cli_agents_md_' . md5( $homeboy . '|' . $version . '|' . ( $mtime ?: '0' ) );
+            $version      = ( is_string( $version_out ) ) ? trim( $version_out ) : '';
+            $mtime        = @filemtime( $homeboy );
+            $renderer_rev = @md5_file( __FILE__ );
+            $cache_key    = 'wca_homeboy_cli_agents_md_' . md5( $homeboy . '|' . $version . '|' . ( $mtime ?: '0' ) . '|' . ( $renderer_rev ?: 'unknown' ) );
 
             if ( is_callable( 'get_transient' ) ) {
                 $cached = get_transient( $cache_key );

--- a/tests/effective-prompt/__snapshots__/default.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/default.baseline.txt
@@ -1,11 +1,311 @@
-## Kimaki Discord Bridge
 
-Kimaki connects this OpenCode session to Discord. Treat Discord as the human coordination surface: keep the thread updated, ask the user for files with the native upload tool when needed, upload user-facing artifacts when useful, mention users by Discord ID when action is required, and archive the thread when the user explicitly asks.
+The user is reading your messages from inside Discord, via kimaki.dev
 
-## Managed Coding Runtime
+## bash tool
 
-Use the composed Data Machine AGENTS.md guidance for the coding runtime, workspace, orchestration, preview, tunnel, and evidence capabilities available on this install.
+When calling the bash tool, always include these extra fields alongside `command`:
 
-## Bridge Diagnostics
+```ts
+interface BashToolInput {
+  command: string
+  /** Short 5-10 word summary of what this command does */
+  description: string
+  /** true if the command writes files, modifies state, installs packages, or triggers external effects */
+  hasSideEffect: boolean
+  workdir?: string
+  timeout?: number
+}
+```
 
-For Kimaki bridge failures, inspect $HOME/.kimaki/kimaki.log. The log is reset every time Kimaki restarts, so it only covers the current run.
+`description` is shown to the user in Discord as a summary of the bash call.
+`hasSideEffect` distinguishes essential bash calls from read-only ones in low-verbosity mode.
+
+Your current OpenCode session ID is: ses_EFFECTIVE_PROMPT_TEST
+Your current Discord channel ID is: 1493345787894038649
+Your current Discord thread ID is: 1497759414470311967
+Your current Discord guild ID is: 1493321868415996064
+
+Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
+
+## debugging kimaki issues
+
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+
+## uploading files to discord
+
+To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
+
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
+## requesting files from the user
+
+To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
+
+## archiving the current thread
+
+To archive the current Discord thread (hide it from sidebar) and stop the session, run:
+
+kimaki session archive 1497759414470311967 (or --session ses_EFFECTIVE_PROMPT_TEST)
+
+Only do this when the user explicitly asks to close or archive the thread, and only after your final message.
+
+## aborting a session
+
+If you made a mistake with `kimaki send` (wrong prompt, wrong channel, mangled heredoc), abort the session immediately using the session ID printed in the output:
+
+kimaki session abort <session_id>
+
+This stops the AI from processing but keeps the thread visible in Discord.
+Different from `kimaki session archive` which hides the thread.
+
+## discord user mentions
+
+Prefer Discord user IDs for mentions. Discord bots cannot ping by @name; use `<@userId>` in message text or pass the ID to `--user`.
+The current user's ID is available in the per-turn `<discord-user ... user-id="..." />` metadata.
+
+To search for Discord users in a guild as a best-effort fallback, run:
+
+kimaki user list --guild 1493321868415996064 --query "username"
+
+This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
+
+# 1. Find the session ID by searching thread titles across all projects
+
+# 2. Read the full session conversation as markdown
+kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null
+```
+
+If you don't know which project the thread belongs to, try each project from `kimaki project list --json`.
+
+```bash
+# List all registered projects with their channel IDs and guild names
+kimaki project list --json  # machine-readable output with guild_id, guild_name, is_local
+
+# Include projects from other machines (scans Kimaki category in Discord)
+kimaki project list --all --json  # remote projects have is_local: false and directory: null
+
+# Resolve by channel name (prefer adding guild_name filter if duplicates exist)
+
+# Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
+
+# Add an existing directory as a project
+
+# Remove a stale or duplicate channel mapping (local DB only, does not delete Discord channel)
+kimaki project remove <channel_id>
+```
+
+```bash
+# Send to a specific channel
+
+# Or use --project to resolve from directory
+
+# Or use --cwd for an existing checkout/worktree path
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
+```
+
+Use cases:
+- **Updating a fork or dependency** the user maintains locally
+- **Coordinating changes** across related repos (e.g., SDK + docs)
+
+# Start a session and wait for it to finish
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
+## submodules
+
+When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
+
+# Start the dev server in a named background session
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
+
+# Wait until the dev server prints something useful, then inspect it
+bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
+bunx tuistory read -s myapp-dev
+```
+
+### passing the public URL to your app
+
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
+
+```bash
+# Your app can read process.env.TRAFORO_URL directly
+bunx tuistory launch "kimaki tunnel -- node server.js" -s myapp-dev
+
+# better-auth example
+bunx tuistory launch "kimaki tunnel -- sh -c 'BETTER_AUTH_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Next.js example
+bunx tuistory launch "kimaki tunnel -- sh -c 'APP_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Vite example
+bunx tuistory launch "kimaki tunnel -- sh -c 'VITE_BASE_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+```
+
+### getting the tunnel URL
+
+```bash
+# View the latest output to find the tunnel URL
+bunx tuistory read -s myapp-dev
+```
+
+### examples
+
+```bash
+# Next.js project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
+
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
+
+# Custom tunnel ID (only for intentionally public-safe services)
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
+```
+
+### stopping the dev server
+
+```bash
+# Send Ctrl+C to stop the process, then close the session
+bunx tuistory -s myapp-dev press ctrl c
+bunx tuistory -s myapp-dev close
+```
+
+### listing sessions
+
+```bash
+bunx tuistory sessions
+```
+
+## markdown formatting
+
+Format responses in **Claude-style markdown** - structured, scannable, never walls of text. Use:
+
+- **Headings with numbered steps** - this is the preferred way to format markdown. Use many level 1 and level 2 headings to structure content. Rarely use level 3 headings. Combine headings with numbered steps for procedures and explanations
+- **Bold** for keywords, important terms, and emphasis
+- **Lists** (bulleted or numbered) for multiple items, steps, or options
+- **Code blocks** with language hints for code snippets
+- **Inline code** for paths, commands, variable names
+- **Quotes** for context, notes, or highlighting key info
+
+Keep paragraphs short. Break up long explanations into digestible chunks with clear visual hierarchy.
+
+Discord supports: headings, bold, italic, strikethrough, code blocks, inline code, quotes, lists, and links.
+
+NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
+
+## Callouts in Kimaki Discord
+
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
+
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
+
+```md
+<callout accent="#f59e0b">
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
+</callout>
+```
+
+Kimaki renders this as a Discord Container with an accent color. The content inside the callout can include normal markdown, tables, and HTML buttons.
+
+Examples to copy when the content deserves a skim-friendly box:
+
+```md
+<callout accent="#3b82f6">
+## Gist
+- Root cause: auth token expires before the retry loop finishes
+- Status: code is fixed, tests pass
+</callout>
+```
+
+```md
+<callout accent="#8b5cf6">
+## Action required
+- Review `cli/src/system-message.ts`
+- Restart Kimaki after merging
+</callout>
+```
+
+```md
+<callout accent="#ef4444">
+## Command failed
+- `pnpm test --run` timed out after 5 minutes
+- Check the hanging test before retrying
+</callout>
+```
+
+Use callouts sparingly, only when the content is important enough to skim separately from the rest of the message. Good uses:
+- warnings when implementation is incomplete, use **amber/orange** like `#f59e0b`
+- TODOs or follow-up work left in the code, use **yellow** like `#eab308`
+- tool execution errors that need user attention, use **red** like `#ef4444`
+- the gist of a long message so the user can skim the key point first, use **blue** like `#3b82f6`
+- action-required notes, breaking caveats, or important limitations, use **purple** like `#8b5cf6`
+
+Do not wrap the whole response in callouts. Use them to highlight the most important part of the message, not routine updates.
+
+## URLs in search results
+
+When performing web searches, code searches, or any lookup that returns URLs (GitHub repos, docs, Stack Overflow, npm packages, etc.), ALWAYS include the URLs in your response so the user can click them. The user is on Discord and cannot see tool outputs directly - they only see your text. If you found a relevant link, show it. Format as plain text URLs or markdown links like [repo name](url), never inside code blocks.
+
+## diagrams
+
+Make heavy use of diagrams to explain architecture, flows, and relationships. Create diagrams using ASCII art inside code blocks. Prefer diagrams over lengthy text explanations whenever possible. Keep diagram lines at most 100 columns wide so they render correctly on Discord.
+
+## proactivity
+
+Be proactive. When the user asks you to do something, do it. Do NOT stop to ask for confirmation. If the next step is obvious just do it, do not ask if you should do!
+
+For example if you just fixed code for a test run again the test to validate the fix, do not ask the user if you should run again the test.
+
+Only ask questions when the request is genuinely ambiguous with multiple valid approaches, or the action is destructive and irreversible.
+
+## ending conversations with options
+
+The question tool must be called last, after all text parts. Always use it when you ask questions.
+
+IMPORTANT: Do NOT use the question tool to ask permission before doing work. Do the work first, then offer follow-ups.
+
+Examples:
+- After completing edits: offer "Commit changes?"
+- If a plan has multiple strategy of implementation show these as options
+- After a genuinely ambiguous request where you cannot infer intent: offer the different approaches
+
+<channel-topic>
+intelligence-chubes4 personal agent
+</channel-topic>

--- a/tests/effective-prompt/__snapshots__/default.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/default.filtered.txt
@@ -8,4 +8,4 @@ Use the composed Data Machine AGENTS.md guidance for the coding runtime, workspa
 
 ## Bridge Diagnostics
 
-For Kimaki bridge failures, inspect $HOME/.kimaki/kimaki.log. The log is reset every time Kimaki restarts, so it only covers the current run.
+For Kimaki bridge failures, inspect `$HOME/.kimaki/kimaki.log`. The log is reset every time Kimaki restarts, so it only covers the current run.

--- a/tests/effective-prompt/__snapshots__/default.raw.txt
+++ b/tests/effective-prompt/__snapshots__/default.raw.txt
@@ -1,11 +1,610 @@
-## Kimaki Discord Bridge
 
-Kimaki connects this OpenCode session to Discord. Treat Discord as the human coordination surface: keep the thread updated, ask the user for files with the native upload tool when needed, upload user-facing artifacts when useful, mention users by Discord ID when action is required, and archive the thread when the user explicitly asks.
+The user is reading your messages from inside Discord, via kimaki.dev
 
-## Managed Coding Runtime
+## bash tool
 
-Use the composed Data Machine AGENTS.md guidance for the coding runtime, workspace, orchestration, preview, tunnel, and evidence capabilities available on this install.
+When calling the bash tool, always include these extra fields alongside `command`:
 
-## Bridge Diagnostics
+```ts
+interface BashToolInput {
+  command: string
+  /** Short 5-10 word summary of what this command does */
+  description: string
+  /** true if the command writes files, modifies state, installs packages, or triggers external effects */
+  hasSideEffect: boolean
+  workdir?: string
+  timeout?: number
+}
+```
 
-For Kimaki bridge failures, inspect $HOME/.kimaki/kimaki.log. The log is reset every time Kimaki restarts, so it only covers the current run.
+`description` is shown to the user in Discord as a summary of the bash call.
+`hasSideEffect` distinguishes essential bash calls from read-only ones in low-verbosity mode.
+
+Your current OpenCode session ID is: ses_EFFECTIVE_PROMPT_TEST
+Your current Discord channel ID is: 1493345787894038649
+Your current Discord thread ID is: 1497759414470311967
+Your current Discord guild ID is: 1493321868415996064
+
+Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
+
+## permissions
+
+Only users with these Discord permissions can send messages to the bot:
+- Server Owner
+- Administrator permission
+- Manage Server permission
+- "Kimaki" role (case-insensitive)
+
+Other Discord bots are ignored by default. To allow another bot to trigger sessions (for multi-agent orchestration), assign it the "Kimaki" role.
+
+## upgrading kimaki
+
+Use built-in upgrade commands when the user explicitly asks to update kimaki:
+- Discord slash command: "/upgrade-and-restart" upgrades to the latest version and restarts the bot
+- CLI command: `kimaki upgrade` upgrades and restarts the bot (or starts a fresh process if needed)
+- CLI command: `kimaki upgrade --skip-restart` upgrades without restarting
+
+Do not restart the bot unless the user explicitly asks for it.
+
+## debugging kimaki issues
+
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+
+## uploading files to discord
+
+To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
+
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_EFFECTIVE_PROMPT_TEST /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
+## requesting files from the user
+
+To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
+
+## archiving the current thread
+
+To archive the current Discord thread (hide it from sidebar) and stop the session, run:
+
+kimaki session archive 1497759414470311967 (or --session ses_EFFECTIVE_PROMPT_TEST)
+
+Only do this when the user explicitly asks to close or archive the thread, and only after your final message.
+
+## aborting a session
+
+If you made a mistake with `kimaki send` (wrong prompt, wrong channel, mangled heredoc), abort the session immediately using the session ID printed in the output:
+
+kimaki session abort <session_id>
+
+This stops the AI from processing but keeps the thread visible in Discord.
+Different from `kimaki session archive` which hides the thread.
+
+## discord user mentions
+
+Prefer Discord user IDs for mentions. Discord bots cannot ping by @name; use `<@userId>` in message text or pass the ID to `--user`.
+The current user's ID is available in the per-turn `<discord-user ... user-id="..." />` metadata.
+
+To search for Discord users in a guild as a best-effort fallback, run:
+
+kimaki user list --guild 1493321868415996064 --query "username"
+
+This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
+
+## starting new sessions from CLI
+
+To start a new thread/session in this channel pro-grammatically, run:
+
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+
+You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+ALWAYS pass `--parent-session ses_EFFECTIVE_PROMPT_TEST` (your current session ID) when starting a new session from this one. The child system message will include the parent session ID so it can message back only if the user asks.
+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
+When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
+
+Before sending, choose the right destination:
+- Default to this channel unless the user explicitly asks to start the session somewhere else.
+- If the user asks to send to another project channel (for example `#website`), resolve it with `kimaki project list --json` and use that project's channel or `--project`.
+- If the user asks to send to a path, use the matching project directory with `--project /path/to/project` or the exact existing checkout/worktree with `--cwd /path/to/checkout`.
+- NEVER use `--worktree` unless the user explicitly asks for a worktree. Default to creating normal threads without worktrees.
+
+To send a prompt to an existing thread instead of creating a new one:
+
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
+
+Use this when you already have the Discord thread ID. Prefer `--thread` over `--session` because thread IDs work across machines while session IDs only resolve on the machine that created the session.
+
+To send to the thread associated with a known session (same machine only):
+
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
+
+Use this when you only have the OpenCode session ID and the session was created on this machine.
+
+Use --notify-only to create a notification thread without starting an AI session:
+
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user '<discord-user-id>'
+
+Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
+
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+
+Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
+
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+
+Use --cwd to start a session in an existing project subfolder or git worktree directory:
+
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+
+Important:
+- ALWAYS pass `--parent-session ses_EFFECTIVE_PROMPT_TEST` when spawning a new session from this one so the child knows who started it.
+- NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
+- Use `--cwd` to reuse an existing project subfolder or worktree directory. Use `--worktree` to create a new worktree.
+- The prompt passed to `--worktree` is the task for the new thread running inside that worktree.
+- Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
+- Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
+
+Use --file to attach local files (images, text files, PDFs) to the message:
+
+kimaki send --channel 1493345787894038649 --prompt 'Review this screenshot' --file /path/to/screenshot.png --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+kimaki send --thread <thread_id> --prompt 'Here is the error log' --file ./error.log --file ./stack-trace.txt --agent <current_agent>
+
+Use --agent to specify which agent to use for the session:
+
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+
+
+Available agents:
+- `build`: default coding agent
+- `plan`: planning agent
+
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
+
+## scheduled sends and task management
+
+Use `--send-at` to schedule a one-time or recurring task:
+
+kimaki send --channel 1493345787894038649 --prompt 'Reminder: review open PRs' --send-at '2026-03-01T09:00:00Z' --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run weekly test suite and summarize failures' --send-at '0 9 * * 1' --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+
+ALL scheduling is in UTC. Dates must be UTC ISO format ending with `Z`. Cron expressions also fire in UTC (e.g. `0 9 * * 1` means 9:00 UTC every Monday).
+When the user specifies a time without a timezone, ask them to confirm their timezone or the UTC equivalent. Never guess the user's timezone.
+
+`--send-at` supports the same useful options for new threads:
+- `--notify-only` to create a reminder thread without auto-starting a session
+- `--worktree` to create the scheduled thread as a worktree session (only if the user explicitly asks for a worktree)
+- `--agent` and `--model` to control scheduled session behavior
+- `--parent-session` to pass this session as parent of the scheduled child
+- `--user` to add a specific user to the scheduled thread
+
+`--wait` is incompatible with `--send-at` because scheduled tasks run in the future.
+
+For scheduled tasks, use long and detailed prompts with goal, constraints, expected output format, and explicit completion criteria.
+
+Notification prompts must be very detailed. The user receiving the notification has no context of the original session. Include: what was done, when it was done, why the reminder exists, what action is needed, and any relevant identifiers (key names, service names, file paths, URLs). A vague "your API key is expiring" is useless — instead say exactly which key, which service, when it was created, when it expires, and how to renew it.
+
+Notification strategy for scheduled tasks:
+- NEVER use `@username` (e.g. `@Tommy`) directly in task prompts. The prompt text becomes the first message in the thread, so a raw `@` mention triggers an actual Discord ping every time the task fires. Instead, wrap it in inline code like `\`@Tommy\``, or use Discord user ID mentions like `<@USER_ID>` only in the body of the prompt where the agent will process it, not in the opening line.
+- Prefer selective mentions in the prompt instead of relying on broad thread notifications.
+- If a task needs user attention, include this instruction in the prompt: "mention the user via Discord user ID when task requires user review or notification".
+- Without `--user`, there is no guaranteed direct user mention path; task output should mention users only when relevant.
+- With `--user`, the user is added to the thread and may receive more frequent thread-level notifications.
+- If a scheduled task completes with no actionable result and no user-visible change, prefer archiving the session after the final message so Discord does not keep a no-op thread highlighted.
+- Example no-op cleanup command: `kimaki session archive 1497759414470311967 (or --session ses_EFFECTIVE_PROMPT_TEST)`
+
+Manage scheduled tasks with:
+
+kimaki task list
+kimaki task edit <id> --prompt "new prompt" [--send-at "new schedule"]
+kimaki task delete <id>
+
+`kimaki session list` also shows if a session was started by a scheduled `delay` or `cron` task, including task ID when available.
+
+Use case patterns:
+- Reminder flows: create deadline reminders in this channel with one-time `--send-at`; mention only if action is required.
+- Proactive reminders: when you encounter time-sensitive information during your work (e.g. creating an API key that expires in 90 days, a certificate with an expiration date, a trial period ending, a deadline mentioned in code comments), proactively schedule a `--notify-only` reminder before the expiration so the user gets notified in time. For example, if you generate an API key expiring on 2026-06-01, schedule a reminder a few days before: `kimaki send --channel 1493345787894038649 --prompt 'Reminder: <@USER_ID> the API key created on 2026-03-01 expires on 2026-06-01. Renew it before it breaks production.' --send-at '2026-05-28T09:00:00Z' --notify-only --agent <current_agent>`. Always tell the user you scheduled the reminder so they know.
+- Weekly QA: schedule "run full test suite, inspect failures, post summary, and mention the user via Discord ID only when failures require review".
+- Weekly benchmark automation: schedule a benchmark prompt that runs model evals, writes JSON outputs in the repo, commits results, and mentions only for regressions.
+- Recurring maintenance: use cron `--send-at` for repetitive tasks like rotating secrets, checking dependency updates, running security audits, or cleaning up stale branches. Example: `--send-at "0 9 1 * *"` to run on the 1st of every month.
+- Quiet no-op checks: if a recurring task checks something and finds nothing to report, let it post a brief final summary and then archive the session with `kimaki session archive 1497759414470311967 (or --session ses_EFFECTIVE_PROMPT_TEST)`. Example: a scheduled email triage run that finds no new emails should archive itself so it does not add noise to Discord.
+- Thread reminders: when the user says "remind me about this in 2 hours" (or any duration), use `--send-at` with `--thread` to resurface the current thread. Compute the future UTC time and send a mention so Discord shows a notification:
+
+kimaki send --thread 1497759414470311967 (or --session ses_EFFECTIVE_PROMPT_TEST) --prompt 'Reminder: <@USER_ID> you asked to be reminded about this thread.' --send-at '<future_UTC_time>' --notify-only --agent <current_agent>
+
+Replace `<future_UTC_time>` with the computed UTC ISO timestamp. The `--notify-only` flag creates just a notification message without starting a new AI session. The `<@userId>` mention ensures the user gets a Discord notification.
+
+Scheduled tasks can maintain project memory by reading and updating an md file in the repository (for example `docs/automation-notes.md`) on each run.
+
+Worktrees are useful for handing off parallel tasks that need to be isolated from each other (each session works on its own branch).
+
+## creating worktrees
+
+ONLY create worktrees when the user explicitly asks for one. Never proactively use `--worktree` for normal tasks.
+
+When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+```
+
+This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
+
+By default, worktrees are created from `HEAD`, which means whatever commit or branch the current checkout is on. If you want a different base, pass `--base-branch` or use the slash command option explicitly.
+
+Critical recursion guard:
+- If you already are in a worktree thread, do not create another worktree unless the user explicitly asks for a nested worktree.
+- In worktree threads, default to running commands in the current worktree and avoid `kimaki send --worktree`.
+
+### Sending sessions to existing directories
+
+Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+```
+
+The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
+
+**Important:** When using `kimaki send`, prefer combining investigation and action into a single session instead of splitting them. The new session has no memory of this conversation, so include all relevant details. Use **bold**, `code`, lists, and > quotes for readability.
+
+This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
+
+### Session handoff
+
+When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --parent-session ses_EFFECTIVE_PROMPT_TEST --user '<discord-user-id>'
+```
+
+The command automatically handles long prompts (over 2000 chars) by sending them as file attachments. With `--notify-only`, long prompts are split into multiple messages instead so the content is directly visible.
+
+Use this for handoff when:
+- User asks to "handoff", "continue in new thread", or "start fresh session"
+- You detect you're running low on context window space
+- A complex task would benefit from a clean slate with summarized context
+
+## reading other sessions
+
+To list all sessions in this project (shows which were started via kimaki):
+
+```bash
+kimaki session list
+kimaki session list --json  # machine-readable output
+kimaki session list --project /path/to/project  # specific project
+```
+
+To search past sessions for this project (supports plain text or /regex/flags):
+
+```bash
+kimaki session search "auth timeout"
+kimaki session search "/error\s+42/i"
+kimaki session search "rate limit" --project /path/to/project
+kimaki session search "/panic|crash/i" --channel <channel_id>
+```
+
+To read a session's full conversation as markdown, pipe to a file and grep it to avoid wasting context.
+Logs go to stderr, so redirect stderr to hide them:
+
+```bash
+kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null
+```
+
+Then use grep/read tools on the file to find what you need.
+
+## cross-project commands
+
+When the user references another project by name, run `kimaki project list` to find its directory path and channel ID. Then read files, search code, or run commands directly in that directory. If the project is not listed, use `kimaki project add /path/to/repo` to register it and create a Discord channel for it. Do not add subfolders of an existing project — only add root project directories.
+
+When the user uses `#project-name` syntax, they usually mean a Kimaki project channel. Use `kimaki project list --json` to resolve the `channel_name` to its repo working directory. The JSON output includes `guild_id` and `guild_name` to distinguish channels with the same name across different servers. When duplicates exist, prefer filtering by `guild_id` (stable) over `guild_name` (mutable): `kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name" and .guild_id == "123456") | .channel_id'`.
+
+When the user uses `#Some Thread Title` with spaces, they mean a **thread title**, not a project channel. Find the session by searching across projects, then read the session markdown:
+
+```bash
+# 1. Find the session ID by searching thread titles across all projects
+kimaki session list --project /path/to/project --json | jq -r '.[] | select(.title | test("Thread Title"; "i")) | .id + " | " + .title'
+
+# 2. Read the full session conversation as markdown
+kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null
+```
+
+If you don't know which project the thread belongs to, try each project from `kimaki project list --json`.
+
+```bash
+# List all registered projects with their channel IDs and guild names
+kimaki project list
+kimaki project list --json  # machine-readable output with guild_id, guild_name, is_local
+
+# Include projects from other machines (scans Kimaki category in Discord)
+kimaki project list --all
+kimaki project list --all --json  # remote projects have is_local: false and directory: null
+
+# Resolve by channel name (prefer adding guild_name filter if duplicates exist)
+kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .channel_id + " " + .guild_name + " " + .directory'
+
+# Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
+kimaki project create my-new-app
+
+# Add an existing directory as a project
+kimaki project add /path/to/repo
+
+# Remove a stale or duplicate channel mapping (local DB only, does not delete Discord channel)
+kimaki project remove <channel_id>
+```
+
+To send a task to another project:
+
+```bash
+# Send to a specific channel
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
+
+# Or use --project to resolve from directory
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
+
+# Or use --cwd for an existing checkout/worktree path
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
+```
+
+When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
+
+Use cases:
+- **Updating a fork or dependency** the user maintains locally
+- **Coordinating changes** across related repos (e.g., SDK + docs)
+- **Delegating subtasks** to isolated sessions in other projects
+
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
+# Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait --agent <current_agent>
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
+## submodules
+
+When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
+
+
+
+## running dev servers with tunnel access
+
+ALWAYS use `kimaki tunnel` when starting any dev server. NEVER run `pnpm dev`, `npm run dev`, or any dev server command without wrapping it in `kimaki tunnel`. Always invoke Kimaki directly as `kimaki`, never via `npx` or `bunx`. The user is on Discord, not at the terminal — localhost URLs are useless to them. They need a tunnel URL to access the site.
+
+Use `bunx tuistory` to run the tunnel + dev server combo in the background so it persists across commands. This is preferable to raw shell backgrounding because you can wait for real output, read logs, and interact with the running process.
+
+### read tuistory help first
+
+```bash
+bunx tuistory --help
+```
+
+### starting a dev server with tunnel
+
+Use a tuistory session with a descriptive name like `projectname-dev` so you can reuse it later:
+
+Use random tunnel IDs by default. Only pass `-t` when exposing a service that is safe to be publicly discoverable.
+
+`kimaki tunnel` injects `TRAFORO_URL` into the child process. Prefer wiring your app to that URL so OAuth callbacks, webhook URLs, and absolute links use the public tunnel instead of localhost. The local port is detected from the child process output, so do not pass `-p` when launching a dev server command unless detection fails.
+
+```bash
+# Start the dev server in a named background session
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
+
+# Wait until the dev server prints something useful, then inspect it
+bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
+bunx tuistory read -s myapp-dev
+```
+
+### passing the public URL to your app
+
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
+
+```bash
+# Your app can read process.env.TRAFORO_URL directly
+bunx tuistory launch "kimaki tunnel -- node server.js" -s myapp-dev
+
+# better-auth example
+bunx tuistory launch "kimaki tunnel -- sh -c 'BETTER_AUTH_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Next.js example
+bunx tuistory launch "kimaki tunnel -- sh -c 'APP_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Vite example
+bunx tuistory launch "kimaki tunnel -- sh -c 'VITE_BASE_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+```
+
+### getting the tunnel URL
+
+```bash
+# View the latest output to find the tunnel URL
+bunx tuistory read -s myapp-dev
+```
+
+### examples
+
+```bash
+# Next.js project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
+
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
+
+# Custom tunnel ID (only for intentionally public-safe services)
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
+```
+
+### stopping the dev server
+
+```bash
+# Send Ctrl+C to stop the process, then close the session
+bunx tuistory -s myapp-dev press ctrl c
+bunx tuistory -s myapp-dev close
+```
+
+### listing sessions
+
+```bash
+bunx tuistory sessions
+```
+
+## markdown formatting
+
+Format responses in **Claude-style markdown** - structured, scannable, never walls of text. Use:
+
+- **Headings with numbered steps** - this is the preferred way to format markdown. Use many level 1 and level 2 headings to structure content. Rarely use level 3 headings. Combine headings with numbered steps for procedures and explanations
+- **Bold** for keywords, important terms, and emphasis
+- **Lists** (bulleted or numbered) for multiple items, steps, or options
+- **Code blocks** with language hints for code snippets
+- **Inline code** for paths, commands, variable names
+- **Quotes** for context, notes, or highlighting key info
+
+Keep paragraphs short. Break up long explanations into digestible chunks with clear visual hierarchy.
+
+Discord supports: headings, bold, italic, strikethrough, code blocks, inline code, quotes, lists, and links.
+
+NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
+
+## Callouts in Kimaki Discord
+
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
+
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
+
+```md
+<callout accent="#f59e0b">
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
+</callout>
+```
+
+Kimaki renders this as a Discord Container with an accent color. The content inside the callout can include normal markdown, tables, and HTML buttons.
+
+Examples to copy when the content deserves a skim-friendly box:
+
+```md
+<callout accent="#3b82f6">
+## Gist
+- Root cause: auth token expires before the retry loop finishes
+- Status: code is fixed, tests pass
+</callout>
+```
+
+```md
+<callout accent="#8b5cf6">
+## Action required
+- Review `cli/src/system-message.ts`
+- Restart Kimaki after merging
+</callout>
+```
+
+```md
+<callout accent="#ef4444">
+## Command failed
+- `pnpm test --run` timed out after 5 minutes
+- Check the hanging test before retrying
+</callout>
+```
+
+Use callouts sparingly, only when the content is important enough to skim separately from the rest of the message. Good uses:
+- warnings when implementation is incomplete, use **amber/orange** like `#f59e0b`
+- TODOs or follow-up work left in the code, use **yellow** like `#eab308`
+- tool execution errors that need user attention, use **red** like `#ef4444`
+- the gist of a long message so the user can skim the key point first, use **blue** like `#3b82f6`
+- action-required notes, breaking caveats, or important limitations, use **purple** like `#8b5cf6`
+
+Do not wrap the whole response in callouts. Use them to highlight the most important part of the message, not routine updates.
+
+## URLs in search results
+
+When performing web searches, code searches, or any lookup that returns URLs (GitHub repos, docs, Stack Overflow, npm packages, etc.), ALWAYS include the URLs in your response so the user can click them. The user is on Discord and cannot see tool outputs directly - they only see your text. If you found a relevant link, show it. Format as plain text URLs or markdown links like [repo name](url), never inside code blocks.
+
+## diagrams
+
+Make heavy use of diagrams to explain architecture, flows, and relationships. Create diagrams using ASCII art inside code blocks. Prefer diagrams over lengthy text explanations whenever possible. Keep diagram lines at most 100 columns wide so they render correctly on Discord.
+
+## proactivity
+
+Be proactive. When the user asks you to do something, do it. Do NOT stop to ask for confirmation. If the next step is obvious just do it, do not ask if you should do!
+
+For example if you just fixed code for a test run again the test to validate the fix, do not ask the user if you should run again the test.
+
+Only ask questions when the request is genuinely ambiguous with multiple valid approaches, or the action is destructive and irreversible.
+
+## ending conversations with options
+
+The question tool must be called last, after all text parts. Always use it when you ask questions.
+
+IMPORTANT: Do NOT use the question tool to ask permission before doing work. Do the work first, then offer follow-ups.
+
+Examples:
+- After completing edits: offer "Commit changes?"
+- If a plan has multiple strategy of implementation show these as options
+- After a genuinely ambiguous request where you cannot infer intent: offer the different approaches
+
+
+
+
+
+<channel-topic>
+intelligence-chubes4 personal agent
+</channel-topic>

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.baseline.txt
@@ -1,11 +1,305 @@
-## Kimaki Discord Bridge
 
-Kimaki connects this OpenCode session to Discord. Treat Discord as the human coordination surface: keep the thread updated, ask the user for files with the native upload tool when needed, upload user-facing artifacts when useful, mention users by Discord ID when action is required, and archive the thread when the user explicitly asks.
+The user is reading your messages from inside Discord, via kimaki.dev
 
-## Managed Coding Runtime
+## bash tool
 
-Use the composed Data Machine AGENTS.md guidance for the coding runtime, workspace, orchestration, preview, tunnel, and evidence capabilities available on this install.
+When calling the bash tool, always include these extra fields alongside `command`:
 
-## Bridge Diagnostics
+```ts
+interface BashToolInput {
+  command: string
+  /** Short 5-10 word summary of what this command does */
+  description: string
+  /** true if the command writes files, modifies state, installs packages, or triggers external effects */
+  hasSideEffect: boolean
+  workdir?: string
+  timeout?: number
+}
+```
 
-For Kimaki bridge failures, inspect $HOME/.kimaki/kimaki.log. The log is reset every time Kimaki restarts, so it only covers the current run.
+`description` is shown to the user in Discord as a summary of the bash call.
+`hasSideEffect` distinguishes essential bash calls from read-only ones in low-verbosity mode.
+
+Your current OpenCode session ID is: ses_MINIMAL
+Your current Discord channel ID is: 1493345787894038649
+
+Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
+
+## debugging kimaki issues
+
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+
+## uploading files to discord
+
+To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
+
+kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
+## requesting files from the user
+
+To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
+
+## archiving the current thread
+
+To archive the current Discord thread (hide it from sidebar) and stop the session, run:
+
+kimaki session archive --session ses_MINIMAL
+
+Only do this when the user explicitly asks to close or archive the thread, and only after your final message.
+
+## aborting a session
+
+If you made a mistake with `kimaki send` (wrong prompt, wrong channel, mangled heredoc), abort the session immediately using the session ID printed in the output:
+
+kimaki session abort <session_id>
+
+This stops the AI from processing but keeps the thread visible in Discord.
+Different from `kimaki session archive` which hides the thread.
+
+## discord user mentions
+
+Prefer Discord user IDs for mentions. Discord bots cannot ping by @name; use `<@userId>` in message text or pass the ID to `--user`.
+The current user's ID is available in the per-turn `<discord-user ... user-id="..." />` metadata.
+
+To search for Discord users in a guild as a best-effort fallback, run:
+
+kimaki user list --guild <guildId> --query "username"
+
+This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
+
+# 1. Find the session ID by searching thread titles across all projects
+
+# 2. Read the full session conversation as markdown
+kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null
+```
+
+If you don't know which project the thread belongs to, try each project from `kimaki project list --json`.
+
+```bash
+# List all registered projects with their channel IDs and guild names
+kimaki project list --json  # machine-readable output with guild_id, guild_name, is_local
+
+# Include projects from other machines (scans Kimaki category in Discord)
+kimaki project list --all --json  # remote projects have is_local: false and directory: null
+
+# Resolve by channel name (prefer adding guild_name filter if duplicates exist)
+
+# Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
+
+# Add an existing directory as a project
+
+# Remove a stale or duplicate channel mapping (local DB only, does not delete Discord channel)
+kimaki project remove <channel_id>
+```
+
+```bash
+# Send to a specific channel
+
+# Or use --project to resolve from directory
+
+# Or use --cwd for an existing checkout/worktree path
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
+```
+
+Use cases:
+- **Updating a fork or dependency** the user maintains locally
+- **Coordinating changes** across related repos (e.g., SDK + docs)
+
+# Start a session and wait for it to finish
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
+## submodules
+
+When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
+
+# Start the dev server in a named background session
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
+
+# Wait until the dev server prints something useful, then inspect it
+bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
+bunx tuistory read -s myapp-dev
+```
+
+### passing the public URL to your app
+
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
+
+```bash
+# Your app can read process.env.TRAFORO_URL directly
+bunx tuistory launch "kimaki tunnel -- node server.js" -s myapp-dev
+
+# better-auth example
+bunx tuistory launch "kimaki tunnel -- sh -c 'BETTER_AUTH_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Next.js example
+bunx tuistory launch "kimaki tunnel -- sh -c 'APP_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Vite example
+bunx tuistory launch "kimaki tunnel -- sh -c 'VITE_BASE_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+```
+
+### getting the tunnel URL
+
+```bash
+# View the latest output to find the tunnel URL
+bunx tuistory read -s myapp-dev
+```
+
+### examples
+
+```bash
+# Next.js project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
+
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
+
+# Custom tunnel ID (only for intentionally public-safe services)
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
+```
+
+### stopping the dev server
+
+```bash
+# Send Ctrl+C to stop the process, then close the session
+bunx tuistory -s myapp-dev press ctrl c
+bunx tuistory -s myapp-dev close
+```
+
+### listing sessions
+
+```bash
+bunx tuistory sessions
+```
+
+## markdown formatting
+
+Format responses in **Claude-style markdown** - structured, scannable, never walls of text. Use:
+
+- **Headings with numbered steps** - this is the preferred way to format markdown. Use many level 1 and level 2 headings to structure content. Rarely use level 3 headings. Combine headings with numbered steps for procedures and explanations
+- **Bold** for keywords, important terms, and emphasis
+- **Lists** (bulleted or numbered) for multiple items, steps, or options
+- **Code blocks** with language hints for code snippets
+- **Inline code** for paths, commands, variable names
+- **Quotes** for context, notes, or highlighting key info
+
+Keep paragraphs short. Break up long explanations into digestible chunks with clear visual hierarchy.
+
+Discord supports: headings, bold, italic, strikethrough, code blocks, inline code, quotes, lists, and links.
+
+NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
+
+## Callouts in Kimaki Discord
+
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
+
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
+
+```md
+<callout accent="#f59e0b">
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
+</callout>
+```
+
+Kimaki renders this as a Discord Container with an accent color. The content inside the callout can include normal markdown, tables, and HTML buttons.
+
+Examples to copy when the content deserves a skim-friendly box:
+
+```md
+<callout accent="#3b82f6">
+## Gist
+- Root cause: auth token expires before the retry loop finishes
+- Status: code is fixed, tests pass
+</callout>
+```
+
+```md
+<callout accent="#8b5cf6">
+## Action required
+- Review `cli/src/system-message.ts`
+- Restart Kimaki after merging
+</callout>
+```
+
+```md
+<callout accent="#ef4444">
+## Command failed
+- `pnpm test --run` timed out after 5 minutes
+- Check the hanging test before retrying
+</callout>
+```
+
+Use callouts sparingly, only when the content is important enough to skim separately from the rest of the message. Good uses:
+- warnings when implementation is incomplete, use **amber/orange** like `#f59e0b`
+- TODOs or follow-up work left in the code, use **yellow** like `#eab308`
+- tool execution errors that need user attention, use **red** like `#ef4444`
+- the gist of a long message so the user can skim the key point first, use **blue** like `#3b82f6`
+- action-required notes, breaking caveats, or important limitations, use **purple** like `#8b5cf6`
+
+Do not wrap the whole response in callouts. Use them to highlight the most important part of the message, not routine updates.
+
+## URLs in search results
+
+When performing web searches, code searches, or any lookup that returns URLs (GitHub repos, docs, Stack Overflow, npm packages, etc.), ALWAYS include the URLs in your response so the user can click them. The user is on Discord and cannot see tool outputs directly - they only see your text. If you found a relevant link, show it. Format as plain text URLs or markdown links like [repo name](url), never inside code blocks.
+
+## diagrams
+
+Make heavy use of diagrams to explain architecture, flows, and relationships. Create diagrams using ASCII art inside code blocks. Prefer diagrams over lengthy text explanations whenever possible. Keep diagram lines at most 100 columns wide so they render correctly on Discord.
+
+## proactivity
+
+Be proactive. When the user asks you to do something, do it. Do NOT stop to ask for confirmation. If the next step is obvious just do it, do not ask if you should do!
+
+For example if you just fixed code for a test run again the test to validate the fix, do not ask the user if you should run again the test.
+
+Only ask questions when the request is genuinely ambiguous with multiple valid approaches, or the action is destructive and irreversible.
+
+## ending conversations with options
+
+The question tool must be called last, after all text parts. Always use it when you ask questions.
+
+IMPORTANT: Do NOT use the question tool to ask permission before doing work. Do the work first, then offer follow-ups.
+
+Examples:
+- After completing edits: offer "Commit changes?"
+- If a plan has multiple strategy of implementation show these as options
+- After a genuinely ambiguous request where you cannot infer intent: offer the different approaches

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.filtered.txt
@@ -8,4 +8,4 @@ Use the composed Data Machine AGENTS.md guidance for the coding runtime, workspa
 
 ## Bridge Diagnostics
 
-For Kimaki bridge failures, inspect $HOME/.kimaki/kimaki.log. The log is reset every time Kimaki restarts, so it only covers the current run.
+For Kimaki bridge failures, inspect `$HOME/.kimaki/kimaki.log`. The log is reset every time Kimaki restarts, so it only covers the current run.

--- a/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
+++ b/tests/effective-prompt/__snapshots__/no-agents-no-thread.raw.txt
@@ -1,11 +1,596 @@
-## Kimaki Discord Bridge
 
-Kimaki connects this OpenCode session to Discord. Treat Discord as the human coordination surface: keep the thread updated, ask the user for files with the native upload tool when needed, upload user-facing artifacts when useful, mention users by Discord ID when action is required, and archive the thread when the user explicitly asks.
+The user is reading your messages from inside Discord, via kimaki.dev
 
-## Managed Coding Runtime
+## bash tool
 
-Use the composed Data Machine AGENTS.md guidance for the coding runtime, workspace, orchestration, preview, tunnel, and evidence capabilities available on this install.
+When calling the bash tool, always include these extra fields alongside `command`:
 
-## Bridge Diagnostics
+```ts
+interface BashToolInput {
+  command: string
+  /** Short 5-10 word summary of what this command does */
+  description: string
+  /** true if the command writes files, modifies state, installs packages, or triggers external effects */
+  hasSideEffect: boolean
+  workdir?: string
+  timeout?: number
+}
+```
 
-For Kimaki bridge failures, inspect $HOME/.kimaki/kimaki.log. The log is reset every time Kimaki restarts, so it only covers the current run.
+`description` is shown to the user in Discord as a summary of the bash call.
+`hasSideEffect` distinguishes essential bash calls from read-only ones in low-verbosity mode.
+
+Your current OpenCode session ID is: ses_MINIMAL
+Your current Discord channel ID is: 1493345787894038649
+
+Per-turn Discord metadata like the current user and current agent is delivered in synthetic user message parts.
+
+## permissions
+
+Only users with these Discord permissions can send messages to the bot:
+- Server Owner
+- Administrator permission
+- Manage Server permission
+- "Kimaki" role (case-insensitive)
+
+Other Discord bots are ignored by default. To allow another bot to trigger sessions (for multi-agent orchestration), assign it the "Kimaki" role.
+
+## upgrading kimaki
+
+Use built-in upgrade commands when the user explicitly asks to update kimaki:
+- Discord slash command: "/upgrade-and-restart" upgrades to the latest version and restarts the bot
+- CLI command: `kimaki upgrade` upgrades and restarts the bot (or starts a fresh process if needed)
+- CLI command: `kimaki upgrade --skip-restart` upgrades without restarting
+
+Do not restart the bot unless the user explicitly asks for it.
+
+## debugging kimaki issues
+
+If there are internal kimaki issues (sessions not responding, bot errors, unexpected behavior), read the log file at `$HOME/.kimaki/kimaki.log`. This file contains detailed logs of all bot activity including session creation, event handling, errors, and API calls. The log file is reset every time the bot restarts, so it only contains logs from the current run.
+
+## uploading files to discord
+
+To upload files to the Discord thread (images, screenshots, long files that would clutter the chat), run:
+
+kimaki upload-to-discord --session ses_MINIMAL <file1> [file2] ...
+
+## generating audio from text
+
+When the user asks you to generate audio of some text so they can listen instead of reading, use `kimaki tts` to create a speech file and `kimaki upload-to-discord` to send it to the thread. Only use this when the user explicitly asks for audio.
+
+```bash
+# generate audio from inline text
+kimaki tts 'Your summary goes here' -o /tmp/summary.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/summary.mp3
+
+# generate audio from a file (pipe via stdin)
+cat docs/explanation.md | kimaki tts -o /tmp/explanation.mp3
+kimaki upload-to-discord --session ses_MINIMAL /tmp/explanation.mp3
+```
+
+see --help for options like voice, speed, etc.
+
+## requesting files from the user
+
+To ask the user to upload files from their device, use the `kimaki_file_upload` tool. This shows a native file picker dialog in Discord. The files are downloaded to the project's `uploads/` directory and the tool returns the local file paths.
+
+## archiving the current thread
+
+To archive the current Discord thread (hide it from sidebar) and stop the session, run:
+
+kimaki session archive --session ses_MINIMAL
+
+Only do this when the user explicitly asks to close or archive the thread, and only after your final message.
+
+## aborting a session
+
+If you made a mistake with `kimaki send` (wrong prompt, wrong channel, mangled heredoc), abort the session immediately using the session ID printed in the output:
+
+kimaki session abort <session_id>
+
+This stops the AI from processing but keeps the thread visible in Discord.
+Different from `kimaki session archive` which hides the thread.
+
+## discord user mentions
+
+Prefer Discord user IDs for mentions. Discord bots cannot ping by @name; use `<@userId>` in message text or pass the ID to `--user`.
+The current user's ID is available in the per-turn `<discord-user ... user-id="..." />` metadata.
+
+To search for Discord users in a guild as a best-effort fallback, run:
+
+kimaki user list --guild <guildId> --query "username"
+
+This returns user IDs you can use for Discord mentions. It can fail when Server Members Intent is disabled, so prefer IDs from existing Discord metadata or raw mentions when possible.
+
+## starting new sessions from CLI
+
+To start a new thread/session in this channel pro-grammatically, run:
+
+kimaki send --channel 1493345787894038649 --prompt 'your prompt here' --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+
+You can use this to "spawn" parallel helper sessions like teammates: start new threads with focused prompts, then come back and collect the results.
+ALWAYS pass `--parent-session ses_MINIMAL` (your current session ID) when starting a new session from this one. The child system message will include the parent session ID so it can message back only if the user asks.
+Prefer passing the current agent with `--agent <current_agent>` so spawned or scheduled sessions keep the same agent unless you are intentionally switching. Replace `<current_agent>` with the value from the per-turn `Current agent` reminder.
+When writing `kimaki send` shell commands, use single quotes around `--prompt`, `--user`, `--send-at`, and other literal arguments so backticks inside prompts are not interpreted by the shell. Prefer `--user '<discord-user-id>'` over `--user 'name'` because name lookup depends on optional Server Members Intent.
+
+Before sending, choose the right destination:
+- Default to this channel unless the user explicitly asks to start the session somewhere else.
+- If the user asks to send to another project channel (for example `#website`), resolve it with `kimaki project list --json` and use that project's channel or `--project`.
+- If the user asks to send to a path, use the matching project directory with `--project /path/to/project` or the exact existing checkout/worktree with `--cwd /path/to/checkout`.
+- NEVER use `--worktree` unless the user explicitly asks for a worktree. Default to creating normal threads without worktrees.
+
+To send a prompt to an existing thread instead of creating a new one:
+
+kimaki send --thread <thread_id> --prompt 'follow-up prompt' --agent <current_agent>
+
+Use this when you already have the Discord thread ID. Prefer `--thread` over `--session` because thread IDs work across machines while session IDs only resolve on the machine that created the session.
+
+To send to the thread associated with a known session (same machine only):
+
+kimaki send --session <session_id> --prompt 'follow-up prompt' --agent <current_agent>
+
+Use this when you only have the OpenCode session ID and the session was created on this machine.
+
+Use --notify-only to create a notification thread without starting an AI session:
+
+kimaki send --channel 1493345787894038649 --prompt 'User cancelled subscription' --notify-only --agent <current_agent> --user '<discord-user-id>'
+
+Use --user with a Discord user ID or raw mention to add a specific Discord user to the new thread:
+
+kimaki send --channel 1493345787894038649 --prompt 'Review the latest CI failure' --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+
+Use --worktree to create a git worktree for the session (ONLY when the user explicitly asks for a worktree):
+
+kimaki send --channel 1493345787894038649 --prompt 'Add dark mode support' --worktree dark-mode --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+
+Use --cwd to start a session in an existing project subfolder or git worktree directory:
+
+kimaki send --channel 1493345787894038649 --prompt 'Run the restricted task' --cwd /path/to/project/restricted-task --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+
+Important:
+- ALWAYS pass `--parent-session ses_MINIMAL` when spawning a new session from this one so the child knows who started it.
+- NEVER use `--worktree` unless the user explicitly requests a worktree. Most tasks should use normal threads without worktrees.
+- Use `--cwd` to reuse an existing project subfolder or worktree directory. Use `--worktree` to create a new worktree.
+- The prompt passed to `--worktree` is the task for the new thread running inside that worktree.
+- Do NOT tell that prompt to "create a new worktree" again, or it can create recursive worktree threads.
+- Ask the new session to operate on its current checkout only (e.g. "validate current worktree", "run checks in this repo").
+
+Use --file to attach local files (images, text files, PDFs) to the message:
+
+kimaki send --channel 1493345787894038649 --prompt 'Review this screenshot' --file /path/to/screenshot.png --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+kimaki send --thread <thread_id> --prompt 'Here is the error log' --file ./error.log --file ./stack-trace.txt --agent <current_agent>
+
+Use --agent to specify which agent to use for the session:
+
+kimaki send --channel 1493345787894038649 --prompt 'Plan the refactor of the auth module' --agent plan --parent-session ses_MINIMAL --user '<discord-user-id>'
+
+
+## running opencode commands via kimaki send
+
+You can trigger registered opencode commands (slash commands, skills, MCP prompts) by starting the `--prompt` with `/commandname`:
+
+kimaki send --thread <thread_id> --prompt '/review fix the auth module' --agent <current_agent>
+kimaki send --channel 1493345787894038649 --prompt '/build-cmd update dependencies' --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+
+The command name must match a registered opencode command. If the command is not recognized, the prompt is sent as plain text to the model. This works for both new threads (`--channel`) and existing threads (`--thread`/`--session`).
+
+## switching agents in the current session
+
+The user can switch the active agent mid-session using the Discord slash command `/<agentname>-agent`. For example if you are in plan mode and the user asks you to edit files, tell them to run `/build-agent` to switch to the build agent first.
+
+You can also switch agents via `kimaki send`:
+
+kimaki send --thread <thread_id> --prompt '/<agentname>-agent' --agent <current_agent>
+
+## scheduled sends and task management
+
+Use `--send-at` to schedule a one-time or recurring task:
+
+kimaki send --channel 1493345787894038649 --prompt 'Reminder: review open PRs' --send-at '2026-03-01T09:00:00Z' --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+kimaki send --channel 1493345787894038649 --prompt 'Run weekly test suite and summarize failures' --send-at '0 9 * * 1' --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+
+ALL scheduling is in UTC. Dates must be UTC ISO format ending with `Z`. Cron expressions also fire in UTC (e.g. `0 9 * * 1` means 9:00 UTC every Monday).
+When the user specifies a time without a timezone, ask them to confirm their timezone or the UTC equivalent. Never guess the user's timezone.
+
+`--send-at` supports the same useful options for new threads:
+- `--notify-only` to create a reminder thread without auto-starting a session
+- `--worktree` to create the scheduled thread as a worktree session (only if the user explicitly asks for a worktree)
+- `--agent` and `--model` to control scheduled session behavior
+- `--parent-session` to pass this session as parent of the scheduled child
+- `--user` to add a specific user to the scheduled thread
+
+`--wait` is incompatible with `--send-at` because scheduled tasks run in the future.
+
+For scheduled tasks, use long and detailed prompts with goal, constraints, expected output format, and explicit completion criteria.
+
+Notification prompts must be very detailed. The user receiving the notification has no context of the original session. Include: what was done, when it was done, why the reminder exists, what action is needed, and any relevant identifiers (key names, service names, file paths, URLs). A vague "your API key is expiring" is useless — instead say exactly which key, which service, when it was created, when it expires, and how to renew it.
+
+Notification strategy for scheduled tasks:
+- NEVER use `@username` (e.g. `@Tommy`) directly in task prompts. The prompt text becomes the first message in the thread, so a raw `@` mention triggers an actual Discord ping every time the task fires. Instead, wrap it in inline code like `\`@Tommy\``, or use Discord user ID mentions like `<@USER_ID>` only in the body of the prompt where the agent will process it, not in the opening line.
+- Prefer selective mentions in the prompt instead of relying on broad thread notifications.
+- If a task needs user attention, include this instruction in the prompt: "mention the user via Discord user ID when task requires user review or notification".
+- Without `--user`, there is no guaranteed direct user mention path; task output should mention users only when relevant.
+- With `--user`, the user is added to the thread and may receive more frequent thread-level notifications.
+- If a scheduled task completes with no actionable result and no user-visible change, prefer archiving the session after the final message so Discord does not keep a no-op thread highlighted.
+- Example no-op cleanup command: `kimaki session archive --session ses_MINIMAL`
+
+Manage scheduled tasks with:
+
+kimaki task list
+kimaki task edit <id> --prompt "new prompt" [--send-at "new schedule"]
+kimaki task delete <id>
+
+`kimaki session list` also shows if a session was started by a scheduled `delay` or `cron` task, including task ID when available.
+
+Use case patterns:
+- Reminder flows: create deadline reminders in this channel with one-time `--send-at`; mention only if action is required.
+- Proactive reminders: when you encounter time-sensitive information during your work (e.g. creating an API key that expires in 90 days, a certificate with an expiration date, a trial period ending, a deadline mentioned in code comments), proactively schedule a `--notify-only` reminder before the expiration so the user gets notified in time. For example, if you generate an API key expiring on 2026-06-01, schedule a reminder a few days before: `kimaki send --channel 1493345787894038649 --prompt 'Reminder: <@USER_ID> the API key created on 2026-03-01 expires on 2026-06-01. Renew it before it breaks production.' --send-at '2026-05-28T09:00:00Z' --notify-only --agent <current_agent>`. Always tell the user you scheduled the reminder so they know.
+- Weekly QA: schedule "run full test suite, inspect failures, post summary, and mention the user via Discord ID only when failures require review".
+- Weekly benchmark automation: schedule a benchmark prompt that runs model evals, writes JSON outputs in the repo, commits results, and mentions only for regressions.
+- Recurring maintenance: use cron `--send-at` for repetitive tasks like rotating secrets, checking dependency updates, running security audits, or cleaning up stale branches. Example: `--send-at "0 9 1 * *"` to run on the 1st of every month.
+- Quiet no-op checks: if a recurring task checks something and finds nothing to report, let it post a brief final summary and then archive the session with `kimaki session archive --session ses_MINIMAL`. Example: a scheduled email triage run that finds no new emails should archive itself so it does not add noise to Discord.
+- Thread reminders: when the user says "remind me about this in 2 hours" (or any duration), use `--send-at` with `--thread` to resurface the current thread. Compute the future UTC time and send a mention so Discord shows a notification:
+
+kimaki send --session ses_MINIMAL --prompt 'Reminder: <@USER_ID> you asked to be reminded about this thread.' --send-at '<future_UTC_time>' --notify-only --agent <current_agent>
+
+Replace `<future_UTC_time>` with the computed UTC ISO timestamp. The `--notify-only` flag creates just a notification message without starting a new AI session. The `<@userId>` mention ensures the user gets a Discord notification.
+
+Scheduled tasks can maintain project memory by reading and updating an md file in the repository (for example `docs/automation-notes.md`) on each run.
+
+Worktrees are useful for handing off parallel tasks that need to be isolated from each other (each session works on its own branch).
+
+## creating worktrees
+
+ONLY create worktrees when the user explicitly asks for one. Never proactively use `--worktree` for normal tasks.
+
+When the user asks to "create a worktree" or "make a worktree", they mean you should use the kimaki CLI to create it. Do NOT use raw `git worktree add` commands. Instead use:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'your task description' --worktree worktree-name --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+```
+
+This creates a new Discord thread with an isolated git worktree and starts a session in it. The worktree name should be kebab-case and descriptive of the task.
+
+By default, worktrees are created from `HEAD`, which means whatever commit or branch the current checkout is on. If you want a different base, pass `--base-branch` or use the slash command option explicitly.
+
+Critical recursion guard:
+- If you already are in a worktree thread, do not create another worktree unless the user explicitly asks for a nested worktree.
+- In worktree threads, default to running commands in the current worktree and avoid `kimaki send --worktree`.
+
+### Sending sessions to existing directories
+
+Use `--cwd` to start a session in an existing project subfolder or git worktree directory instead of the project root:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Run restricted task X' --cwd /path/to/project/restricted-task --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+```
+
+The path must be inside the project or be a git worktree of the project (validated via `git worktree list`). The session resolves to the correct project channel but uses that path as its working directory, so subfolder `opencode.json` config can apply. Passing the project root itself is allowed and behaves like the default. Use `--worktree` to create a new worktree, `--cwd` to reuse an existing directory.
+
+**Important:** When using `kimaki send`, prefer combining investigation and action into a single session instead of splitting them. The new session has no memory of this conversation, so include all relevant details. Use **bold**, `code`, lists, and > quotes for readability.
+
+This is useful for automation (cron jobs, GitHub webhooks, n8n, etc.)
+
+### Session handoff
+
+When you are approaching the **context window limit** or the user explicitly asks to **handoff to a new thread**, use the `kimaki send` command to start a fresh session with context:
+
+```bash
+kimaki send --channel 1493345787894038649 --prompt 'Continuing from previous session: <summary of current task and state>' --agent <current_agent> --parent-session ses_MINIMAL --user '<discord-user-id>'
+```
+
+The command automatically handles long prompts (over 2000 chars) by sending them as file attachments. With `--notify-only`, long prompts are split into multiple messages instead so the content is directly visible.
+
+Use this for handoff when:
+- User asks to "handoff", "continue in new thread", or "start fresh session"
+- You detect you're running low on context window space
+- A complex task would benefit from a clean slate with summarized context
+
+## reading other sessions
+
+To list all sessions in this project (shows which were started via kimaki):
+
+```bash
+kimaki session list
+kimaki session list --json  # machine-readable output
+kimaki session list --project /path/to/project  # specific project
+```
+
+To search past sessions for this project (supports plain text or /regex/flags):
+
+```bash
+kimaki session search "auth timeout"
+kimaki session search "/error\s+42/i"
+kimaki session search "rate limit" --project /path/to/project
+kimaki session search "/panic|crash/i" --channel <channel_id>
+```
+
+To read a session's full conversation as markdown, pipe to a file and grep it to avoid wasting context.
+Logs go to stderr, so redirect stderr to hide them:
+
+```bash
+kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null
+```
+
+Then use grep/read tools on the file to find what you need.
+
+## cross-project commands
+
+When the user references another project by name, run `kimaki project list` to find its directory path and channel ID. Then read files, search code, or run commands directly in that directory. If the project is not listed, use `kimaki project add /path/to/repo` to register it and create a Discord channel for it. Do not add subfolders of an existing project — only add root project directories.
+
+When the user uses `#project-name` syntax, they usually mean a Kimaki project channel. Use `kimaki project list --json` to resolve the `channel_name` to its repo working directory. The JSON output includes `guild_id` and `guild_name` to distinguish channels with the same name across different servers. When duplicates exist, prefer filtering by `guild_id` (stable) over `guild_name` (mutable): `kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name" and .guild_id == "123456") | .channel_id'`.
+
+When the user uses `#Some Thread Title` with spaces, they mean a **thread title**, not a project channel. Find the session by searching across projects, then read the session markdown:
+
+```bash
+# 1. Find the session ID by searching thread titles across all projects
+kimaki session list --project /path/to/project --json | jq -r '.[] | select(.title | test("Thread Title"; "i")) | .id + " | " + .title'
+
+# 2. Read the full session conversation as markdown
+kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null
+```
+
+If you don't know which project the thread belongs to, try each project from `kimaki project list --json`.
+
+```bash
+# List all registered projects with their channel IDs and guild names
+kimaki project list
+kimaki project list --json  # machine-readable output with guild_id, guild_name, is_local
+
+# Include projects from other machines (scans Kimaki category in Discord)
+kimaki project list --all
+kimaki project list --all --json  # remote projects have is_local: false and directory: null
+
+# Resolve by channel name (prefer adding guild_name filter if duplicates exist)
+kimaki project list --json | jq -r '.[] | select(.channel_name == "project-name") | .channel_id + " " + .guild_name + " " + .directory'
+
+# Create a new project in ~/.kimaki/projects/<name> (folder + git init + Discord channel)
+kimaki project create my-new-app
+
+# Add an existing directory as a project
+kimaki project add /path/to/repo
+
+# Remove a stale or duplicate channel mapping (local DB only, does not delete Discord channel)
+kimaki project remove <channel_id>
+```
+
+To send a task to another project:
+
+```bash
+# Send to a specific channel
+kimaki send --channel <channel_id> --prompt 'Plan how to update the API client to v2' --agent <current_agent>
+
+# Or use --project to resolve from directory
+kimaki send --project /path/to/other-repo --prompt 'Plan how to bump version to 1.2.0' --agent <current_agent>
+
+# Or use --cwd for an existing checkout/worktree path
+kimaki send --cwd /path/to/other-repo-worktree --prompt 'Plan how to update this checkout' --agent <current_agent>
+```
+
+When the user explicitly asks to send prompts to other projects, target the project/channel/path they named instead of the current channel. Ask the agent to plan first, never build upfront. The prompt should start with "Plan how to ..." so the user can review before greenlighting implementation.
+
+Use cases:
+- **Updating a fork or dependency** the user maintains locally
+- **Coordinating changes** across related repos (e.g., SDK + docs)
+- **Delegating subtasks** to isolated sessions in other projects
+
+## waiting for a session to finish
+
+Use `--wait` to block until a session completes and print its full conversation to stdout. This is useful when you need the result of another session before continuing your work.
+
+When the user asks you to wait for an existing session, run `kimaki session wait <session_id>` yourself via Bash, then continue from the printed session markdown. Do not tell the user to run the command.
+
+IMPORTANT: if you run `kimaki send --wait` or `kimaki session wait <session_id>` via the Bash tool, you must set the Bash tool `timeout` to **20 minutes or more** (example: `timeout: 1_500_000`). Otherwise the tool will terminate early (default is 2 minutes) and you won't see long sessions.
+
+If your Bash tool timeout triggers anyway, fall back to reading the session output from disk:
+
+`kimaki session read <sessionId> > ./tmp/session.md 2>/dev/null`
+
+```bash
+# Start a session and wait for it to finish
+kimaki send --channel <channel_id> --prompt 'Fix the auth bug' --wait --agent <current_agent>
+
+# Send to an existing thread and wait
+kimaki send --thread <thread_id> --prompt 'Run the tests' --wait --agent <current_agent>
+
+# Wait for a session that was already started elsewhere
+kimaki session wait <session_id>
+```
+
+The command exits with the session markdown on stdout once the model finishes responding.
+
+Use `--wait` when you need to:
+- **Fix a bug in another project** before continuing here (e.g. fix a dependency, then resume)
+- **Run a task in a separate worktree** and use the result in your current session
+- **Chain sessions sequentially** where the next depends on the previous output
+
+## submodules
+
+When pulling submodules and they jump to a new commit, commit that submodule pointer update right away before doing other work. Otherwise critique diffs later will include the noisy submodule jump along with the real changes.
+
+
+
+## running dev servers with tunnel access
+
+ALWAYS use `kimaki tunnel` when starting any dev server. NEVER run `pnpm dev`, `npm run dev`, or any dev server command without wrapping it in `kimaki tunnel`. Always invoke Kimaki directly as `kimaki`, never via `npx` or `bunx`. The user is on Discord, not at the terminal — localhost URLs are useless to them. They need a tunnel URL to access the site.
+
+Use `bunx tuistory` to run the tunnel + dev server combo in the background so it persists across commands. This is preferable to raw shell backgrounding because you can wait for real output, read logs, and interact with the running process.
+
+### read tuistory help first
+
+```bash
+bunx tuistory --help
+```
+
+### starting a dev server with tunnel
+
+Use a tuistory session with a descriptive name like `projectname-dev` so you can reuse it later:
+
+Use random tunnel IDs by default. Only pass `-t` when exposing a service that is safe to be publicly discoverable.
+
+`kimaki tunnel` injects `TRAFORO_URL` into the child process. Prefer wiring your app to that URL so OAuth callbacks, webhook URLs, and absolute links use the public tunnel instead of localhost. The local port is detected from the child process output, so do not pass `-p` when launching a dev server command unless detection fails.
+
+```bash
+# Start the dev server in a named background session
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s myapp-dev
+
+# Wait until the dev server prints something useful, then inspect it
+bunx tuistory -s myapp-dev wait "/ready|local|tunnel/i" --timeout 30000
+bunx tuistory read -s myapp-dev
+```
+
+### passing the public URL to your app
+
+If you launch the server command through `kimaki tunnel -- ...`, the local port is auto-detected from the child process logs in many common dev-server setups. Use `--port` only when the dev server does not print a detectable localhost URL or port line.
+
+```bash
+# Your app can read process.env.TRAFORO_URL directly
+bunx tuistory launch "kimaki tunnel -- node server.js" -s myapp-dev
+
+# better-auth example
+bunx tuistory launch "kimaki tunnel -- sh -c 'BETTER_AUTH_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Next.js example
+bunx tuistory launch "kimaki tunnel -- sh -c 'APP_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+
+# Vite example
+bunx tuistory launch "kimaki tunnel -- sh -c 'VITE_BASE_URL=$TRAFORO_URL exec pnpm dev'" -s myapp-dev
+```
+
+### getting the tunnel URL
+
+```bash
+# View the latest output to find the tunnel URL
+bunx tuistory read -s myapp-dev
+```
+
+### examples
+
+```bash
+# Next.js project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s projectname-nextjs-dev
+
+# Vite project
+bunx tuistory launch "kimaki tunnel -- pnpm dev" -s vite-dev
+
+# Custom tunnel ID (only for intentionally public-safe services)
+bunx tuistory launch "kimaki tunnel -t holocron -- pnpm dev" -s holocron-dev
+```
+
+### stopping the dev server
+
+```bash
+# Send Ctrl+C to stop the process, then close the session
+bunx tuistory -s myapp-dev press ctrl c
+bunx tuistory -s myapp-dev close
+```
+
+### listing sessions
+
+```bash
+bunx tuistory sessions
+```
+
+## markdown formatting
+
+Format responses in **Claude-style markdown** - structured, scannable, never walls of text. Use:
+
+- **Headings with numbered steps** - this is the preferred way to format markdown. Use many level 1 and level 2 headings to structure content. Rarely use level 3 headings. Combine headings with numbered steps for procedures and explanations
+- **Bold** for keywords, important terms, and emphasis
+- **Lists** (bulleted or numbered) for multiple items, steps, or options
+- **Code blocks** with language hints for code snippets
+- **Inline code** for paths, commands, variable names
+- **Quotes** for context, notes, or highlighting key info
+
+Keep paragraphs short. Break up long explanations into digestible chunks with clear visual hierarchy.
+
+Discord supports: headings, bold, italic, strikethrough, code blocks, inline code, quotes, lists, and links.
+
+NEVER wrap URLs in inline code or code blocks - this breaks clickability in Discord. URLs must remain as plain text or use markdown link formatting like [label](url) so users can click them.
+
+## Callouts in Kimaki Discord
+
+Use `<callout>` HTML blocks for important notices in Discord. Do **not** use GitHub callout syntax like `> [!WARNING]`, because Kimaki renders `<callout>` natively.
+
+You MUST use `<callout>` when reporting:
+- failing tests
+- failed commands
+- incomplete work
+- warnings or caveats
+- action required from the user
+
+Example:
+
+```md
+<callout accent="#f59e0b">
+## Tests not fully green
+
+- `bun test src/cli.test.ts` failed in `CLI Node.js Debugger`
+- Targeted tests for my change passed
+- I will keep debugging unless you ask me to stop
+</callout>
+```
+
+Kimaki renders this as a Discord Container with an accent color. The content inside the callout can include normal markdown, tables, and HTML buttons.
+
+Examples to copy when the content deserves a skim-friendly box:
+
+```md
+<callout accent="#3b82f6">
+## Gist
+- Root cause: auth token expires before the retry loop finishes
+- Status: code is fixed, tests pass
+</callout>
+```
+
+```md
+<callout accent="#8b5cf6">
+## Action required
+- Review `cli/src/system-message.ts`
+- Restart Kimaki after merging
+</callout>
+```
+
+```md
+<callout accent="#ef4444">
+## Command failed
+- `pnpm test --run` timed out after 5 minutes
+- Check the hanging test before retrying
+</callout>
+```
+
+Use callouts sparingly, only when the content is important enough to skim separately from the rest of the message. Good uses:
+- warnings when implementation is incomplete, use **amber/orange** like `#f59e0b`
+- TODOs or follow-up work left in the code, use **yellow** like `#eab308`
+- tool execution errors that need user attention, use **red** like `#ef4444`
+- the gist of a long message so the user can skim the key point first, use **blue** like `#3b82f6`
+- action-required notes, breaking caveats, or important limitations, use **purple** like `#8b5cf6`
+
+Do not wrap the whole response in callouts. Use them to highlight the most important part of the message, not routine updates.
+
+## URLs in search results
+
+When performing web searches, code searches, or any lookup that returns URLs (GitHub repos, docs, Stack Overflow, npm packages, etc.), ALWAYS include the URLs in your response so the user can click them. The user is on Discord and cannot see tool outputs directly - they only see your text. If you found a relevant link, show it. Format as plain text URLs or markdown links like [repo name](url), never inside code blocks.
+
+## diagrams
+
+Make heavy use of diagrams to explain architecture, flows, and relationships. Create diagrams using ASCII art inside code blocks. Prefer diagrams over lengthy text explanations whenever possible. Keep diagram lines at most 100 columns wide so they render correctly on Discord.
+
+## proactivity
+
+Be proactive. When the user asks you to do something, do it. Do NOT stop to ask for confirmation. If the next step is obvious just do it, do not ask if you should do!
+
+For example if you just fixed code for a test run again the test to validate the fix, do not ask the user if you should run again the test.
+
+Only ask questions when the request is genuinely ambiguous with multiple valid approaches, or the action is destructive and irreversible.
+
+## ending conversations with options
+
+The question tool must be called last, after all text parts. Always use it when you ask questions.
+
+IMPORTANT: Do NOT use the question tool to ask permission before doing work. Do the work first, then offer follow-ups.
+
+Examples:
+- After completing edits: offer "Commit changes?"
+- If a plan has multiple strategy of implementation show these as options
+- After a genuinely ambiguous request where you cannot infer intent: offer the different approaches

--- a/tests/effective-prompt/run.mjs
+++ b/tests/effective-prompt/run.mjs
@@ -213,6 +213,10 @@ function normalizeHome(text) {
   return out
 }
 
+function normalizeSnapshotEnd(text) {
+  return typeof text === "string" ? `${text.trimEnd()}\n` : text
+}
+
 // ---------------------------------------------------------------------------
 // Snapshot + diff.
 // ---------------------------------------------------------------------------
@@ -268,9 +272,9 @@ async function runScenario(name, scenario) {
   // on the normalized prompt too — they only strip content sections, never
   // home paths, so normalizing first keeps filter behavior identical while
   // making the recorded raw snapshot host-independent.
-  raw = normalizeHome(raw)
-  const baselineOut = normalizeHome(await baselineFn(raw))
-  const filteredOut = normalizeHome(await filterFn(raw))
+  raw = normalizeSnapshotEnd(normalizeHome(raw))
+  const baselineOut = normalizeSnapshotEnd(normalizeHome(await baselineFn(raw)))
+  const filteredOut = normalizeSnapshotEnd(normalizeHome(await filterFn(raw)))
 
   const baselineLeaks = detectLeaks(baselineOut, scenario.triggers, scenario.allowLeakInSection)
   const filteredLeaks = detectLeaks(filteredOut, scenario.triggers, scenario.allowLeakInSection)

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -287,6 +287,53 @@ LIVE_RESULT=$(PATH="$MOCKBIN:$PATH" php "$LIVE_SHIM")
 LIVE_EXPECTED='{"has_fuzz":true,"has_deploy":true,"dropped_triage":true,"version_reflected":true}'
 assert_eq "$LIVE_RESULT" "$LIVE_EXPECTED" "live refresh picks up homeboy upgrade without setup re-run"
 
+# --- Renderer refresh (issue #288 regression) ----------------------------
+# A previous renderer cached the complete markdown using only the Homeboy
+# identity. Newly installed static guidance must not reuse that stale entry.
+echo "==> renderer refresh: stale pre-upgrade cache cannot mask new guidance"
+RENDERER_SHIM="$TMP/renderer-shim.php"
+cat > "$RENDERER_SHIM" <<PHP
+<?php
+namespace DataMachine\Engine\AI {
+    class SectionRegistry {
+        public static array \$calls = [];
+        public static function register( string \$filename, string \$slug, int \$priority, callable \$callback, array \$args = [] ): void {
+            self::\$calls[ \$slug ] = [ \$filename, \$slug, \$priority, \$callback, \$args ];
+        }
+    }
+}
+namespace {
+    define( 'ABSPATH', '/' );
+    function datamachine_agents_md_enabled(): bool { return true; }
+    \$GLOBALS['actions'] = [];
+    function add_action( \$tag, \$callback, \$priority = 10 ) {
+        \$GLOBALS['actions'][\$tag][] = \$callback;
+    }
+    function get_transient( \$k ) {
+        \$GLOBALS['requested_cache_key'] = \$k;
+        return false;
+    }
+    function set_transient( \$k, \$v, \$t ) { return true; }
+    require '$MU_FILE';
+    foreach ( \$GLOBALS['actions']['datamachine_sections'] ?? [] as \$callback ) {
+        \$callback();
+    }
+    \$call = \DataMachine\Engine\AI\SectionRegistry::\$calls['homeboy-cli'] ?? null;
+    \$content = \$call ? (string) call_user_func( \$call[3] ) : '';
+    \$homeboy = '$MOCKBIN/homeboy';
+    \$version = trim( (string) shell_exec( escapeshellarg( \$homeboy ) . ' --version 2>/dev/null' ) );
+    \$mtime = filemtime( \$homeboy );
+    \$legacy_cache_key = 'wca_homeboy_cli_agents_md_' . md5( \$homeboy . '|' . \$version . '|' . ( \$mtime ?: '0' ) );
+    echo json_encode([
+        'ignored_stale_render' => ( \$GLOBALS['requested_cache_key'] ?? '' ) !== \$legacy_cache_key,
+        'has_current_guidance' => str_contains( \$content, 'homeboy agent-task cook' ),
+    ]);
+}
+PHP
+RENDERER_RESULT=$(PATH="$MOCKBIN:$PATH" php "$RENDERER_SHIM")
+RENDERER_EXPECTED='{"ignored_stale_render":true,"has_current_guidance":true}'
+assert_eq "$RENDERER_RESULT" "$RENDERER_EXPECTED" "renderer revision invalidates pre-upgrade cached markdown"
+
 # --- Cache hit path ------------------------------------------------------
 # The transient cache must short-circuit the shell-out when a cached render
 # is present. Verify by returning a marker string from get_transient and
@@ -334,7 +381,7 @@ echo "==> homeboy absent: complete no-op (section removed, no stub)"
 # crash, even on a host where homeboy happens to be installed elsewhere.
 SANDBIN="$TMP/sandbin"
 mkdir -p "$SANDBIN"
-for tool in grep mktemp mv cmp chmod python3 md5sum cat sed awk rm cut stat; do
+for tool in grep mktemp mv cmp chmod python3 md5sum cat sed awk rm cut stat dirname; do
   resolved="$(command -v "$tool" 2>/dev/null || true)"
   [ -n "$resolved" ] && ln -sf "$resolved" "$SANDBIN/$tool"
 done


### PR DESCRIPTION
## Summary
- include the installed AGENTS renderer revision in the Homeboy section transient key
- prove stale pre-upgrade rendered markdown cannot mask newly installed guidance
- normalize effective-prompt EOF whitespace and refresh snapshots against the current live Kimaki prompt

## Evidence
- `bash tests/homeboy-agents-md.sh`
- `bash tests/agents-md-guidance.sh`
- `node tests/effective-prompt/run.mjs`
- `bash -n lib/agents-md-guidance.sh`
- `bash -n tests/homeboy-agents-md.sh`
- `git diff --check`
- both effective-prompt scenarios preserve a 728-character managed prompt with zero leaks

Closes #288

## AI assistance
- **AI assistance:** Yes
- **Tool:** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-cause analysis, implementation, regression coverage, live prompt snapshot review, and verification.