### PR TITLE
Anchor Claude WordPress edit denies to the project

### DIFF
--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -208,11 +208,13 @@ runtime_install_hooks() {
     ]')
 
   local wordpress_deny_rules
-  wordpress_deny_rules=$(jq -n '[
-    "Edit(/wp-content/plugins/**)",
-    "Edit(/wp-content/themes/**)",
-    "Edit(/wp-includes/**)"
-  ]')
+  wordpress_deny_rules=$(jq -n \
+    --arg site "$SITE_PATH" \
+    '[
+      "Edit(\($site)/wp-content/plugins/**)",
+      "Edit(\($site)/wp-content/themes/**)",
+      "Edit(\($site)/wp-includes/**)"
+    ]')
 
   local settings='{}'
   if [ -f "$settings_file" ]; then

--- a/tests/claude-code-permissions.sh
+++ b/tests/claude-code-permissions.sh
@@ -36,14 +36,17 @@ import sys
 with open(sys.argv[1], encoding="utf-8") as handle:
     data = json.load(handle)
 
+site_path = sys.argv[1].removesuffix("/.claude/settings.json")
 expected = {
-    "Edit(/wp-content/plugins/**)",
-    "Edit(/wp-content/themes/**)",
-    "Edit(/wp-includes/**)",
+    f"Edit({site_path}/wp-content/plugins/**)",
+    f"Edit({site_path}/wp-content/themes/**)",
+    f"Edit({site_path}/wp-includes/**)",
 }
 denies = set(data.get("permissions", {}).get("deny", []))
 if not expected <= denies:
     raise SystemExit(f"missing WordPress mutation denies: {sorted(expected - denies)}")
+if any(rule.startswith("Edit(/wp-content/") for rule in denies):
+    raise SystemExit(f"WordPress mutation denies must be project-anchored: {sorted(denies)}")
 if "Read(./private/**)" not in denies:
     raise SystemExit(f"existing deny was not preserved: {sorted(denies)}")
 PY


### PR DESCRIPTION
## Summary
- generate Claude Code WordPress edit denies from the absolute site path
- prevent ineffective root-level `/wp-content/...` deny rules
- strengthen the permission regression test to require project anchoring

## Verification
- `./tests/claude-code-permissions.sh`
- `bash -n runtimes/claude-code.sh tests/claude-code-permissions.sh`
- `./tests/agents-md-guidance.sh`
- reproduced the bad generated rules on the live Studio install before this fix

## AI assistance
OpenAI gpt-5.6-sol via OpenCode identified the live configuration mismatch and drafted the fix, tests, and PR description. Chris Huber reviewed the evidence and remains responsible for the changes.