### PR TITLE
fix: stop provisioning exposing wp-config.php

### DIFF
--- a/lib/infrastructure.sh
+++ b/lib/infrastructure.sh
@@ -221,6 +221,31 @@ setup_ssl() {
   fi
 }
 
+# Restrict the credentials file after the site-wide grant (issue #302).
+#
+# The recursive `chmod -R g+w` above exists so the service user — a member of
+# www-data — can edit themes and plugins. Applied to the whole site path it
+# also sweeps in wp-config.php, which holds the database credentials, salts,
+# and auth keys. That leaves the file world-readable (any local account can
+# read the credentials) and agent-writable (the coding agent can rewrite the
+# site's database connection), neither of which the agent needs.
+#
+# 0640 owned by www-data keeps PHP-FPM and nginx working — both run as
+# www-data on a standard provision — while removing world read and group
+# write. Applied unconditionally so re-running provisioning corrects a mode
+# an earlier install left loosened, rather than only fixing fresh sites.
+harden_wp_config_permissions() {
+  local site_path="$1"
+  local config="$site_path/wp-config.php"
+
+  if [ "$DRY_RUN" != true ] && [ ! -f "$config" ]; then
+    return 0
+  fi
+
+  run_cmd chown www-data:www-data "$config"
+  run_cmd chmod 640 "$config"
+}
+
 setup_service_permissions() {
   if [ "$LOCAL_MODE" = true ]; then
     log "Phase 6: Local mode — skipping service user setup"
@@ -236,6 +261,7 @@ setup_service_permissions() {
 
     run_cmd chmod -R g+w "$SITE_PATH"
     run_cmd chown -R www-data:www-data "$SITE_PATH"
+    harden_wp_config_permissions "$SITE_PATH"
 
     run_cmd mkdir -p "$KIMAKI_DATA_DIR"
     run_cmd chown -R "$SERVICE_USER:$SERVICE_USER" "$KIMAKI_DATA_DIR"

--- a/tests/wp-config-permissions.sh
+++ b/tests/wp-config-permissions.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# tests/wp-config-permissions.sh — Regression coverage for issue #302 in
+# lib/infrastructure.sh.
+#
+# Phase 6 grants the service user write access to the site with a recursive
+# `chmod -R g+w "$SITE_PATH"`, so it can edit themes and plugins. That grant
+# also sweeps in wp-config.php, which holds the database credentials, salts,
+# and auth keys. The result observed on two provisioned hosts:
+#
+#   -rw-rw-r--  <service-user>:www-data  wp-config.php
+#
+# World-readable, so any local account can read the database credentials, and
+# group-writable by a service user that is a member of www-data, so the coding
+# agent can rewrite the site's database connection. The agent gains nothing
+# from either.
+#
+# harden_wp_config_permissions must restore 0640 owned by www-data after the
+# site-wide grant. Asserts:
+#   1. A world-readable, group-writable config is tightened to 0640
+#   2. It is applied unconditionally, so re-provisioning corrects a mode an
+#      earlier install left loosened (not only fresh sites)
+#   3. An already-correct config is left at 0640
+#   4. A missing config is not an error (site not yet installed)
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# Stub the provisioning surface harden_wp_config_permissions depends on, so
+# the function can be exercised without running a real install. chown is
+# recorded rather than performed: the test does not run as root and cannot
+# change file ownership.
+CHOWN_LOG="$TMP/chown.log"
+: > "$CHOWN_LOG"
+
+DRY_RUN=false
+run_cmd() {
+  if [ "${1:-}" = "chown" ]; then
+    printf '%s\n' "$*" >> "$CHOWN_LOG"
+    return 0
+  fi
+  "$@"
+}
+
+# shellcheck disable=SC1091
+eval "$(sed -n '/^harden_wp_config_permissions() {/,/^}/p' lib/infrastructure.sh)"
+
+mode_of() {
+  stat -c '%a' "$1"
+}
+
+# 1. The state provisioning actually leaves behind: world-readable and
+#    group-writable.
+site="$TMP/site"
+mkdir -p "$site"
+printf '<?php // credentials\n' > "$site/wp-config.php"
+chmod 664 "$site/wp-config.php"
+
+harden_wp_config_permissions "$site"
+
+got=$(mode_of "$site/wp-config.php")
+[ "$got" = "640" ] || fail "expected 0640 after hardening, got 0$got"
+grep -q 'chown www-data:www-data' "$CHOWN_LOG" \
+  || fail "expected ownership to be set to www-data"
+
+# 2. Re-running provisioning on a host an earlier install left loose must
+#    correct it. Without this, every already-provisioned host stays exposed.
+chmod 664 "$site/wp-config.php"
+harden_wp_config_permissions "$site"
+got=$(mode_of "$site/wp-config.php")
+[ "$got" = "640" ] || fail "re-provisioning must correct a loosened mode, got 0$got"
+
+# 3. An already-correct config stays correct.
+harden_wp_config_permissions "$site"
+got=$(mode_of "$site/wp-config.php")
+[ "$got" = "640" ] || fail "expected 0640 to be preserved, got 0$got"
+
+# 4. A site path with no wp-config.php yet must not fail the phase.
+empty="$TMP/empty"
+mkdir -p "$empty"
+harden_wp_config_permissions "$empty" \
+  || fail "a missing wp-config.php must not fail provisioning"
+
+# 5. World read is the specific bit that matters for a credentials file.
+chmod 644 "$site/wp-config.php"
+harden_wp_config_permissions "$site"
+if [ -r "$site/wp-config.php" ] && [ "$(stat -c '%A' "$site/wp-config.php" | cut -c8-10)" != "---" ]; then
+  fail "world permissions must be cleared on the credentials file"
+fi
+
+echo "wp-config permissions tests passed"


### PR DESCRIPTION
## Summary

Phase 6 of provisioning grants the service user write access to the site so it can edit themes and plugins:

```sh
usermod -a -G www-data "$SERVICE_USER"
chmod -R g+w "$SITE_PATH"
chown -R www-data:www-data "$SITE_PATH"
```

The recursive grant also sweeps in `wp-config.php`, which holds the database credentials, salts, and auth keys. Observed on two provisioned hosts:

```
-rw-rw-r--  <service-user>:www-data  wp-config.php
```

- **World-readable** — any local account can read the database credentials.
- **Group-writable** by a service user that is a member of `www-data` — the coding agent can rewrite the file defining the site's database connection and security keys.

The agent gains nothing from either. It needs to edit `wp-content`; `wp-config.php` is written once at install and read thereafter.

## Fix

`harden_wp_config_permissions` runs after the site-wide grant and sets the credentials file to `0640` owned by `www-data`. PHP-FPM and nginx both run as `www-data` on a standard provision, so they keep reading it; world read and group write are gone.

**Applied unconditionally, not only to fresh sites.** This is the part that matters most: without it every already-provisioned host stays exposed, since nobody re-installs from scratch. Re-running provisioning now corrects a mode an earlier install left loosened.

A missing `wp-config.php` is not an error — provisioning may run before WordPress is installed. `DRY_RUN` still routes through `run_cmd` so a dry run reports the calls it would make.

## Verified on two live sites

Applied `chmod 640` by hand to both affected hosts before writing this, to confirm the fix is safe rather than assuming it:

| Host | Before | After | Verified |
|---|---|---|---|
| a client WordPress site | `644 www-data:www-data` | `640` | front page, `/register/`, `/shop/` all 200; registration block still renders |
| the host running this agent | `664 <service-user>:www-data` | `640` | front page and `/wp-login.php` 200; WP-CLI reads options |

Nothing broke on either.

## Tests

`tests/wp-config-permissions.sh`, following the convention in `tests/cli-channel-perms.sh` — the function is extracted and exercised against a temp site with `chown` recorded rather than performed, since the suite does not run as root.

Covers:

1. the state provisioning actually leaves behind (`664`) is tightened to `640`
2. **re-provisioning corrects a previously loosened mode** — the regression that would otherwise leave existing hosts exposed
3. an already-correct config stays correct
4. a missing `wp-config.php` does not fail the phase
5. world permission bits are cleared, since that is the specific bit that matters for a credentials file

Verified load-bearing: reverting the mode to `664` fails the new test with `expected 0640 after hardening, got 0664`.

Full suite: **33 passed, 3 failed** — `cli-channel-binary-path`, `datamachine-worker`, and `kimaki-agent-fallback` all fail identically on pristine `main` with these changes stashed, so they are pre-existing and unrelated.

## Deliberately not included

Whether the grant should scope to `wp-content` rather than `$SITE_PATH` is a larger question. Core files are replaced wholesale by WordPress updates and are not something an agent should be editing in place, so a narrower grant would express the intended capability more precisely. That is a behavior change worth discussing separately rather than folding into a security fix.

Closes #302