### PR TITLE
Migrate legacy Claude WordPress deny rules

### DIFF
--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -216,6 +216,13 @@ runtime_install_hooks() {
       "Edit(\($site)/wp-includes/**)"
     ]')
 
+  local legacy_wordpress_deny_rules
+  legacy_wordpress_deny_rules=$(jq -n '[
+    "Edit(/wp-content/plugins/**)",
+    "Edit(/wp-content/themes/**)",
+    "Edit(/wp-includes/**)"
+  ]')
+
   local settings='{}'
   if [ -f "$settings_file" ]; then
     settings=$(cat "$settings_file")
@@ -227,6 +234,7 @@ runtime_install_hooks() {
     --arg cmd "$hook_cmd" \
     --argjson allow_rules "$workspace_allow_rules" \
     --argjson deny_rules "$wordpress_deny_rules" \
+    --argjson legacy_deny_rules "$legacy_wordpress_deny_rules" \
     '
     .autoMemoryEnabled = false
 
@@ -240,7 +248,7 @@ runtime_install_hooks() {
       )
 
     | .permissions.deny = (
-        ((.permissions.deny // []) + $deny_rules) | unique
+        (((.permissions.deny // []) - $legacy_deny_rules + $deny_rules) | unique)
       )
 
     | .hooks.SessionStart = (

--- a/tests/claude-code-permissions.sh
+++ b/tests/claude-code-permissions.sh
@@ -15,7 +15,12 @@ mkdir -p "$SITE_PATH/.claude" "$DM_WORKSPACE_DIR"
 cat > "$SITE_PATH/.claude/settings.json" <<'JSON'
 {
   "permissions": {
-    "deny": ["Read(./private/**)"]
+    "deny": [
+      "Read(./private/**)",
+      "Edit(/wp-content/plugins/**)",
+      "Edit(/wp-content/themes/**)",
+      "Edit(/wp-includes/**)"
+    ]
   }
 }
 JSON


### PR DESCRIPTION
## Summary
- remove the ineffective root-level Claude edit deny rules generated by v1.10.1
- preserve unrelated user deny rules
- retain the absolute project-anchored WordPress source denies
- cover an additive upgrade from the legacy persisted configuration

## Verification
- `./tests/claude-code-permissions.sh`
- `bash -n runtimes/claude-code.sh tests/claude-code-permissions.sh`
- `./tests/agents-md-guidance.sh`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode identified the persisted migration residue and drafted the fix, tests, and PR description. Chris Huber reviewed the evidence and remains responsible for the changes.