### PR TITLE
Configure targeted DMC path resolution

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -111,6 +111,9 @@ homeboy_dmc_command_json() {
     resolve)
       homeboy_json_array bash "$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh" "${wp_argv[@]}" datamachine-code workspace worktree get '{handle}' --format=json "${wp_flags[@]}"
       ;;
+    resolve_path)
+      homeboy_json_array bash "$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh" "${wp_argv[@]}" datamachine-code workspace worktree get '{path}' --format=json "${wp_flags[@]}"
+      ;;
     ensure)
       # DMC derives the canonical handle from repo + branch and validates the
       # task/base intent before returning the checkout to Homeboy.
@@ -129,8 +132,9 @@ homeboy_dmc_command_json() {
 }
 
 homeboy_dmc_worktree_provider_json() {
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"resolve":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
     "$(homeboy_dmc_command_json resolve)" \
+    "$(homeboy_dmc_command_json resolve_path)" \
     "$(homeboy_dmc_command_json ensure)" \
     "$(homeboy_dmc_command_json list)" \
     "$(homeboy_dmc_command_json cleanup_preview)" \

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -78,11 +78,14 @@ line = open(sys.argv[1], encoding="utf-8").read().strip()
 _, payload = line.split("|", 1)
 commands = json.loads(payload)["commands"]
 expected_resolve = ["bash", f"{sys.argv[2]}/scripts/homeboy-dmc-resolve.sh", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{handle}", "--format=json", f"--path={sys.argv[3]}"]
+expected_resolve_path = ["bash", f"{sys.argv[2]}/scripts/homeboy-dmc-resolve.sh", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{path}", "--format=json", f"--path={sys.argv[3]}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--base-branch={base}", "--task-url={task_url}", "--format=json", f"--path={sys.argv[3]}"]
 if commands.get("resolve_not_found_exit_codes") != [42]:
     raise SystemExit("FAIL: DMC typed-not-found classification must be exactly [42]")
 if commands.get("resolve") != expected_resolve:
     raise SystemExit(f"FAIL: DMC resolve adapter mapping mismatch: {commands.get('resolve')!r}")
+if commands.get("resolve_path") != expected_resolve_path:
+    raise SystemExit(f"FAIL: DMC path resolve adapter mapping mismatch: {commands.get('resolve_path')!r}")
 if commands.get("ensure") != expected_ensure:
     raise SystemExit(f"FAIL: DMC ensure mapping mismatch: {commands.get('ensure')!r}")
 PY
@@ -185,6 +188,7 @@ configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 
 assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
 assert_contains "\"resolve\":[\"bash\",\"$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{handle}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_path\":[\"bash\",\"$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{path}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--base-branch={base}\",\"--task-url={task_url}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"list\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--with-status\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"


### PR DESCRIPTION
## Summary
- generate Homeboy `commands.resolve_path` for the DMC worktree provider
- route exact canonical paths through the same supervised `workspace worktree get` adapter as handle resolution
- retain list discovery for compatibility with older Homeboy versions
- assert the exact generated and dry-run provider contracts

Depends on Extra-Chill/homeboy#10643 and Extra-Chill/data-machine-code#977.

Closes #312

## Verification
- `bash tests/homeboy-dmc-provider.sh`
- `bash -n lib/homeboy.sh tests/homeboy-dmc-provider.sh`
- `git diff --check`

## AI assistance
- Model: OpenAI `openai/gpt-5.6-sol`
- Tool: OpenCode
- Used for: integration diagnosis, implementation, and regression coverage. Chris Huber reviewed and remains responsible for every line.