### PR TITLE
Configure DMC promotion apply for Homeboy

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -76,7 +76,9 @@ homeboy_dmc_wp_argv() {
     argv=(${WP_CMD:-wp})
   fi
 
-  printf '%s\n' "${argv[@]}"
+  if [ "${#argv[@]}" -gt 0 ]; then
+    printf '%s\n' "${argv[@]}"
+  fi
 }
 
 homeboy_dmc_wp_flags() {
@@ -86,17 +88,22 @@ homeboy_dmc_wp_flags() {
     argv+=(--path="$SITE_PATH")
   fi
 
-  # shellcheck disable=SC2206
-  local root_flags=(${WP_ROOT_FLAG:-})
-  argv+=("${root_flags[@]}")
+  if [ -n "${WP_ROOT_FLAG:-}" ]; then
+    # shellcheck disable=SC2206
+    local root_flags=(${WP_ROOT_FLAG})
+    argv+=("${root_flags[@]}")
+  fi
 
-  printf '%s\n' "${argv[@]}"
+  if [ "${#argv[@]}" -gt 0 ]; then
+    printf '%s\n' "${argv[@]}"
+  fi
 }
 
 homeboy_dmc_command_json() {
   local action="$1"
   local wp_argv=()
   local wp_flags=()
+  local command=()
   local value
 
   while IFS= read -r value; do
@@ -109,23 +116,32 @@ homeboy_dmc_command_json() {
 
   case "$action" in
     resolve)
-      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree get '{handle}' --format=json "${wp_flags[@]}"
+      command=("${wp_argv[@]}" datamachine-code workspace worktree get '{handle}' --format=json)
+      ;;
+    apply)
+      command=("${wp_argv[@]}" datamachine-code workspace promotion-apply '{handle}')
       ;;
     list)
-      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree list --with-status --format=json "${wp_flags[@]}"
+      command=("${wp_argv[@]}" datamachine-code workspace worktree list --with-status --format=json)
       ;;
     cleanup_preview)
-      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --dry-run --format=json "${wp_flags[@]}"
+      command=("${wp_argv[@]}" datamachine-code workspace cleanup safe --dry-run --format=json)
       ;;
     cleanup_apply)
-      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --format=json "${wp_flags[@]}"
+      command=("${wp_argv[@]}" datamachine-code workspace cleanup safe --format=json)
       ;;
   esac
