### PR TITLE
fix: detect stale Kimaki dispatch helpers

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -98,6 +98,14 @@ jobs:
       - name: Run tests/service-identity-adoption.sh
         run: ./tests/service-identity-adoption.sh
 
+  kimaki-dispatch-helper-health:
+    name: Kimaki dispatch helper health (#304)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/kimaki-dispatch-helper-health.sh
+        run: ./tests/kimaki-dispatch-helper-health.sh
+
   agents-md-guidance:
     name: AGENTS.md guidance registry
     runs-on: ubuntu-latest

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -389,9 +389,9 @@ _kimaki_install_dispatch_helpers() {
 
   local suffix
   suffix=$(_kimaki_instance_suffix)
-  local dispatch_wrapper="/usr/local/bin/wp-coding-agents-kimaki${suffix}-dispatch"
-  local target_helper="/usr/local/lib/wp-coding-agents/kimaki${suffix}-dispatch-target"
-  local sudoers_file="/etc/sudoers.d/wp-coding-agents-kimaki${suffix}-dispatch"
+  local dispatch_wrapper="${KIMAKI_DISPATCH_WRAPPER_DIR:-/usr/local/bin}/wp-coding-agents-kimaki${suffix}-dispatch"
+  local target_helper="${KIMAKI_DISPATCH_TARGET_DIR:-/usr/local/lib/wp-coding-agents}/kimaki${suffix}-dispatch-target"
+  local sudoers_file="${KIMAKI_DISPATCH_SUDOERS_DIR:-/etc/sudoers.d}/wp-coding-agents-kimaki${suffix}-dispatch"
   local service_home="${SERVICE_HOME:-}"
   local data_dir="${KIMAKI_DATA_DIR:-}"
   local kimaki_bin="${KIMAKI_BIN:-}"
@@ -432,14 +432,18 @@ exec sudo -n -H -u $service_user_q $target_helper_q \"\$@\""
     return 0
   fi
 
-  if [ "$(id -u)" -ne 0 ]; then
-    if [ -x "$target_helper" ] \
-      && [ -x "$dispatch_wrapper" ] \
-      && sudo -n -H -u "$SERVICE_USER" "$target_helper" --version >/dev/null 2>&1; then
+  if [ "$(_kimaki_effective_uid)" -ne 0 ]; then
+    if _kimaki_dispatch_helpers_match \
+      "$target_helper" "$target_content" \
+      "$dispatch_wrapper" "$wrapper_content" \
+      "$sudoers_file" "$sudoers_content" \
+      && _kimaki_validate_dispatch_callers "$dispatch_wrapper" "$SERVICE_USER"; then
       log "  Keeping functional root-owned Kimaki dispatch wrapper for $SERVICE_USER"
       return 0
     fi
-    error "Kimaki dispatch wrapper requires root privileges to install or update"
+
+    _kimaki_report_dispatch_root_repair_required
+    return 0
   fi
 
   install -d -m 0755 "$(dirname "$target_helper")"
@@ -458,8 +462,86 @@ exec sudo -n -H -u $service_user_q $target_helper_q \"\$@\""
     visudo -cf "$sudoers_file" >/dev/null
   fi
 
+  if ! _kimaki_dispatch_helpers_match \
+    "$target_helper" "$target_content" \
+    "$dispatch_wrapper" "$wrapper_content" \
+    "$sudoers_file" "$sudoers_content"; then
+    error "Kimaki dispatch helper validation failed after root installation"
+  fi
+  if ! _kimaki_validate_dispatch_callers "$dispatch_wrapper" "$SERVICE_USER"; then
+    error "Kimaki dispatch wrapper validation failed for www-data or $SERVICE_USER"
+  fi
+
   log "  Installed Kimaki dispatch wrapper: $dispatch_wrapper → $SERVICE_USER"
   UPDATED_ITEMS+=("Kimaki dispatch wrapper")
+}
+
+_kimaki_effective_uid() {
+  printf '%s\n' "${WP_CODING_AGENTS_TEST_EUID:-$(id -u)}"
+}
+
+_kimaki_dispatch_helpers_match() {
+  local target_helper="$1" target_content="$2"
+  local dispatch_wrapper="$3" wrapper_content="$4"
+  local sudoers_file="$5" sudoers_content="$6"
+
+  [ -x "$target_helper" ] \
+    && [ -x "$dispatch_wrapper" ] \
+    && [ -r "$sudoers_file" ] \
+    && printf '%s\n' "$target_content" | cmp -s - "$target_helper" \
+    && printf '%s\n' "$wrapper_content" | cmp -s - "$dispatch_wrapper" \
+    && printf '%s\n' "$sudoers_content" | cmp -s - "$sudoers_file"
+}
+
+_kimaki_dispatch_caller_can_execute() {
+  local caller="$1" dispatch_wrapper="$2"
+  local invoking_user
+  invoking_user=$(id -un 2>/dev/null || true)
+
+  if [ "$invoking_user" = "$caller" ]; then
+    "$dispatch_wrapper" --version >/dev/null 2>&1
+    return $?
+  fi
+
+  command -v sudo >/dev/null 2>&1 || return 1
+  sudo -n -H -u "$caller" "$dispatch_wrapper" --version >/dev/null 2>&1
+}
+
+_kimaki_validate_dispatch_callers() {
+  local dispatch_wrapper="$1" service_user="$2"
+  local caller seen=""
+
+  for caller in www-data "$service_user"; do
+    [ -n "$caller" ] || continue
+    case " $seen " in *" $caller "*) continue ;; esac
+    seen="$seen $caller"
+    _kimaki_dispatch_caller_can_execute "$caller" "$dispatch_wrapper" || return 1
+  done
+}
+
+_kimaki_dispatch_repair_command() {
+  local command
+  printf -v command 'sudo -- %q --kimaki-only --wp-path %q --kimaki-unit %q' \
+    "$SCRIPT_DIR/upgrade.sh" "$SITE_PATH" "${KIMAKI_UNIT:-kimaki.service}"
+  printf '%s\n' "$command"
+}
+
+_kimaki_json_escape() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  printf '%s' "$value"
+}
+
+_kimaki_report_dispatch_root_repair_required() {
+  KIMAKI_DISPATCH_ROOT_REPAIR_REQUIRED=true
+  KIMAKI_DISPATCH_ROOT_REPAIR_COMMAND=$(_kimaki_dispatch_repair_command)
+
+  warn "  Kimaki dispatch helpers could not be certified for www-data and $SERVICE_USER."
+  warn "  Root repair required: $KIMAKI_DISPATCH_ROOT_REPAIR_COMMAND"
+  printf '{"status":"root_repair_required","component":"kimaki_dispatch_helpers","repair_command":"%s"}\n' \
+    "$(_kimaki_json_escape "$KIMAKI_DISPATCH_ROOT_REPAIR_COMMAND")"
 }
 
 _kimaki_dispatch_sudoers_content() {

--- a/tests/kimaki-dispatch-helper-health.sh
+++ b/tests/kimaki-dispatch-helper-health.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Regression coverage for stale pre-#243 root-owned Kimaki dispatch helpers.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/bridges/_dispatch.sh"
+source "$SCRIPT_DIR/bridges/kimaki.sh"
+
+KIMAKI_DISPATCH_WRAPPER_DIR="$TMP/bin"
+KIMAKI_DISPATCH_TARGET_DIR="$TMP/lib"
+KIMAKI_DISPATCH_SUDOERS_DIR="$TMP/sudoers"
+mkdir -p "$KIMAKI_DISPATCH_WRAPPER_DIR" "$KIMAKI_DISPATCH_TARGET_DIR" "$KIMAKI_DISPATCH_SUDOERS_DIR"
+
+LOCAL_MODE=false
+SERVICE_USER=opencode
+SERVICE_HOME="$TMP/home/opencode"
+KIMAKI_DATA_DIR="$SERVICE_HOME/.kimaki"
+KIMAKI_BIN="$TMP/kimaki"
+KIMAKI_UNIT=kimaki.service
+SITE_PATH="$TMP/site"
+PATH=/usr/local/bin:/usr/bin:/bin
+DRY_RUN=false
+UPDATED_ITEMS=()
+WP_CODING_AGENTS_TEST_EUID=1000
+
+printf '#!/bin/sh\nprintf "kimaki test\\n"\n' > "$KIMAKI_BIN"
+chmod 0755 "$KIMAKI_BIN"
+
+wrapper="$KIMAKI_DISPATCH_WRAPPER_DIR/wp-coding-agents-kimaki-dispatch"
+target="$KIMAKI_DISPATCH_TARGET_DIR/kimaki-dispatch-target"
+sudoers="$KIMAKI_DISPATCH_SUDOERS_DIR/wp-coding-agents-kimaki-dispatch"
+
+service_home_q=$(_kimaki_shell_quote "$SERVICE_HOME")
+data_dir_q=$(_kimaki_shell_quote "$KIMAKI_DATA_DIR")
+kimaki_bin_q=$(_kimaki_shell_quote "$KIMAKI_BIN")
+path_q=$(_kimaki_shell_quote "$PATH")
+target_q=$(_kimaki_shell_quote "$target")
+service_user_q=$(_kimaki_shell_quote "$SERVICE_USER")
+
+cat > "$target" <<EOF
+#!/bin/sh
+set -eu
+export HOME=$service_home_q
+export KIMAKI_DATA_DIR=$data_dir_q
+export PATH=$path_q
+exec $kimaki_bin_q "\$@"
+EOF
+cat > "$wrapper" <<EOF
+#!/bin/sh
+set -eu
+exec sudo -n -H -u $service_user_q $target_q "\$@"
+EOF
+chmod 0755 "$target" "$wrapper"
+
+# This is the exact pre-#243 stale shape: service-user grant only, no www-data.
+printf '%s\n' "opencode ALL=(opencode) NOPASSWD: $target *" > "$sudoers"
+
+_kimaki_install_dispatch_helpers > "$TMP/first.out" 2>&1
+first=$(< "$TMP/first.out")
+[ "${KIMAKI_DISPATCH_ROOT_REPAIR_REQUIRED:-false}" = true ]
+echo "$first" | grep -q '"status":"root_repair_required"'
+echo "$first" | grep -q 'sudo -- .*upgrade.sh --kimaki-only --wp-path .* --kimaki-unit kimaki.service'
+if echo "$first" | grep -q 'Keeping functional root-owned'; then
+  echo "FAIL: pre-#243 helper installation was blessed as healthy" >&2
+  exit 1
+fi
+
+# Repeated non-root upgrades must continue reporting the unresolved boundary.
+KIMAKI_DISPATCH_ROOT_REPAIR_REQUIRED=false
+_kimaki_install_dispatch_helpers > "$TMP/second.out" 2>&1
+second=$(< "$TMP/second.out")
+[ "${KIMAKI_DISPATCH_ROOT_REPAIR_REQUIRED:-false}" = true ]
+echo "$second" | grep -q '"status":"root_repair_required"'
+if echo "$second" | grep -q 'Keeping functional root-owned'; then
+  echo "FAIL: repeated non-root upgrade blessed stale helpers" >&2
+  exit 1
+fi
+
+generated=$(_kimaki_dispatch_sudoers_content "$SERVICE_USER" "$target")
+[ "$(echo "$generated" | grep -c '^www-data ALL=(opencode)')" -eq 1 ]
+[ "$(echo "$generated" | grep -c '^opencode ALL=(opencode)')" -eq 1 ]
+deduped=$(_kimaki_dispatch_sudoers_content www-data "$target")
+[ "$(echo "$deduped" | grep -c '^www-data ALL=(www-data)')" -eq 1 ]
+
+# Caller validation exercises the scheduled web user and service user once each,
+# while a www-data service identity remains deduplicated.
+callers_file="$TMP/callers"
+_kimaki_dispatch_caller_can_execute() {
+  printf '%s\n' "$1" >> "$callers_file"
+}
+_kimaki_validate_dispatch_callers "$wrapper" opencode
+[ "$(grep -c '^www-data$' "$callers_file")" -eq 1 ]
+[ "$(grep -c '^opencode$' "$callers_file")" -eq 1 ]
+: > "$callers_file"
+_kimaki_validate_dispatch_callers "$wrapper" www-data
+[ "$(grep -c '^www-data$' "$callers_file")" -eq 1 ]
+
+# Root rewrites all three artifacts from current generated content and validates
+# both caller paths. The caller probe remains stubbed; content checks stay real.
+chown() { return 0; }
+WP_CODING_AGENTS_TEST_EUID=0
+_kimaki_install_dispatch_helpers >/dev/null
+
+expected_sudoers=$(_kimaki_dispatch_sudoers_content "$SERVICE_USER" "$target")
+printf '%s\n' "$expected_sudoers" | cmp -s - "$sudoers"
+grep -q '^www-data ALL=(opencode)' "$sudoers"
+grep -q '^opencode ALL=(opencode)' "$sudoers"
+
+echo "PASS: tests/kimaki-dispatch-helper-health.sh"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -390,6 +390,11 @@ UPDATED_ITEMS=()
 # --repair-opencode-json flag was NOT passed. Shown loudly in print_summary.
 OPENCODE_JSON_DRIFT=false
 
+# Set by the Kimaki bridge when a non-root upgrade cannot prove or repair the
+# root-owned dispatch wrapper, target, and sudoers installation.
+KIMAKI_DISPATCH_ROOT_REPAIR_REQUIRED=false
+KIMAKI_DISPATCH_ROOT_REPAIR_COMMAND=""
+
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -1150,6 +1155,12 @@ print_summary() {
     warn "opencode.json: managed entries were added, but unexpected plugins remain."
     warn "  Re-run with: ./upgrade.sh --repair-opencode-json"
     warn "  to remove them (the backup from this run is preserved)."
+  fi
+
+  if [ "${KIMAKI_DISPATCH_ROOT_REPAIR_REQUIRED:-false}" = true ]; then
+    echo ""
+    warn "Kimaki dispatch helpers: root repair required."
+    warn "  $KIMAKI_DISPATCH_ROOT_REPAIR_COMMAND"
   fi
 
   if declare -F ai_gateway_enabled_for_opencode >/dev/null && ai_gateway_enabled_for_opencode; then


### PR DESCRIPTION
## Summary
- Require non-root Kimaki helper health checks to match the current wrapper, target, and sudoers templates and prove both `www-data` and the adopted service user can traverse the registered wrapper path.
- Emit a machine-readable `root_repair_required` result plus an exact shell-safe root repair command when non-root cannot inspect, validate, or repair root-owned artifacts.
- Rewrite and post-validate all helper artifacts during root upgrades, including current caller grants, and add a dedicated CI regression for repeated non-root upgrades over pre-#243 state.

## Root cause and production timeline
Production helper artifacts were installed as root at **2026-06-27 01:24 UTC**. PR #243, which added the required `www-data -> SERVICE_USER` sudoers grant, merged later at **2026-06-27 01:56 UTC**.

The non-root upgrade fast path checked only that the adopted service user could invoke the target directly. That path bypassed the registered wrapper and never inspected the root-owned sudoers file, so the pre-#243 service-user-only grant was repeatedly certified as healthy while scheduled WordPress dispatch from `www-data` continued failing.

## Why #240 and #243 did not stick
#240 established the wrapper-based dispatch path, and #243 corrected the generated sudoers template to include `www-data`. Neither changed the non-root upgrade health oracle: an already-installed target that worked for the service user still caused an early return before current wrapper, target, or sudoers content was compared. Because non-root upgrades could not rewrite the root-owned files, the corrected #243 template never reached this host.

## Ownership boundary
wp-coding-agents owns generation, installation, upgrade health, and repair instructions for the Kimaki wrapper, target, and sudoers artifacts. Homeboy may invoke an upgrade, coordinate a deployment, or consume its output, but it does not own or infer the health of these wp-coding-agents installation artifacts. This PR keeps the repair signal and validation in the owning bridge installer rather than adding Homeboy-specific behavior.

## Behavior
Before:
- `SERVICE_USER -> target --version` was treated as complete helper health.
- Stale root-owned sudoers content could survive every non-root upgrade.
- Scheduled `www-data -> wrapper -> SERVICE_USER` execution was not tested.

After:
- Non-root health requires exact generated-content matches for wrapper, target, and sudoers plus successful wrapper execution as both `www-data` and the adopted service user.
- If privilege prevents inspection or either caller proof, output includes `{"status":"root_repair_required",...}` and an exact `sudo -- .../upgrade.sh --kimaki-only --wp-path ... --kimaki-unit ...` repair command; the final summary repeats the required action.
- Root upgrades rewrite all three artifacts, validate sudoers syntax when `visudo` is available, compare installed bytes with generated content, and execute the wrapper through both caller identities.
- Local mode, root service identities, explicit identity flags, and per-instance helper suffixes retain their existing branches.

## Tests
- Added `tests/kimaki-dispatch-helper-health.sh` and a dedicated CI job.
- Covers pre-#243 service-user-only sudoers state across repeated non-root upgrades and proves it is never logged as healthy.
- Covers structured repair output and the exact repair command.
- Covers `www-data` and service-user grants, caller validation, and deduplication when the service user is `www-data`.
- Covers root rewrite against current generated content.
- Passed all bounded shell workflow tests, all tracked shell syntax checks, `git diff --check`, and focused `shellcheck` on modified scripts.

## Remaining privilege limitations
A normal service user commonly cannot read `/etc/sudoers.d` or impersonate `www-data`; that is now reported as root repair required rather than guessed healthy. The root repair remains an explicit operator action. This PR does not merge, release, deploy, restart Kimaki, or verify production cron dispatch; production verification follows the eventual authorized merge/release/deploy.

Closes #304