### PR TITLE
fix: isolate agent sync from login profiles

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -48,6 +48,15 @@ jobs:
       - name: Run tests/managed-skill-targets.sh
         run: ./tests/managed-skill-targets.sh
 
+  dm-agent-sync:
+    name: Data Machine agent sync plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Run tests/dm-agent-sync.mjs
+        run: bun tests/dm-agent-sync.mjs
+
   cli-transport:
     name: CLI dispatch transport runtime
     runs-on: ubuntu-latest

--- a/bridges/kimaki/plugins/dm-agent-sync.ts
+++ b/bridges/kimaki/plugins/dm-agent-sync.ts
@@ -97,7 +97,9 @@ async function runDatamachineCommand($: any, wpCli: WpCli, sitePath: string, age
   }
   args.push("--allow-root");
 
-  return $`sh -lc ${[wpCli, ...args.map(shellQuote)].join(" ")}`.quiet().nothrow();
+  // Do not start a login shell here. Service-user profiles are unrelated user
+  // state and may contain interactive, stale, or failing initialization.
+  return $`sh -c ${[wpCli, ...args.map(shellQuote)].join(" ")}`.quiet().nothrow();
 }
 
 /**

--- a/tests/dm-agent-sync.mjs
+++ b/tests/dm-agent-sync.mjs
@@ -78,7 +78,7 @@ async function withEnv(env, callback) {
 
 const commonResponses = [
   [/^command -v wp$/, output("/usr/local/bin/wp")],
-  [/^sh -lc wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
+  [/^sh -c wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
 ]
 
 {
@@ -126,7 +126,7 @@ const commonResponses = [
   const config = {}
   const warnings = await runConfig(config, [
     [/^command -v wp$/, output("/usr/local/bin/wp")],
-    [/^sh -lc wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("", 1, "db down")],
+    [/^sh -c wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("", 1, "db down")],
   ])
   assert.ok(warnings.some((line) => line.includes("memory compose failed")))
   assert.equal(config.agent, undefined)
@@ -135,8 +135,8 @@ const commonResponses = [
 await withEnv({ DATAMACHINE_WP_CMD: "custom-wp", DATAMACHINE_AGENT_SLUG: "intelligence-chubes4" }, async () => {
   const config = {}
   const warnings = await runConfig(config, [
-    [/^sh -lc custom-wp 'datamachine' 'memory' 'compose' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
-    [/^sh -lc custom-wp 'datamachine' 'memory' 'injectable-files' '--format=json' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output(JSON.stringify([
+    [/^sh -c custom-wp 'datamachine' 'memory' 'compose' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
+    [/^sh -c custom-wp 'datamachine' 'memory' 'injectable-files' '--format=json' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output(JSON.stringify([
       { path: "/tmp/datamachine-site/AGENTS.md" },
       { path: "/tmp/datamachine-site/MEMORY.md" },
     ]))],


### PR DESCRIPTION
## Summary
- invoke Data Machine WP-CLI commands through a non-login shell so service-user profile state cannot abort startup sync
- update compose and injectable-files command assertions for the non-login path
- run the existing dm-agent-sync Bun test in CI

Closes #308.

## Root cause
The login shell sourced a stale temporary Rust environment from the service user's `.profile` and exited `2` before WP-CLI ran. The same compose command succeeds through `sh -c`.

## Verification
- `bun tests/dm-agent-sync.mjs`
- `sh -c "wp datamachine memory compose --agent=extra-chill-bot --path=/var/www/extrachill.com --allow-root"`
- `git diff --check`