+
+  if [ "${#wp_flags[@]}" -gt 0 ]; then
+    command+=("${wp_flags[@]}")
+  fi
+  homeboy_json_array "${command[@]}"
 }
 
 homeboy_dmc_worktree_provider_json() {
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"resolve":%s,"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"resolve":%s,"apply":%s,"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
     "$(homeboy_dmc_command_json resolve)" \
+    "$(homeboy_dmc_command_json apply)" \
     "$(homeboy_dmc_command_json list)" \
     "$(homeboy_dmc_command_json cleanup_preview)" \
     "$(homeboy_dmc_command_json cleanup_apply)"

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -43,8 +43,8 @@ assert_not_contains() {
   fi
 }
 
-assert_provider_mapping() {
-  python3 - "$1" <<'PY'
+assert_provider_contract() {
+  python3 - "$1" "$SITE_PATH" <<'PY'
 import json
 import sys
 
@@ -54,6 +54,19 @@ try:
     provider = json.loads(payload)
 except json.JSONDecodeError as error:
     raise SystemExit(f"FAIL: provider config is not valid JSON: {error}: {payload!r}")
+site_path = sys.argv[2]
+prefix = ["studio", "wp", "datamachine-code", "workspace"]
+expected_commands = {
+    "resolve": prefix + ["worktree", "get", "{handle}", "--format=json", f"--path={site_path}"],
+    "apply": prefix + ["promotion-apply", "{handle}", f"--path={site_path}"],
+    "list": prefix + ["worktree", "list", "--with-status", "--format=json", f"--path={site_path}"],
+    "cleanup_preview": prefix + ["cleanup", "safe", "--dry-run", "--format=json", f"--path={site_path}"],
+    "cleanup_apply": prefix + ["cleanup", "safe", "--format=json", f"--path={site_path}"],
+}
+if provider.get("enabled") is not True or provider.get("kind") != "command" or provider.get("apply_enabled") is not True:
+    raise SystemExit("FAIL: provider enablement fields changed")
+if provider.get("commands") != expected_commands:
+    raise SystemExit(f"FAIL: provider commands changed: {provider.get('commands')!r}")
 expected = {
     "items": "$",
     "handle": "$.handle",
@@ -101,11 +114,18 @@ export HOMEBOY_CONFIG_LOG STUDIO_LOG
 # when the test runs under newer Bash so this path stays portable.
 enable -n mapfile 2>/dev/null || true
 
+NO_FLAG_COMMAND="$(SITE_PATH= WP_ROOT_FLAG= homeboy_dmc_command_json apply)"
+if [ "$NO_FLAG_COMMAND" != '["studio","wp","datamachine-code","workspace","promotion-apply","{handle}"]' ]; then
+  echo "FAIL: empty optional WP flags changed the apply argv: $NO_FLAG_COMMAND"
+  exit 1
+fi
+
 DRY_RUN=true
 configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 
 assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
 assert_contains "\"resolve\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{handle}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"promotion-apply\",\"{handle}\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"list\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--with-status\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
@@ -120,8 +140,7 @@ configure_homeboy_dmc_worktree_provider > "$TMP/apply.log"
 
 assert_contains "wp datamachine-code workspace worktree list --format=json --path=$SITE_PATH" "$STUDIO_LOG"
 assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
-assert_provider_mapping "$HOMEBOY_CONFIG_LOG"
-assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
+assert_provider_contract "$HOMEBOY_CONFIG_LOG"
 
 HOMEBOY_MODE="disabled"
 HOMEBOY_CONFIG_LOG="$TMP/disabled-homeboy-config.log"


### PR DESCRIPTION
## Summary
Configure Homeboy's DMC provider to discover the typed promotion apply adapter.

## What changed
- Added exact promotion-apply argv generation with explicit {handle} substitution.
- Included commands.apply in setup/upgrade provider JSON.
- Hardened optional WP flag arrays and asserted the full provider contract.

## How to test
1. Run `bash tests/homeboy-dmc-provider.sh`; expect exact provider contract and optional-skip paths pass.
2. Run `bash -n lib/homeboy.sh tests/homeboy-dmc-provider.sh`; expect shell syntax passes.

## Compatibility
Additive provider field with preserved existing argv and safety mappings.

## Evidence
**Declared public contracts**
- `homeboy-dmc-provider-config`: Generated DMC provider configuration now includes the typed promotion apply argv.

**Compatibility impact:** The apply command is additive; existing provider commands and mappings are unchanged. Empty optional WP flags no longer create empty argv values or set -u failures.

**External-consumer impact:** wp-coding-agents setup/upgrade will configure Homeboy to invoke the DMC adapter; users without the paired DMC/Homeboy versions retain existing commands but must not use apply until dependencies are present.

**External usage:** completed; source: Live Homeboy config output and wp-coding-agents provider generator tests; limitations: Full no-override Cook proof requires the paired Homeboy and DMC PRs to be built/installed together.; evidence: https://github.com/Extra-Chill/homeboy/issues/7898

- Base unchanged since verification: main remains at d4b30d16e7a24985e51ecf3d0892eddac4477900.
- CI expected: GitHub Actions repository checks
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/wp-coding-agents/issues/291
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/homeboy/issues/7898
- Verified finalization base: main at d4b30d16e7a24985e51ecf3d0892eddac4477900
- empty-flags-portability: passed (no empty argv or set -u failure) (Passed)
- provider-contract: passed (exact apply, resolve, list, cleanup, enablement, and mapping JSON) (Passed)
- shell-syntax: passed (library and test scripts) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented the provider apply wiring and exact JSON assertions; GPT-5.6 Sol diagnosed the gate failure, hardened optional argv handling, added the regression assertion, and finalized the candidate.

## Source relationships
- Closes #291
- Relates to Extra-Chill/homeboy#7898
