### PR TITLE
Support a managed-hosting posture: agent edits live source, no DMC/git

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -123,6 +123,14 @@ jobs:
       - name: Run tests/kimaki-dispatch-helper-health.sh
         run: ./tests/kimaki-dispatch-helper-health.sh
 
+  posture:
+    name: installed-source posture (#314)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/posture.sh
+        run: ./tests/posture.sh
+
   agents-md-guidance:
     name: AGENTS.md guidance registry
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ node_modules/
 
 # Credentials
 # Credentials stored at ~/.wp-coding-agents-credentials on the VPS
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ operator-entrypoints/wp-coding-agents-setup/setup.md
 | Flag | Description |
 | --- | --- |
 | `--runtime <name>` | Coding runtime: `opencode`, `claude-code`, or `codex`. Auto-detected when omitted. |
+| `--posture <name>` | `engineering` (default) or `managed`. See [Install Posture](#install-posture). |
 | `--local` | Local machine mode. Skips server infrastructure. |
 | `--existing` | Add to an existing WordPress install. |
 | `--wp-path <path>` | WordPress root path. Implies `--existing`. |
@@ -180,6 +181,38 @@ operator-entrypoints/wp-coding-agents-setup/setup.md
 | `--dry-run` | Print planned actions without applying them. |
 
 Run `./setup.sh --help` for the complete setup surface.
+
+## Install Posture
+
+Posture is the agent's relationship to the installed WordPress source. It is a
+declared intent rather than a detected fact, and it is the single input that
+decides the plugin set, every runtime permission surface, and the AGENTS.md
+guidance the agent reads.
+
+| | `engineering` (default) | `managed` |
+| --- | --- | --- |
+| `wp-content/themes/`, `wp-content/plugins/` | read-only reference | **editable in place** |
+| `wp-includes/` | read-only | read-only |
+| Data Machine Code | installed | not installed |
+| Workspace, git, GitHub | the agent's workflow | not present |
+| How changes reach version control | the agent commits and opens pull requests | captured out-of-band by the operator |
+
+**Engineering** is the developer setup: the installed tree is reference
+material, and every code change happens in a Data Machine Code workspace so it
+is tracked in git and reviewed through GitHub.
+
+**Managed** is for managed agentic hosting, where a non-technical owner should
+never have to deal with pull requests. The agent edits the live theme and
+plugins directly and its changes are live on save; something outside the box —
+for example a scheduled `homeboy harvest` — captures them into git as restore
+points.
+
+A single source of truth (`lib/source-policy.sh`) derives the runtime
+permissions and the generated guidance from the chosen posture, so the prose
+cannot tell the agent to do something the permissions then block.
+
+The chosen posture is recorded on the install, so `./upgrade.sh` converges to it
+without repeating the flag. Pass `--posture` to either script to change it.
 
 On VPS hosts with multiple Kimaki services, setup and upgrade select the unit
 whose `WorkingDirectory=` exactly matches the WordPress site path. Ambiguous or

--- a/guidance/_dispatch.sh
+++ b/guidance/_dispatch.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# guidance/_dispatch.sh — auto-discovery + dispatch for guidance/*.sh.
+#
+# Mirrors bridges/_dispatch.sh and runtimes/*.sh: each guidance file is a
+# self-contained AGENTS.md section unit that owns its own id, priority, label,
+# applicability, and prose. Adding a section is "drop a file in guidance/" — no
+# edits to lib/, setup.sh, upgrade.sh, or this file.
+#
+# WHY THIS EXISTS
+#
+# lib/agents-md-guidance.sh is the MECHANISM: it scaffolds the mu-plugin,
+# renders marker-delimited PHP blocks, and rewrites them idempotently. It used
+# to also carry the CONTENT — the actual prose for every section — as heredocs
+# inside sync functions. That coupling meant every new section, and every
+# posture variant of an existing section, grew the same file. This directory is
+# the content half; lib/agents-md-guidance.sh no longer knows what WordPress or
+# Homeboy are.
+#
+# POSTURE VARIANTS
+#
+# A section whose prose depends on the install posture (see lib/source-policy.sh)
+# ships one file per posture:
+#
+#   guidance/wordpress-source.engineering.sh
+#   guidance/wordpress-source.managed.sh
+#
+# Resolution for section <id> is `<id>.<posture>.sh` when present, else
+# `<id>.sh`. Posture-neutral sections ship a single `<id>.sh` and are unaffected.
+# Two files that differ wholesale beat one file with a conditional wrapped
+# around a heredoc: the diff of a posture is the file, and neither variant can
+# quietly inherit a clause meant for the other.
+#
+# HOOK CONTRACT (functions namespaced guidance_* inside each unit file)
+#
+#   Mandatory:
+#     guidance_id            — SectionRegistry section id (stable across postures)
+#     guidance_priority      — integer sort key within AGENTS.md
+#     guidance_label         — human label recorded in section metadata
+#     guidance_render        — emit the section markdown on stdout
+#
+#   Optional:
+#     guidance_description   — metadata blurb (default: empty)
+#     guidance_freshness     — static | conditional | live (default: static)
+#     guidance_conditions    — metadata note on when the section applies
+#     guidance_applies       — return non-zero to UNREGISTER instead of register.
+#                              Use for presence-gated sections (e.g. homeboy).
+#     guidance_register      — take over registration entirely. Units that must
+#                              emit a hand-written PHP block (rather than static
+#                              markdown) implement this instead of guidance_render.
+#
+# Units are sourced in a SUBSHELL for every operation, so definitions never leak
+# between units and a unit is free to define `_helpers` without collisions.
+
+if [ -n "${SCRIPT_DIR:-}" ] && [ -d "$SCRIPT_DIR/guidance" ]; then
+  GUIDANCE_DIR="$SCRIPT_DIR/guidance"
+else
+  GUIDANCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# guidance_names — every discoverable section id, one per line, de-duplicated.
+#
+# Discovery: any guidance/*.sh whose basename does not start with `_`. A
+# `<id>.<posture>.sh` filename contributes the id once, no matter how many
+# posture variants exist.
+guidance_names() {
+  local f base id seen=""
+  for f in "$GUIDANCE_DIR"/*.sh; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f" .sh)"
+    case "$base" in
+      _*) continue ;;
+    esac
+    id="${base%%.*}"
+    case " $seen " in
+      *" $id "*) continue ;;
+    esac
+    seen="$seen $id"
+    echo "$id"
+  done
+}
+
+# guidance_file <id> — absolute path to the unit for the active posture.
+#
+# Prefers the posture-specific variant, falls back to the neutral file.
+guidance_file() {
+  local id="$1"
+  local posture="${POSTURE:-engineering}"
+
+  if [ -f "$GUIDANCE_DIR/${id}.${posture}.sh" ]; then
+    printf '%s' "$GUIDANCE_DIR/${id}.${posture}.sh"
+    return 0
+  fi
+
+  if [ -f "$GUIDANCE_DIR/${id}.sh" ]; then
+    printf '%s' "$GUIDANCE_DIR/${id}.sh"
+    return 0
+  fi
+
+  return 1
+}
+
+# guidance_sync_unit <id> — register or unregister one section.
+#
+# Registration goes through lib/agents-md-guidance.sh, which stays responsible
+# for idempotency: an unchanged block is not rewritten.
+guidance_sync_unit() {
+  local id="$1"
+  local f
+  f="$(guidance_file "$id")" || {
+    warn "  guidance_sync_unit: unknown section '$id'"
+    return 1
+  }
+
+  # The unit NAME (filename) and the SectionRegistry section id are distinct:
+  # guidance/homeboy.sh owns section 'homeboy-cli'. Always address the registry
+  # by guidance_id, or an unregister silently misses the block it meant to
+  # remove.
+  local section_id
+  section_id="$(guidance_call "$id" id)"
+
+  # Applicability and custom registration run in a subshell that has the unit
+  # sourced; everything they need from the parent is already exported.
+  if ! (
+    # shellcheck disable=SC1090
+    source "$f"
+    if declare -F guidance_applies >/dev/null 2>&1; then
+      guidance_applies
+    fi
+  ); then
+    agents_md_guidance_unregister "$section_id"
+    return 0
+  fi
+
+  if (
+    # shellcheck disable=SC1090
+    source "$f"
+    declare -F guidance_register >/dev/null 2>&1
+  ); then
+    (
+      # shellcheck disable=SC1090
+      source "$f"
+      guidance_register
+    )
+    return $?
+  fi
+
+  local priority label description freshness conditions content
+  priority="$(guidance_call "$id" priority)"
+  label="$(guidance_call "$id" label)"
+  description="$(guidance_call "$id" description 2>/dev/null || true)"
+  freshness="$(guidance_call "$id" freshness 2>/dev/null || true)"
+  conditions="$(guidance_call "$id" conditions 2>/dev/null || true)"
+  content="$(guidance_call "$id" render)"
+
+  AGENTS_MD_GUIDANCE_FRESHNESS="${freshness:-static}" \
+    AGENTS_MD_GUIDANCE_CONDITIONS="${conditions:-Registered by wp-coding-agents on managed WordPress coding-agent installations.}" \
+    agents_md_guidance_register \
+      "$section_id" \
+      "$priority" \
+      "$label" \
+      "$description" \
+      "$content"
+}
+
+# guidance_call <id> <hook> [args...] — invoke one hook in a subshell.
+guidance_call() {
+  local id="$1" hook="$2"
+  shift 2
+  local f
+  f="$(guidance_file "$id")" || return 1
+  (
+    # shellcheck disable=SC1090
+    source "$f"
+    if ! declare -F "guidance_${hook}" >/dev/null; then
+      exit 2
+    fi
+    "guidance_${hook}" "$@"
+  )
+}
+
+# guidance_sync_all — sync every discovered section for the active posture.
+#
+# Called once from setup.sh and once from upgrade.sh. Individual units may also
+# be synced on their own (lib/homeboy.sh re-syncs the homeboy section after the
+# binary's availability is settled); both paths are idempotent.
+guidance_sync_all() {
+  local id
+  for id in $(guidance_names); do
+    guidance_sync_unit "$id"
+  done
+}

--- a/guidance/abilities.sh
+++ b/guidance/abilities.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# guidance/abilities.sh — WordPress Abilities discovery guidance.
+#
+# Posture-neutral: abilities are the tool surface in both engineering and
+# managed installs, and the routing advice does not change with the agent's
+# relationship to installed source.
+
+guidance_id() { printf 'abilities'; }
+guidance_priority() { printf '2'; }
+guidance_label() { printf 'Abilities'; }
+guidance_description() { printf 'Generic WordPress Abilities discovery guidance.'; }
+guidance_freshness() { printf 'static'; }
+guidance_conditions() { printf 'Registered by wp-coding-agents on managed WordPress coding-agent installations.'; }
+
+guidance_render() {
+  cat <<'MD'
+## Abilities
+
+WordPress Abilities are the universal tool surface. Plugins expose abilities through the active runtime, REST API, MCP, and chat.
+
+**Default routing**
+- Use abilities exposed by the active runtime when they match the task.
+- Inspect the active runtime tool listings and plugin-specific `--help` before assuming a capability or argument is available.
+MD
+}

--- a/guidance/homeboy.sh
+++ b/guidance/homeboy.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# guidance/homeboy.sh — Homeboy orchestration routing guidance (issues #208, #254, #298).
+#
+# Strictly presence-gated on the optional homeboy binary, and additionally on
+# postures that actually have a workspace: the routing advice below is about
+# cooking tracked changes in managed worktrees, which is meaningless on a
+# managed-hosting install where the agent edits live source and never touches
+# git.
+#
+# The section is registered as a LIVE block: the PHP callback re-checks for the
+# binary at AGENTS.md compose time, so a host that loses homeboy stops emitting
+# the section without needing a wp-coding-agents sync (the #254 trigger gap).
+# Nothing about homeboy is baked at setup time.
+#
+# This unit implements guidance_register rather than guidance_render because its
+# payload is a hand-written PHP block, not static markdown.
+
+guidance_id() { printf 'homeboy-cli'; }
+guidance_priority() { printf '30'; }
+guidance_label() { printf 'Homeboy'; }
+guidance_description() { printf 'Host orchestration routing, safety, and discovery guidance.'; }
+guidance_freshness() { printf 'live'; }
+
+guidance_applies() {
+  if ! source_policy_workspace_enabled; then
+    return 1
+  fi
+
+  local homeboy_path
+  homeboy_path="$(type -P homeboy 2>/dev/null || true)"
+  [ -n "$homeboy_path" ] && [ -f "$homeboy_path" ] && [ -x "$homeboy_path" ]
+}
+
+guidance_register() {
+  local file
+  file="$(agents_md_guidance_mu_plugin_path)" || {
+    warn "  guidance/homeboy: SITE_PATH not set — skipping"
+    return 1
+  }
+
+  agents_md_guidance_ensure_mu_plugin_file || return 1
+
+  local new_block
+  new_block="$(_guidance_homeboy_live_block)" || {
+    warn "  guidance/homeboy: could not render live block — skipping"
+    return 1
+  }
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would register live AGENTS.md guidance section 'homeboy-cli' in $file"
+    echo -e "${BLUE}[dry-run]${NC} Block:"
+    echo "$new_block" | sed 's/^/    /'
+    return 0
+  fi
+
+  if _agents_md_guidance_block_matches "$file" "homeboy-cli" "$new_block"; then
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp "${file}.XXXXXX")
+  _agents_md_guidance_rewrite "$file" "homeboy-cli" "$new_block" > "$tmp"
+
+  if cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+    return 0
+  fi
+
+  mv "$tmp" "$file"
+  service_file_normalize_perms "$file"
+  log "  Registered live AGENTS.md guidance section 'homeboy-cli' in $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("AGENTS.md guidance: homeboy-cli (live)")
+  fi
+}
+
+# Quoted heredoc ('PHP_BLOCK') so PHP $variables, backticks, and ${...} are
+# emitted verbatim — bash never touches them.
+_guidance_homeboy_live_block() {
+  cat <<'PHP_BLOCK'
+    // BEGIN agents-md-guidance:homeboy-cli
+    if ( ! function_exists( 'wp_coding_agents_render_homeboy_cli_section' ) ) {
+        function wp_coding_agents_render_homeboy_cli_section() {
+            // Homeboy is optional. The section is a clean no-op when the
+            // binary is not on PATH, matching the presence-gating the bash
+            // setup path applies.
+            $homeboy = null;
+            $path_env = ( is_callable( 'getenv' ) ) ? getenv( 'PATH' ) : false;
+            if ( is_string( $path_env ) && $path_env !== '' ) {
+                foreach ( explode( PATH_SEPARATOR, $path_env ) as $dir ) {
+                    if ( $dir === '' ) {
+                        continue;
+                    }
+                    $candidate = rtrim( $dir, '/' ) . '/homeboy';
+                    if ( @is_executable( $candidate ) ) {
+                        $homeboy = $candidate;
+                        break;
+                    }
+                }
+            }
+            if ( $homeboy === null ) {
+                return '';
+            }
+
+            return <<<'MD'
+## Homeboy
+
+Homeboy orchestrates coding agents, deterministic gates, evidence, promotion, review, releases, and deployments. Data Machine Code owns authoritative repository and worktree state; Homeboy consumes managed worktrees to execute and finalize work.
+
+**Default routing**
+- One tracked change: `homeboy agent-task cook`
+- Multiple independent changes: `homeboy agent-task fanout cook-batch`
+- Review a candidate: `homeboy review`
+- Inspect runs and evidence: `homeboy runs`
+- Repeating workflows: `homeboy agent-task loop`; explicitly stateful workflows: `homeboy agent-task controller`
+- Component and runner health: `homeboy status` and `homeboy runner status`
+
+**Operator boundary**
+Run `homeboy release` or `homeboy deploy` only when the user explicitly asks.
+
+**Discovery**
+Use `homeboy --help` and `homeboy <command> --help` for the live command contract. Inspect active configuration with `homeboy config show` and provider readiness with `homeboy agent-task providers`.
+MD;
+        }
+    }
+
+    \DataMachine\Engine\AI\SectionRegistry::register(
+        'AGENTS.md',
+        'homeboy-cli',
+        30,
+        static function () {
+            return wp_coding_agents_render_homeboy_cli_section();
+        },
+        array(
+            'label'       => 'Homeboy',
+            'description' => 'Host orchestration routing, safety, and discovery guidance.',
+            'owner'       => 'wp-coding-agents',
+            'freshness'   => 'live',
+            'conditions'  => 'Registered on hosts where the homeboy binary is installed and omitted at compose time when the binary is unavailable.',
+        )
+    );
+    // END agents-md-guidance:homeboy-cli
+PHP_BLOCK
+}

--- a/guidance/wordpress-source.engineering.sh
+++ b/guidance/wordpress-source.engineering.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# guidance/wordpress-source.engineering.sh — installed WordPress source, engineering posture.
+#
+# The agent treats the installed tree as reference material and makes every code
+# change in a Data Machine Code workspace, tracked in git and reviewed through
+# GitHub. Matches the deny rules lib/source-policy.sh hands the runtimes for this
+# posture: all three roots read-only, workspace granted.
+
+guidance_id() { printf 'wordpress-source'; }
+guidance_priority() { printf '1'; }
+guidance_label() { printf 'WordPress Source'; }
+guidance_description() { printf 'Direct-reference and read-only boundaries for installed WordPress source.'; }
+guidance_freshness() { printf 'static'; }
+guidance_conditions() { printf 'Registered by wp-coding-agents on engineering-posture installations.'; }
+
+guidance_render() {
+  cat <<'MD'
+## WordPress Source (Direct Reference, Read-Only)
+
+Use the installed WordPress source to verify core APIs, hooks, conventions, and runtime behavior instead of relying on assumptions. Search and read these directories directly when working on WordPress:
+
+- `wp-content/plugins/` — plugin source (read-only)
+- `wp-content/themes/` — theme source (read-only)
+- `wp-includes/` — WordPress core (read-only)
+
+These paths are **read-only references**. Make code changes in the configured managed workspace, not in the installed source tree.
+MD
+}

--- a/guidance/wordpress-source.managed.sh
+++ b/guidance/wordpress-source.managed.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# guidance/wordpress-source.managed.sh — installed WordPress source, managed posture.
+#
+# Managed agentic hosting: the agent edits the live theme and plugins in place at
+# the owner's request. There is no workspace, no git, and no GitHub in its world.
+# Matches the permissions lib/source-policy.sh hands the runtimes for this
+# posture: themes and plugins editable, wp-includes still read-only.
+#
+# This prose deliberately carries facts the engineering variant has no reason to
+# state. An agent editing production needs to know that its changes are live on
+# save, that they are unbacked until captured, and which paths a capture will
+# silently skip. Omitting those is how an agent loses a day of work in a path
+# nobody told it was excluded.
+
+guidance_id() { printf 'wordpress-source'; }
+guidance_priority() { printf '1'; }
+guidance_label() { printf 'WordPress Source'; }
+guidance_description() { printf 'Live-edit boundaries and production contract for installed WordPress source.'; }
+guidance_freshness() { printf 'static'; }
+guidance_conditions() { printf 'Registered by wp-coding-agents on managed-posture installations, where the agent edits live site source directly.'; }
+
+guidance_render() {
+  cat <<'MD'
+## WordPress Source (Live, Editable)
+
+This site's theme and plugins are yours to edit directly. The installed tree is the working tree — there is no separate checkout, no workspace, and no pull request step.
+
+- `wp-content/themes/` — **editable**, this site's own theme source
+- `wp-content/plugins/` — **editable**, this site's own plugin source
+- `wp-includes/` — WordPress core, **read-only**. Never edit core; change your theme or plugin instead.
+
+Read the installed source directly to verify APIs, hooks, and runtime behavior rather than relying on assumptions.
+
+### Working on production
+
+- **Your edits are live the moment you save them.** There is no staging environment, no review gate, and no deploy step between you and the public site. A syntax error is a down site.
+- **Verify before you leave a change in place.** Load the affected page or run the relevant WP-CLI command. You are the only check that runs before visitors see it.
+- **Work is unbacked until it is captured.** Changes are harvested into version control out-of-band on a schedule the operator owns, and each capture becomes a restore point. Between your edit and the next capture, the live file is the only copy.
+- **Rollback is an operator action.** You cannot revert to a previous restore point yourself. If something breaks and you cannot fix it forward, say so plainly and immediately rather than continuing to edit.
+
+### Changes that will not be captured
+
+Dependency trees, lockfiles, and build output are installed or generated rather than authored, so a capture skips them. Editing them on the live site produces a change that is **never recorded and is destroyed by the next deploy**:
+
+- `vendor/` and `node_modules/` — installed dependency trees
+- `composer.lock`, `package-lock.json`, `package.json` — dependency manifests
+- generated build output
+
+If a task genuinely requires changing one of these, stop and tell the operator. It needs to happen in the source repository, not here.
+MD
+}

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
-# lib/agents-md-guidance.sh — AGENTS.md SectionRegistry guidance writer.
+# lib/agents-md-guidance.sh — AGENTS.md SectionRegistry guidance MECHANISM.
 #
 # wp-coding-agents owns integration-specific runtime guidance for the tools it
 # installs and wires together. Data Machine Code owns the generic AGENTS.md
 # composition substrate; this helper publishes wp-coding-agents' integration
 # guidance into that substrate through Data Machine's SectionRegistry without
 # making DMC know about Homeboy, Kimaki, OpenCode, or WP Codebox conventions.
+#
+# This file is the mechanism ONLY: scaffold the mu-plugin, render a
+# marker-delimited PHP block, rewrite it idempotently, remove it on request. It
+# has no opinion about what any section says. The prose lives in guidance/*.sh,
+# one self-contained unit per section, discovered and dispatched by
+# guidance/_dispatch.sh — see that file for the hook contract and for how
+# posture selects between section variants.
 #
 # Resolved file: $SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agents-md.php
 #
@@ -14,14 +21,6 @@
 #   agents_md_guidance_ensure_mu_plugin_file
 #   agents_md_guidance_register <section_id> <priority> <label> <description> <content>
 #   agents_md_guidance_unregister <section_id>
-#   agents_md_guidance_sync_wordpress_agent_boundaries
-#   agents_md_guidance_sync_homeboy_cli          # presence-gated on an executable Homeboy binary
-#   agents_md_guidance_register_homeboy_cli      # writes a live presence-checked PHP block
-#   agents_md_guidance_unregister_homeboy_cli
-#
-# The homeboy-cli callback checks the current PATH at AGENTS.md compose time, so
-# an unavailable binary contributes no stale guidance. The live CLI help remains
-# authoritative for Homeboy's complete command surface.
 #
 # Honors DRY_RUN (logs intent, makes no changes).
 
@@ -212,208 +211,6 @@ agents_md_guidance_unregister() {
   if [ -n "${UPDATED_ITEMS+x}" ]; then
     UPDATED_ITEMS+=("AGENTS.md guidance removed: $section_id")
   fi
-}
-
-# Register the generic WordPress coding-agent contract before component maps.
-# The concrete WP-CLI command remains environment-owned and is intentionally
-# absent from this static guidance.
-agents_md_guidance_sync_wordpress_agent_boundaries() {
-  local source_content abilities_content
-
-  source_content='## WordPress Source (Direct Reference, Read-Only)
-
-Use the installed WordPress source to verify core APIs, hooks, conventions, and runtime behavior instead of relying on assumptions. Search and read these directories directly when working on WordPress:
-
-- `wp-content/plugins/` — plugin source (read-only)
-- `wp-content/themes/` — theme source (read-only)
-- `wp-includes/` — WordPress core (read-only)
-
-These paths are **read-only references**. Make code changes in the configured managed workspace, not in the installed source tree.'
-
-  abilities_content='## Abilities
-
-WordPress Abilities are the universal tool surface. Plugins expose abilities through the active runtime, REST API, MCP, and chat.
-
-**Default routing**
-- Use abilities exposed by the active runtime when they match the task.
-- Inspect the active runtime tool listings and plugin-specific `--help` before assuming a capability or argument is available.'
-
-  AGENTS_MD_GUIDANCE_FRESHNESS=static \
-    AGENTS_MD_GUIDANCE_CONDITIONS='Registered by wp-coding-agents on managed WordPress coding-agent installations.' \
-    agents_md_guidance_register \
-      'wordpress-source' \
-      1 \
-      'WordPress Source' \
-      'Direct-reference and read-only boundaries for installed WordPress source.' \
-      "$source_content"
-
-  AGENTS_MD_GUIDANCE_FRESHNESS=static \
-    AGENTS_MD_GUIDANCE_CONDITIONS='Registered by wp-coding-agents on managed WordPress coding-agent installations.' \
-    agents_md_guidance_register \
-      'abilities' \
-      2 \
-      'Abilities' \
-      'Generic WordPress Abilities discovery guidance.' \
-      "$abilities_content"
-}
-
-# ---------------------------------------------------------------------------
-# Homeboy routing guidance (issues #208, #254, #298)
-#
-# homeboy is an OPTIONAL host binary. The map is strictly presence-gated:
-#   - present (`command -v homeboy` succeeds) -> emit a first-class section
-#     whose callback verifies Homeboy is still present at compose time.
-#   - absent -> complete no-op (unregister any stale section, emit nothing).
-#
-# The generated section intentionally contains routing, ownership, safety, and
-# discovery guidance rather than a copy of `homeboy --help`. The live CLI is the
-# authoritative command map.
-# ---------------------------------------------------------------------------
-
-# agents_md_guidance_sync_homeboy_cli
-#
-# Presence-gated entry point. Reuses the same `command -v homeboy` detection
-# the rest of the homeboy integration uses so the section and the integration
-# agree on presence. When homeboy is present, registers a LIVE-enumeration
-# section block (no content is baked at setup time).
-agents_md_guidance_sync_homeboy_cli() {
-  local homeboy_path
-  homeboy_path="$(type -P homeboy 2>/dev/null || true)"
-  if [ -n "$homeboy_path" ] && [ -f "$homeboy_path" ] && [ -x "$homeboy_path" ]; then
-    agents_md_guidance_register_homeboy_cli
-  else
-    agents_md_guidance_unregister_homeboy_cli
-  fi
-}
-
-# agents_md_guidance_register_homeboy_cli
-#
-# Writes a self-contained PHP block whose SectionRegistry callback verifies the
-# Homeboy binary remains available at compose time. The block is marker-delimited
-# so it is idempotent and removable by the standard unregister path.
-agents_md_guidance_register_homeboy_cli() {
-  local file
-  file="$(agents_md_guidance_mu_plugin_path)" || {
-    warn "  agents_md_guidance_register_homeboy_cli: SITE_PATH not set — skipping"
-    return 1
-  }
-
-  agents_md_guidance_ensure_mu_plugin_file || return 1
-
-  local new_block
-  new_block="$(_agents_md_guidance_render_homeboy_live_block)" || {
-    warn "  agents_md_guidance_register_homeboy_cli: could not render live block — skipping"
-    return 1
-  }
-
-  agents_md_guidance_ensure_mu_plugin_file || return 1
-
-  if [ "${DRY_RUN:-false}" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} Would register live AGENTS.md guidance section 'homeboy-cli' in $file"
-    echo -e "${BLUE}[dry-run]${NC} Block:"
-    echo "$new_block" | sed 's/^/    /'
-    return 0
-  fi
-
-  if _agents_md_guidance_block_matches "$file" "homeboy-cli" "$new_block"; then
-    return 0
-  fi
-
-  local tmp
-  tmp=$(mktemp "${file}.XXXXXX")
-  _agents_md_guidance_rewrite "$file" "homeboy-cli" "$new_block" > "$tmp"
-
-  if cmp -s "$file" "$tmp"; then
-    rm -f "$tmp"
-    return 0
-  fi
-
-  mv "$tmp" "$file"
-  service_file_normalize_perms "$file"
-  log "  Registered live AGENTS.md guidance section 'homeboy-cli' in $file"
-  if [ -n "${UPDATED_ITEMS+x}" ]; then
-    UPDATED_ITEMS+=("AGENTS.md guidance: homeboy-cli (live)")
-  fi
-}
-
-agents_md_guidance_unregister_homeboy_cli() {
-  agents_md_guidance_unregister "homeboy-cli"
-}
-
-# _agents_md_guidance_render_homeboy_live_block
-#
-# Emits the PHP for the homeboy-cli section block. The block is
-# self-contained: it defines one helper (guarded by `function_exists` so
-# re-firing the datamachine_sections action does not fatally redeclare it) and
-# registers a SectionRegistry section whose callback checks live presence.
-#
-# Quoted heredoc ('PHP_BLOCK') so PHP $variables, backticks, and ${...}
-# are emitted verbatim — bash never touches them.
-_agents_md_guidance_render_homeboy_live_block() {
-  cat <<'PHP_BLOCK'
-    // BEGIN agents-md-guidance:homeboy-cli
-    if ( ! function_exists( 'wp_coding_agents_render_homeboy_cli_section' ) ) {
-        function wp_coding_agents_render_homeboy_cli_section() {
-            // Homeboy is optional. The section is a clean no-op when the
-            // binary is not on PATH, matching the presence-gating the bash
-            // setup path applies.
-            $homeboy = null;
-            $path_env = ( is_callable( 'getenv' ) ) ? getenv( 'PATH' ) : false;
-            if ( is_string( $path_env ) && $path_env !== '' ) {
-                foreach ( explode( PATH_SEPARATOR, $path_env ) as $dir ) {
-                    if ( $dir === '' ) {
-                        continue;
-                    }
-                    $candidate = rtrim( $dir, '/' ) . '/homeboy';
-                    if ( @is_executable( $candidate ) ) {
-                        $homeboy = $candidate;
-                        break;
-                    }
-                }
-            }
-            if ( $homeboy === null ) {
-                return '';
-            }
-
-            return <<<'MD'
-## Homeboy
-
-Homeboy orchestrates coding agents, deterministic gates, evidence, promotion, review, releases, and deployments. Data Machine Code owns authoritative repository and worktree state; Homeboy consumes managed worktrees to execute and finalize work.
-
-**Default routing**
-- One tracked change: `homeboy agent-task cook`
-- Multiple independent changes: `homeboy agent-task fanout cook-batch`
-- Review a candidate: `homeboy review`
-- Inspect runs and evidence: `homeboy runs`
-- Repeating workflows: `homeboy agent-task loop`; explicitly stateful workflows: `homeboy agent-task controller`
-- Component and runner health: `homeboy status` and `homeboy runner status`
-
-**Operator boundary**
-Run `homeboy release` or `homeboy deploy` only when the user explicitly asks.
-
-**Discovery**
-Use `homeboy --help` and `homeboy <command> --help` for the live command contract. Inspect active configuration with `homeboy config show` and provider readiness with `homeboy agent-task providers`.
-MD;
-        }
-    }
-
-    \DataMachine\Engine\AI\SectionRegistry::register(
-        'AGENTS.md',
-        'homeboy-cli',
-        30,
-        static function () {
-            return wp_coding_agents_render_homeboy_cli_section();
-        },
-        array(
-            'label'       => 'Homeboy',
-            'description' => 'Host orchestration routing, safety, and discovery guidance.',
-            'owner'       => 'wp-coding-agents',
-            'freshness'   => 'live',
-            'conditions'  => 'Registered on hosts where the homeboy binary is installed and omitted at compose time when the binary is unavailable.',
-        )
-    );
-    // END agents-md-guidance:homeboy-cli
-PHP_BLOCK
 }
 
 _agents_md_guidance_render_block() {

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -10,19 +10,30 @@ install_data_machine() {
     log "  $WP_CMD plugin activate data-machine --url=subsite.$SITE_DOMAIN $WP_ROOT_FLAG"
   fi
 
-  log "Installing Data Machine Code (developer tools)..."
-  install_plugin data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+  # Data Machine Code is the workspace/git/GitHub tool surface. A managed
+  # install has no workspace by design — the agent edits live source and
+  # changes are captured out-of-band — so installing DMC there contributes
+  # ~90 abilities the agent cannot use plus an AGENTS.md section instructing
+  # it to route work through a git workflow it has no access to. AGENTS.md
+  # composition is unaffected: data-machine core registers the composable file
+  # itself behind the same DATAMACHINE_COMPOSE_AGENTS_MD gate.
+  if source_policy_workspace_enabled; then
+    log "Installing Data Machine Code (developer tools)..."
+    install_plugin data-machine-code https://github.com/Extra-Chill/data-machine-code.git
 
-  # Set workspace path in wp-config.php if not already defined
-  if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/wp-config.php" ] && [ "$IS_STUDIO" = false ]; then
-    if ! grep -q 'DATAMACHINE_WORKSPACE_PATH' "$SITE_PATH/wp-config.php"; then
-      wp_cmd config set DATAMACHINE_WORKSPACE_PATH "$DM_WORKSPACE_DIR" --type=constant
-      log "Set DATAMACHINE_WORKSPACE_PATH to $DM_WORKSPACE_DIR"
-    else
-      log "DATAMACHINE_WORKSPACE_PATH already defined in wp-config.php"
+    # Set workspace path in wp-config.php if not already defined
+    if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/wp-config.php" ] && [ "$IS_STUDIO" = false ]; then
+      if ! grep -q 'DATAMACHINE_WORKSPACE_PATH' "$SITE_PATH/wp-config.php"; then
+        wp_cmd config set DATAMACHINE_WORKSPACE_PATH "$DM_WORKSPACE_DIR" --type=constant
+        log "Set DATAMACHINE_WORKSPACE_PATH to $DM_WORKSPACE_DIR"
+      else
+        log "DATAMACHINE_WORKSPACE_PATH already defined in wp-config.php"
+      fi
+    elif [ "$DRY_RUN" = true ]; then
+      echo -e "${BLUE}[dry-run]${NC} $WP_CMD config set DATAMACHINE_WORKSPACE_PATH $DM_WORKSPACE_DIR --type=constant"
     fi
-  elif [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD config set DATAMACHINE_WORKSPACE_PATH $DM_WORKSPACE_DIR --type=constant"
+  else
+    log "Skipping Data Machine Code (posture: ${POSTURE:-managed} — no workspace on this install)"
   fi
 
   set_compose_agents_md_constant
@@ -61,7 +72,15 @@ upgrade_data_machine_plugins() {
 
   log "Phase 2: Updating Data Machine plugins to latest tagged releases..."
   update_plugin_to_latest_tag data-machine https://github.com/Extra-Chill/data-machine.git
-  update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+
+  # Managed installs deliberately have no DMC. Without this gate every upgrade
+  # silently reinstalls and reactivates it, because update_plugin_to_latest_tag
+  # activates — which is exactly why hand-deactivating DMC never stuck.
+  if source_policy_workspace_enabled; then
+    update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+  else
+    log "  Skipping Data Machine Code (posture: ${POSTURE:-managed})"
+  fi
 
   # Backfill the AGENTS.md composition gate on existing installs (idempotent).
   set_compose_agents_md_constant

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -413,8 +413,8 @@ sync_homeboy_agents_md_guidance() {
   # compose WITHOUT a wp-coding-agents sync — this function just keeps the
   # section block registered (or removes it when homeboy is absent, which
   # is itself the signal that homeboy is not callable on this host).
-  if declare -F agents_md_guidance_sync_homeboy_cli >/dev/null; then
-    agents_md_guidance_sync_homeboy_cli
+  if declare -F guidance_sync_unit >/dev/null; then
+    guidance_sync_unit homeboy
   fi
 }
 

--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -76,11 +76,24 @@ from typing import List, Tuple
 MANAGED_KIMAKI_PLUGIN_NAMES = {"dm-context-filter.ts", "dm-agent-sync.ts"}
 OBSOLETE_KIMAKI_PLUGIN_NAMES = {"homeboy-notification-context.ts"}
 DM_MEMORY_MARKER = "/datamachine-files/"
+# Every installed-source root wp-coding-agents manages, in canonical order.
+# Kept in lockstep with lib/source-policy.sh: that file is the single source of
+# truth for which of these the active posture denies, this list is only the key
+# set the reconciler owns and may therefore overwrite.
 MANAGED_EDIT_RULES = (
     "wp-content/plugins/**",
     "wp-content/themes/**",
     "wp-includes/**",
 )
+
+# Roots that stay read-only under each posture. `wp-includes` is WordPress core
+# and is never editable; managed hosting hands the agent its own theme and
+# plugins only.
+POSTURE_DENIED_EDIT_RULES = {
+    "engineering": MANAGED_EDIT_RULES,
+    "managed": ("wp-includes/**",),
+}
+DEFAULT_POSTURE = "engineering"
 
 
 def expected_plugins(
@@ -360,8 +373,14 @@ def apply_instruction_sync(data: dict, desired: List[str]) -> dict:
     return result
 
 
-def expected_edit_permission(data: dict) -> dict:
-    """Return user edit rules followed by wp-coding-agents deny rules."""
+def expected_edit_permission(data: dict, posture: str = DEFAULT_POSTURE) -> dict:
+    """Return user edit rules followed by the posture's managed rules.
+
+    The managed key set is constant across postures so switching an install
+    rewrites every rule rather than leaving a stale deny behind.
+    """
+    denied = POSTURE_DENIED_EDIT_RULES.get(posture, POSTURE_DENIED_EDIT_RULES[DEFAULT_POSTURE])
+
     permission = data.get("permission", {})
     if isinstance(permission, str):
         current: object = permission
@@ -382,25 +401,25 @@ def expected_edit_permission(data: dict) -> dict:
         rules = {}
 
     for pattern in MANAGED_EDIT_RULES:
-        rules[pattern] = "deny"
+        rules[pattern] = "deny" if pattern in denied else "allow"
     return rules
 
 
-def check_edit_permission(data: dict, runtime: str) -> dict:
+def check_edit_permission(data: dict, runtime: str, posture: str = DEFAULT_POSTURE) -> dict:
     if runtime != "opencode":
         return {"status": "ok"}
 
     permission = data.get("permission", {})
     current = permission.get("edit") if isinstance(permission, dict) else None
-    expected = expected_edit_permission(data)
+    expected = expected_edit_permission(data, posture)
     return {
         "status": "ok" if current == expected else "needed",
         "expected": expected,
     }
 
 
-def apply_edit_permission(data: dict) -> None:
-    expected = expected_edit_permission(data)
+def apply_edit_permission(data: dict, posture: str = DEFAULT_POSTURE) -> None:
+    expected = expected_edit_permission(data, posture)
     permission = data.get("permission", {})
     if isinstance(permission, str):
         permission = {"*": permission}
@@ -422,6 +441,12 @@ def main() -> int:
         "--chat-bridge",
         required=True,
         choices=["kimaki", "cc-connect", "telegram", "none"],
+    )
+    parser.add_argument(
+        "--posture",
+        default=DEFAULT_POSTURE,
+        choices=sorted(POSTURE_DENIED_EDIT_RULES),
+        help="Installed-source posture for this install (see lib/source-policy.sh)",
     )
     parser.add_argument(
         "--kimaki-plugins-dir",
@@ -492,7 +517,7 @@ def main() -> int:
     agent_cleanup_result = check_agent_cleanup(data)
     managed_instructions = read_managed_instructions(args.managed_instructions_file)
     instruction_sync_result = check_instruction_sync(data, managed_instructions)
-    edit_permission_result = check_edit_permission(data, args.runtime)
+    edit_permission_result = check_edit_permission(data, args.runtime, args.posture)
 
     # --- Plugin array check ---
     expected = expected_plugins(
@@ -619,7 +644,7 @@ def main() -> int:
 
     edit_permission_status = "ok"
     if has_edit_permission_drift:
-        apply_edit_permission(data)
+        apply_edit_permission(data, args.posture)
         edit_permission_status = "synced"
 
     with open(args.file, "w", encoding="utf-8") as fh:

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# lib/source-policy.sh — installed-WordPress-source policy, derived from posture.
+#
+# wp-coding-agents installs two fundamentally different kinds of agent:
+#
+#   engineering  The agent treats installed WordPress source as read-only
+#                reference and makes every code change in a Data Machine Code
+#                workspace, tracked in git and reviewed through GitHub. This is
+#                the historical (and default) behavior.
+#
+#   managed      The agent edits the live theme and plugins in place at the
+#                owner's request. There is no workspace, no git, and no GitHub
+#                in the agent's world; changes are captured out-of-band (e.g.
+#                `homeboy harvest` on a schedule) as restore points. Built for
+#                managed agentic hosting, where a non-technical owner should
+#                never have to deal with pull requests.
+#
+# That single choice has to be enforced in four unrelated places — three runtime
+# permission surfaces and the generated AGENTS.md prose. Before this file the
+# same three globs were hardcoded in all of them independently:
+#
+#   runtimes/opencode.sh        permission.edit
+#   runtimes/claude-code.sh     permissions.deny
+#   runtimes/codex.sh           permissions filesystem profile
+#   lib/repair-opencode-json.py reconciliation of permission.edit
+#   lib/agents-md-guidance.sh   the prose telling the agent what it may touch
+#
+# Duplicated policy drifts, and when the prose and the permissions disagree the
+# agent is told to do something it is then blocked from doing. This module is
+# the single answer all of them derive from, so posture cannot be half-applied.
+#
+# Public surface:
+#   source_policy_resolve_posture          # sets POSTURE (flag -> recorded -> default)
+#   source_policy_record_posture           # persists POSTURE for later upgrades
+#   source_policy_is_valid <posture>
+#   source_policy_read_only_roots          # newline-separated, ordered
+#   source_policy_editable_roots           # newline-separated, ordered
+#   source_policy_workspace_enabled        # 0 = workspace/git/GitHub apply
+#
+# Honors DRY_RUN (logs intent, makes no changes).
+
+# The wp option wp-coding-agents records the chosen posture in. Mirrors the
+# existing `datamachine_code_homeboy_available` pattern: a setup-time fact that
+# upgrade.sh has to be able to rediscover without asking again.
+SOURCE_POLICY_OPTION="wp_coding_agents_posture"
+SOURCE_POLICY_DEFAULT_POSTURE="engineering"
+
+# Every installed-source root wp-coding-agents has an opinion about, in the
+# order they are emitted by every consumer. Adding a root here adds it to all
+# runtimes and to the AGENTS.md prose at once.
+_source_policy_all_roots() {
+  printf '%s\n' \
+    'wp-content/plugins' \
+    'wp-content/themes' \
+    'wp-includes'
+}
+
+source_policy_is_valid() {
+  case "${1:-}" in
+    engineering|managed) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Resolve the active posture into the POSTURE global.
+#
+# Precedence: explicit --posture flag (POSTURE_EXPLICIT=true) > posture recorded
+# on the install at setup time > engineering. The recorded value is what lets
+# `upgrade.sh` converge a managed box without the operator repeating the flag —
+# and, critically, without silently reverting it to engineering.
+source_policy_resolve_posture() {
+  if [ "${POSTURE_EXPLICIT:-false}" = true ]; then
+    if ! source_policy_is_valid "${POSTURE:-}"; then
+      error "Unknown --posture '${POSTURE:-}'. Supported: engineering, managed"
+    fi
+    log "Posture: $POSTURE (explicit)"
+    return 0
+  fi
+
+  local recorded=""
+  recorded="$(source_policy_recorded_posture)"
+
+  if source_policy_is_valid "$recorded"; then
+    POSTURE="$recorded"
+    log "Posture: $POSTURE (recorded on this install)"
+    return 0
+  fi
+
+  POSTURE="$SOURCE_POLICY_DEFAULT_POSTURE"
+  log "Posture: $POSTURE (default)"
+}
+
+# Read the posture recorded on this install, or '' when unavailable.
+#
+# Deliberately quiet: a fresh install, a dry run, or a site whose database is
+# not reachable yet must fall through to the default rather than fail.
+source_policy_recorded_posture() {
+  if [ "${DRY_RUN:-false}" = true ]; then
+    printf '%s' "${POSTURE:-}"
+    return 0
+  fi
+
+  if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
+    return 0
+  fi
+
+  wp_cmd option get "$SOURCE_POLICY_OPTION" 2>/dev/null | tr -d '[:space:]' || true
+}
+
+# Persist the resolved posture so upgrade.sh can rediscover it.
+source_policy_record_posture() {
+  local posture="${POSTURE:-$SOURCE_POLICY_DEFAULT_POSTURE}"
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $SOURCE_POLICY_OPTION $posture"
+    return 0
+  fi
+
+  if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
+    return 0
+  fi
+
+  if [ "$(source_policy_recorded_posture)" = "$posture" ]; then
+    return 0
+  fi
+
+  if wp_cmd option update "$SOURCE_POLICY_OPTION" "$posture" >/dev/null 2>&1; then
+    log "  Recorded install posture: $posture"
+    if [ -n "${UPDATED_ITEMS+x}" ]; then
+      UPDATED_ITEMS+=("posture: $posture")
+    fi
+  else
+    warn "Could not record install posture '$posture' — upgrades will fall back to $SOURCE_POLICY_DEFAULT_POSTURE"
+  fi
+}
+
+# Roots the agent must NOT edit under the active posture.
+#
+# `wp-includes/` is WordPress core and is read-only in BOTH postures. Managed
+# hosting hands the agent its own theme and plugins, never core.
+source_policy_read_only_roots() {
+  case "${POSTURE:-$SOURCE_POLICY_DEFAULT_POSTURE}" in
+    managed)
+      printf '%s\n' 'wp-includes'
+      ;;
+    *)
+      _source_policy_all_roots
+      ;;
+  esac
+}
+
+# Roots the agent may edit in place under the active posture.
+source_policy_editable_roots() {
+  case "${POSTURE:-$SOURCE_POLICY_DEFAULT_POSTURE}" in
+    managed)
+      printf '%s\n' 'wp-content/plugins' 'wp-content/themes'
+      ;;
+    *)
+      : # engineering edits nothing in the installed tree
+      ;;
+  esac
+}
+
+# Whether the Data Machine Code workspace (and therefore git/GitHub) is part of
+# this install's architecture.
+#
+# Consumed by the runtimes (workspace allow rules) and by lib/data-machine.sh
+# (whether data-machine-code is installed at all). Returns 0 for yes.
+source_policy_workspace_enabled() {
+  case "${POSTURE:-$SOURCE_POLICY_DEFAULT_POSTURE}" in
+    managed) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Every managed root paired with its action under the active posture, as
+# tab-separated `<root>\t<deny|allow>` lines in canonical root order.
+#
+# This is the shape the runtimes consume. Policy lives here; FORMATTING stays in
+# each runtime, because each one has its own config dialect (OpenCode JSON,
+# Claude Code Edit() globs, Codex TOML filesystem profiles). Emitting every root
+# rather than only the denied ones means an install that switches posture has
+# the same key set rewritten rather than stale keys left behind.
+source_policy_root_actions() {
+  local root
+  local read_only
+  read_only="$(source_policy_read_only_roots)"
+
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    if printf '%s\n' "$read_only" | grep -qxF "$root"; then
+      printf '%s\tdeny\n' "$root"
+    else
+      printf '%s\tallow\n' "$root"
+    fi
+  done < <(_source_policy_all_roots)
+}

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -43,8 +43,14 @@ print_summary() {
     echo "  Agent:       $AGENT_SLUG"
   fi
   echo "  Discover:    $WP_CMD datamachine memory paths${AGENT_SLUG:+ --agent=$AGENT_SLUG} $WP_ROOT_FLAG"
-  echo "  Code tools:  data-machine-code (workspace, GitHub, git)"
-  echo "  Workspace:   $DM_WORKSPACE_DIR (created on first use)"
+  echo "  Posture:     ${POSTURE:-engineering}"
+  if source_policy_workspace_enabled; then
+    echo "  Code tools:  data-machine-code (workspace, GitHub, git)"
+    echo "  Workspace:   $DM_WORKSPACE_DIR (created on first use)"
+  else
+    echo "  Code tools:  none — the agent edits live theme and plugin source in place"
+    echo "  Capture:     changes are harvested into version control out-of-band"
+  fi
   echo ""
   if [ "${HOMEBOY_MODE:-auto}" != "disabled" ] && [ -n "${HOMEBOY_PROJECT_ID:-}" ]; then
     echo "Homeboy:"

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -194,27 +194,41 @@ runtime_install_hooks() {
     wp_prefix="studio wp"
   fi
 
-  local workspace_allow_rules
-  workspace_allow_rules=$(jq -n \
-    --arg ws "$DM_WORKSPACE_DIR" \
-    --arg wp "$wp_prefix" \
-    '[
-      "Read(\($ws)/**)",
-      "Edit(\($ws)/**)",
-      "Write(\($ws)/**)",
-      "Bash(\($wp) datamachine-code workspace:*)",
-      "Bash(\($wp) datamachine-code github:*)",
-      "Bash(\($wp) datamachine-code gitsync:*)"
-    ]')
+  # Workspace access only exists in postures that have a workspace. On a
+  # managed install these rules would grant the agent an empty directory while
+  # advertising a git workflow it has no part in.
+  local workspace_allow_rules='[]'
+  if source_policy_workspace_enabled; then
+    workspace_allow_rules=$(jq -n \
+      --arg ws "$DM_WORKSPACE_DIR" \
+      --arg wp "$wp_prefix" \
+      '[
+        "Read(\($ws)/**)",
+        "Edit(\($ws)/**)",
+        "Write(\($ws)/**)",
+        "Bash(\($wp) datamachine-code workspace:*)",
+        "Bash(\($wp) datamachine-code github:*)",
+        "Bash(\($wp) datamachine-code gitsync:*)"
+      ]')
+  fi
 
-  local wordpress_deny_rules
-  wordpress_deny_rules=$(jq -n \
-    --arg site "$SITE_PATH" \
-    '[
-      "Edit(\($site)/wp-content/plugins/**)",
-      "Edit(\($site)/wp-content/themes/**)",
-      "Edit(\($site)/wp-includes/**)"
-    ]')
+  # Denies are posture-derived (lib/source-policy.sh). Roots the active posture
+  # allows are subtracted as well as added, so switching an install from
+  # engineering to managed actually clears the old denies instead of leaving
+  # the agent blocked by a rule nothing removes.
+  local wordpress_deny_rules='[]'
+  local wordpress_allowed_rules='[]'
+  local _root _action
+  while IFS=$'\t' read -r _root _action; do
+    [ -n "$_root" ] || continue
+    local _rule
+    _rule=$(jq -n --arg site "$SITE_PATH" --arg root "$_root" '"Edit(\($site)/\($root)/**)"')
+    if [ "$_action" = "deny" ]; then
+      wordpress_deny_rules=$(jq -n --argjson acc "$wordpress_deny_rules" --argjson rule "$_rule" '$acc + [$rule]')
+    else
+      wordpress_allowed_rules=$(jq -n --argjson acc "$wordpress_allowed_rules" --argjson rule "$_rule" '$acc + [$rule]')
+    fi
+  done < <(source_policy_root_actions)
 
   local legacy_wordpress_deny_rules
   legacy_wordpress_deny_rules=$(jq -n '[
@@ -234,13 +248,15 @@ runtime_install_hooks() {
     --arg cmd "$hook_cmd" \
     --argjson allow_rules "$workspace_allow_rules" \
     --argjson deny_rules "$wordpress_deny_rules" \
+    --argjson allowed_rules "$wordpress_allowed_rules" \
     --argjson legacy_deny_rules "$legacy_wordpress_deny_rules" \
+    --argjson workspace_enabled "$(source_policy_workspace_enabled && echo true || echo false)" \
     '
     .autoMemoryEnabled = false
 
     | .permissions.additionalDirectories = (
         (.permissions.additionalDirectories // [])
-        | if any(. == $workspace) then . else . + [$workspace] end
+        | if $workspace_enabled and (any(. == $workspace) | not) then . + [$workspace] else . end
       )
 
     | .permissions.allow = (
@@ -248,7 +264,7 @@ runtime_install_hooks() {
       )
 
     | .permissions.deny = (
-        (((.permissions.deny // []) - $legacy_deny_rules + $deny_rules) | unique)
+        (((.permissions.deny // []) - $legacy_deny_rules - $allowed_rules + $deny_rules) | unique)
       )
 
     | .hooks.SessionStart = (

--- a/runtimes/codex.sh
+++ b/runtimes/codex.sh
@@ -106,13 +106,27 @@ runtime_generate_config() {
   fi
 
   mkdir -p "$config_dir"
-  if ! python3 - "$config_file" "$CODEX_PERMISSION_START" "$CODEX_PERMISSION_END" <<'PY'
+
+  # Only roots the active posture keeps read-only appear in the filesystem
+  # profile; anything the posture makes editable inherits the ":workspace"
+  # default. See lib/source-policy.sh.
+  local codex_read_roots=""
+  local _root _action
+  while IFS=$'\t' read -r _root _action; do
+    [ -n "$_root" ] || continue
+    [ "$_action" = "deny" ] || continue
+    codex_read_roots="${codex_read_roots}${_root}"$'\n'
+  done < <(source_policy_root_actions)
+
+  if ! CODEX_READ_ROOTS="$codex_read_roots" python3 - "$config_file" "$CODEX_PERMISSION_START" "$CODEX_PERMISSION_END" <<'PY'
+import os
 import pathlib
 import re
 import sys
 
 path = pathlib.Path(sys.argv[1])
 start, end = sys.argv[2], sys.argv[3]
+read_roots = [line for line in os.environ.get("CODEX_READ_ROOTS", "").splitlines() if line.strip()]
 content = path.read_text(encoding="utf-8") if path.exists() else ""
 pattern = re.compile(rf"^\s*{re.escape(start)}$.*?^\s*{re.escape(end)}\s*$", re.MULTILINE | re.DOTALL)
 unmanaged = pattern.sub("", content)
@@ -121,6 +135,8 @@ if re.search(r"^\s*(default_permissions|sandbox_mode)\s*=", unmanaged, re.MULTIL
 ):
     raise SystemExit("existing Codex default_permissions or sandbox_mode conflicts with managed WordPress permissions")
 
+filesystem = "\n".join(f'"{root}" = "read"' for root in read_roots)
+
 block = f'''{start}
 default_permissions = "wp-coding-agents-wordpress"
 
@@ -128,9 +144,7 @@ default_permissions = "wp-coding-agents-wordpress"
 extends = ":workspace"
 
 [permissions.wp-coding-agents-wordpress.filesystem.":workspace_roots"]
-"wp-content/plugins" = "read"
-"wp-content/themes" = "read"
-"wp-includes" = "read"
+{filesystem}
 {end}'''
 
 before = unmanaged.rstrip()

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -282,16 +282,28 @@ runtime_generate_config() {
     fi
   fi
 
-  # Permission: allow the DM workspace while keeping installed WordPress
-  # source outside OpenCode's shared edit/write/apply_patch mutation surface.
+  # Permission: the installed-source mutation surface is posture-derived (see
+  # lib/source-policy.sh). Engineering keeps every installed root outside
+  # OpenCode's shared edit/write/apply_patch surface and grants the DM
+  # workspace instead; managed inverts that for themes and plugins and grants
+  # no workspace, because there isn't one.
   OPENCODE_JSON="$OPENCODE_JSON,\n  \"permission\": {"
-  OPENCODE_JSON="$OPENCODE_JSON\n    \"external_directory\": {"
-  OPENCODE_JSON="$OPENCODE_JSON\n      \"${DM_WORKSPACE_DIR}/**\": \"allow\""
-  OPENCODE_JSON="$OPENCODE_JSON\n    },"
+  if source_policy_workspace_enabled; then
+    OPENCODE_JSON="$OPENCODE_JSON\n    \"external_directory\": {"
+    OPENCODE_JSON="$OPENCODE_JSON\n      \"${DM_WORKSPACE_DIR}/**\": \"allow\""
+    OPENCODE_JSON="$OPENCODE_JSON\n    },"
+  fi
   OPENCODE_JSON="$OPENCODE_JSON\n    \"edit\": {"
-  OPENCODE_JSON="$OPENCODE_JSON\n      \"wp-content/plugins/**\": \"deny\","
-  OPENCODE_JSON="$OPENCODE_JSON\n      \"wp-content/themes/**\": \"deny\","
-  OPENCODE_JSON="$OPENCODE_JSON\n      \"wp-includes/**\": \"deny\""
+  local _edit_rules=""
+  local _root _action
+  while IFS=$'\t' read -r _root _action; do
+    [ -n "$_root" ] || continue
+    if [ -n "$_edit_rules" ]; then
+      _edit_rules="${_edit_rules},"
+    fi
+    _edit_rules="${_edit_rules}\n      \"${_root}/**\": \"${_action}\""
+  done < <(source_policy_root_actions)
+  OPENCODE_JSON="$OPENCODE_JSON${_edit_rules}"
   OPENCODE_JSON="$OPENCODE_JSON\n    }"
   OPENCODE_JSON="$OPENCODE_JSON\n  }"
 
@@ -342,6 +354,7 @@ _runtime_repair_opencode_json_additive() {
     --file "$SITE_PATH/opencode.json" \
     --runtime opencode \
     --chat-bridge "$BRIDGE_ARG" \
+    --posture "${POSTURE:-engineering}" \
     --kimaki-plugins-dir "$PLUGINS_DIR" \
     "${claude_code_auth_args[@]}" \
     "${managed_args[@]}" \

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature agents-md-guidance; do
+for lib in common detect source-policy wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -31,6 +31,11 @@ done
 # "drop a file in bridges/" — no edit here.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/bridges/_dispatch.sh"
+
+# Guidance dispatcher — auto-discovers guidance/*.sh AGENTS.md section units.
+# Adding a section is "drop a file in guidance/" — no edit here.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/guidance/_dispatch.sh"
 source "$SCRIPT_DIR/services/datamachine-worker.sh"
 
 # Discover available runtimes from runtimes/ directory
@@ -67,6 +72,8 @@ ROTATE_AI_GATEWAY_TOKEN=false
 RUNTIME=""
 CHAT_BRIDGE_EXPLICIT=false
 HOMEBOY_MODE="auto"
+POSTURE=""
+POSTURE_EXPLICIT=false
 HOMEBOY_PROJECT_ID="${HOMEBOY_PROJECT_ID:-}"
 DETECTED_RUNTIMES=()
 IS_STUDIO=false
@@ -189,6 +196,11 @@ while [[ $# -gt 0 ]]; do
       RUNTIME="$2"
       shift 2
       ;;
+    --posture)
+      POSTURE="$2"
+      POSTURE_EXPLICIT=true
+      shift 2
+      ;;
     --agent-slug)
       AGENT_SLUG="$2"
       AGENT_SLUG_EXPLICIT=true
@@ -247,6 +259,16 @@ OPTIONS:
                      WordPress install (Studio, MAMP, manual, etc.)
   --runtime <name>   Coding agent runtime (auto-detected if omitted)
                      Available: ${AVAILABLE_RUNTIMES[*]}
+  --posture <name>   Agent's relationship to installed WordPress source.
+                     engineering (default): source is read-only reference and
+                       all code changes go through a Data Machine Code
+                       workspace, git, and GitHub.
+                     managed: the agent edits the live theme and plugins in
+                       place; no workspace, no git, no GitHub, and
+                       data-machine-code is not installed. For managed agentic
+                       hosting where changes are captured out-of-band.
+                     Recorded on the install so upgrades converge without
+                     repeating the flag.
   --agent-slug <s>   Override Data Machine agent slug (default: derived from domain)
   --agent-name <n>   Override Data Machine agent display name (default: blogname)
   --kimaki-unit <u>  Kimaki systemd unit (default: kimaki.service)
@@ -405,6 +427,10 @@ fi
 
 detect_environment
 
+# Posture must resolve BEFORE anything that enforces it: the plugin set, the
+# runtime permission surfaces, and the AGENTS.md guidance all derive from it.
+source_policy_resolve_posture
+
 if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$LOCAL_MODE" = false ]; then
   bridge_load kimaki
   _kimaki_resolve_instance
@@ -436,7 +462,8 @@ if [ "$RUNTIME_ONLY" != true ]; then
   setup_service_permissions
 fi
 
-agents_md_guidance_sync_wordpress_agent_boundaries
+source_policy_record_posture
+guidance_sync_all
 setup_ai_gateway
 
 runtime_install

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -15,7 +15,12 @@ export DRY_RUN=false
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/agents-md-guidance.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/guidance/_dispatch.sh"
+POSTURE="${POSTURE:-engineering}"
 UPDATED_ITEMS=()
 
 VERBOSE=false
@@ -236,7 +241,7 @@ content = path.read_text().replace("\n}, 100 );\n", "\n} );\n")
 content += "\nadd_action( 'unrelated_action', static function () {}, 100 );\n"
 path.write_text(content)
 PY
-agents_md_guidance_sync_wordpress_agent_boundaries
+guidance_sync_all
 assert_php_lint "$MU_FILE" "WordPress boundary guidance parses with php -l"
 if grep -q '^}, 100 );$' "$MU_FILE"; then
   echo "  ok   existing action wrapper normalized to priority 100"
@@ -258,7 +263,7 @@ else
 fi
 
 HASH_BEFORE=$(file_hash "$MU_FILE")
-agents_md_guidance_sync_wordpress_agent_boundaries
+guidance_sync_all
 HASH_AFTER=$(file_hash "$MU_FILE")
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "WordPress boundary sync is idempotent"
 

--- a/tests/claude-code-permissions.sh
+++ b/tests/claude-code-permissions.sh
@@ -30,6 +30,9 @@ log() { :; }
 warn() { printf '%s\n' "$*" >&2; }
 
 source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+POSTURE="${POSTURE:-engineering}"
 source "$SCRIPT_DIR/runtimes/claude-code.sh"
 
 runtime_install_hooks

--- a/tests/codex-permissions.sh
+++ b/tests/codex-permissions.sh
@@ -24,6 +24,9 @@ UPDATED_ITEMS=()
 log() { :; }
 warn() { printf '%s\n' "$*" >&2; }
 source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+POSTURE="${POSTURE:-engineering}"
 source "$SCRIPT_DIR/runtimes/codex.sh"
 
 runtime_generate_config

--- a/tests/codex-runtime.sh
+++ b/tests/codex-runtime.sh
@@ -29,6 +29,9 @@ printf 'memory context sentinel\n' > "$SITE_PATH/wp-content/uploads/datamachine-
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+POSTURE="${POSTURE:-engineering}"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/runtime-signature.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/runtimes/codex.sh"

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -16,7 +16,12 @@ export DRY_RUN=false
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/agents-md-guidance.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/guidance/_dispatch.sh"
+POSTURE="${POSTURE:-engineering}"
 UPDATED_ITEMS=()
 
 log() { :; }
@@ -44,7 +49,7 @@ SH
 chmod +x "$TMP/bin/homeboy"
 
 echo "==> homeboy present: register concise routing guidance"
-PATH="$TMP/bin:$PATH" agents_md_guidance_sync_homeboy_cli
+PATH="$TMP/bin:$PATH" guidance_sync_unit homeboy
 
 if ! php -l "$MU_FILE" >/dev/null 2>&1; then
   echo "  FAIL generated guidance does not parse"
@@ -100,7 +105,7 @@ assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives concise Homeboy routin
 
 echo "==> re-sync with homeboy present (idempotent)"
 HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)
-PATH="$TMP/bin:$PATH" agents_md_guidance_sync_homeboy_cli
+PATH="$TMP/bin:$PATH" guidance_sync_unit homeboy
 HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-sync"
 
@@ -122,7 +127,7 @@ for tool in grep mktemp mv cmp chmod python3 md5sum cat sed awk rm cut stat dirn
   resolved="$(command -v "$tool" 2>/dev/null || true)"
   [ -n "$resolved" ] && ln -sf "$resolved" "$SANDBIN/$tool"
 done
-PATH="$SANDBIN" agents_md_guidance_sync_homeboy_cli
+PATH="$SANDBIN" guidance_sync_unit homeboy
 
 if grep -q "BEGIN agents-md-guidance:homeboy-cli" "$MU_FILE"; then
   echo "  FAIL homeboy-cli block remained after absence sync"

--- a/tests/opencode-local-plugin-path.sh
+++ b/tests/opencode-local-plugin-path.sh
@@ -30,6 +30,9 @@ warn() { printf '%s\n' "$*" >&2; }
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+POSTURE="${POSTURE:-engineering}"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/runtimes/opencode.sh"
 
 runtime_generate_config

--- a/tests/posture.sh
+++ b/tests/posture.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+# tests/posture.sh — installed-source posture regression coverage (#314).
+#
+# Two properties matter here and neither is obvious from reading one file:
+#
+#   1. Engineering output is UNCHANGED. Every existing install is engineering,
+#      so a posture refactor that shifts a single glob is a silent permission
+#      change on every box in the fleet.
+#
+#   2. Managed output AGREES WITH ITSELF. The whole reason lib/source-policy.sh
+#      exists is that the AGENTS.md prose and the enforced runtime permissions
+#      used to be written independently and drifted: h44lacrosse.com shipped an
+#      agent told to edit live theme and plugin files while its opencode.json
+#      denied exactly those two paths. A managed install that says "editable"
+#      in prose and "deny" in permissions is the bug, not a cosmetic mismatch.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+FAILED=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "         got:  $got"
+    echo "         want: $want"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  case "$haystack" in
+    *"$needle"*) echo "  ok   $name" ;;
+    *)
+      echo "  FAIL $name (missing: $needle)"
+      FAILED=$((FAILED + 1))
+      ;;
+  esac
+}
+
+refute_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  case "$haystack" in
+    *"$needle"*)
+      echo "  FAIL $name (unexpectedly present: $needle)"
+      FAILED=$((FAILED + 1))
+      ;;
+    *) echo "  ok   $name" ;;
+  esac
+}
+
+log() { :; }
+warn() { printf '%s\n' "$*" >&2; }
+error() { printf '%s\n' "$*" >&2; return 1; }
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+
+# ===========================================================================
+echo "==> source policy resolves the documented root matrix"
+# ===========================================================================
+
+POSTURE=engineering
+assert_eq "$(source_policy_root_actions | tr '\t' '=' | tr '\n' ' ')" \
+  "wp-content/plugins=deny wp-content/themes=deny wp-includes=deny " \
+  "engineering keeps every installed root read-only"
+source_policy_workspace_enabled \
+  && echo "  ok   engineering has a workspace" \
+  || { echo "  FAIL engineering has a workspace"; FAILED=$((FAILED + 1)); }
+
+POSTURE=managed
+assert_eq "$(source_policy_root_actions | tr '\t' '=' | tr '\n' ' ')" \
+  "wp-content/plugins=allow wp-content/themes=allow wp-includes=deny " \
+  "managed opens themes and plugins but never core"
+source_policy_workspace_enabled \
+  && { echo "  FAIL managed has no workspace"; FAILED=$((FAILED + 1)); } \
+  || echo "  ok   managed has no workspace"
+
+# An unrecognised posture must fall back to the safe (read-only) matrix rather
+# than silently granting write access to a live site.
+POSTURE=nonsense
+assert_eq "$(source_policy_root_actions | tr '\t' '=' | tr '\n' ' ')" \
+  "wp-content/plugins=deny wp-content/themes=deny wp-includes=deny " \
+  "unknown posture degrades to read-only, never to write"
+
+# ===========================================================================
+echo "==> opencode.json permission surface follows posture"
+# ===========================================================================
+
+_opencode_config_for() {
+  local posture="$1" out="$2"
+  (
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+    SITE_PATH="$TMP/site"
+    KIMAKI_DATA_DIR="$TMP/kimaki-data"
+    mkdir -p "$SITE_PATH" "$KIMAKI_DATA_DIR"
+    export SCRIPT_DIR SITE_PATH KIMAKI_DATA_DIR
+    export CHAT_BRIDGE="kimaki" LOCAL_MODE=true DRY_RUN=false
+    export OPENCODE_MODEL="" OPENCODE_SMALL_MODEL=""
+    export DM_WORKSPACE_DIR="$TMP/workspace"
+    export DM_AGENT_FILES=""
+    export WITH_CLAUDE_CODE_AUTH=false RUNTIME="opencode"
+    UPDATED_ITEMS=()
+    POSTURE="$posture"
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/runtimes/opencode.sh"
+    runtime_generate_config
+    cp "$SITE_PATH/opencode.json" "$out"
+  )
+}
+
+ENG_JSON="$(mktemp)"; MGD_JSON="$(mktemp)"
+trap 'rm -f "$ENG_JSON" "$MGD_JSON"' EXIT
+_opencode_config_for engineering "$ENG_JSON"
+_opencode_config_for managed "$MGD_JSON"
+
+assert_eq "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["permission"]["edit"],sort_keys=True))' "$ENG_JSON")" \
+  '{"wp-content/plugins/**": "deny", "wp-content/themes/**": "deny", "wp-includes/**": "deny"}' \
+  "engineering opencode edit map is byte-identical to the pre-refactor rules"
+
+assert_eq "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["permission"]["edit"],sort_keys=True))' "$MGD_JSON")" \
+  '{"wp-content/plugins/**": "allow", "wp-content/themes/**": "allow", "wp-includes/**": "deny"}' \
+  "managed opencode edit map opens the live working tree"
+
+assert_eq "$(python3 -c 'import json,sys; print("yes" if "external_directory" in json.load(open(sys.argv[1]))["permission"] else "no")' "$ENG_JSON")" \
+  "yes" "engineering grants the workspace directory"
+assert_eq "$(python3 -c 'import json,sys; print("yes" if "external_directory" in json.load(open(sys.argv[1]))["permission"] else "no")' "$MGD_JSON")" \
+  "no" "managed grants no workspace directory (there is none)"
+
+# ===========================================================================
+echo "==> claude-code settings.json follows posture, and switching clears denies"
+# ===========================================================================
+
+_claude_settings_for() {
+  local posture="$1" out="$2" seed="${3:-}"
+  (
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+    export SITE_PATH="$TMP/site"
+    export DM_WORKSPACE_DIR="$TMP/workspace"
+    export AGENT_SLUG="builder" DRY_RUN=false IS_STUDIO=false
+    mkdir -p "$SITE_PATH/.claude" "$DM_WORKSPACE_DIR"
+    if [ -n "$seed" ]; then
+      sed "s|SITE_PATH|$SITE_PATH|g" "$seed" > "$SITE_PATH/.claude/settings.json"
+    fi
+    UPDATED_ITEMS=()
+    POSTURE="$posture"
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/runtimes/claude-code.sh"
+    runtime_install_hooks >/dev/null 2>&1
+    python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1])),sort_keys=True))' \
+      "$SITE_PATH/.claude/settings.json" | sed "s|$SITE_PATH|SITE_PATH|g" > "$out"
+  )
+}
+
+CC_ENG="$(mktemp)"; CC_MGD="$(mktemp)"; CC_SEED="$(mktemp)"
+_claude_settings_for engineering "$CC_ENG"
+assert_contains "$(cat "$CC_ENG")" '"Edit(SITE_PATH/wp-content/themes/**)"' \
+  "engineering denies theme edits"
+assert_contains "$(cat "$CC_ENG")" '"Bash(wp datamachine-code workspace:*)"' \
+  "engineering allows the DMC workspace bash surface"
+
+# Seed a settings.json that already carries the engineering denies, then sync
+# under managed. A posture switch has to REMOVE the stale denies; leaving them
+# is precisely the failure mode that blocked h44-bot from its own theme.
+cat > "$CC_SEED" <<'JSON'
+{"permissions":{"deny":["Read(./private/**)","Edit(SITE_PATH/wp-content/plugins/**)","Edit(SITE_PATH/wp-content/themes/**)","Edit(SITE_PATH/wp-includes/**)"]}}
+JSON
+_claude_settings_for managed "$CC_MGD" "$CC_SEED"
+refute_contains "$(cat "$CC_MGD")" '"Edit(SITE_PATH/wp-content/themes/**)"' \
+  "managed sync clears the stale theme deny"
+refute_contains "$(cat "$CC_MGD")" '"Edit(SITE_PATH/wp-content/plugins/**)"' \
+  "managed sync clears the stale plugin deny"
+assert_contains "$(cat "$CC_MGD")" '"Edit(SITE_PATH/wp-includes/**)"' \
+  "managed still denies WordPress core"
+assert_contains "$(cat "$CC_MGD")" '"Read(./private/**)"' \
+  "managed sync preserves unrelated operator denies"
+refute_contains "$(cat "$CC_MGD")" 'datamachine-code workspace' \
+  "managed grants no workspace bash surface"
+rm -f "$CC_ENG" "$CC_MGD" "$CC_SEED"
+
+# ===========================================================================
+echo "==> codex filesystem profile follows posture"
+# ===========================================================================
+
+_codex_config_for() {
+  local posture="$1"
+  (
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+    export SITE_PATH="$TMP/site" DRY_RUN=false
+    mkdir -p "$SITE_PATH/.codex" "$TMP/bin"
+    printf '#!/bin/sh\necho "codex-cli 0.142.5"\n' > "$TMP/bin/codex"
+    chmod +x "$TMP/bin/codex"
+    export PATH="$TMP/bin:$PATH"
+    UPDATED_ITEMS=()
+    POSTURE="$posture"
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/runtimes/codex.sh"
+    runtime_generate_config >/dev/null 2>&1
+    cat "$SITE_PATH/.codex/config.toml"
+  )
+}
+
+CX_ENG="$(_codex_config_for engineering)"
+CX_MGD="$(_codex_config_for managed)"
+assert_contains "$CX_ENG" '"wp-content/themes" = "read"' "engineering codex profile keeps themes read-only"
+assert_contains "$CX_ENG" '"wp-includes" = "read"' "engineering codex profile keeps core read-only"
+refute_contains "$CX_MGD" '"wp-content/themes" = "read"' "managed codex profile drops the theme read-only rule"
+refute_contains "$CX_MGD" '"wp-content/plugins" = "read"' "managed codex profile drops the plugin read-only rule"
+assert_contains "$CX_MGD" '"wp-includes" = "read"' "managed codex profile still protects core"
+
+# ===========================================================================
+echo "==> AGENTS.md guidance agrees with the enforced permissions"
+# ===========================================================================
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/agents-md-guidance.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/guidance/_dispatch.sh"
+
+POSTURE=engineering
+ENG_PROSE="$(guidance_call wordpress-source render)"
+assert_eq "$(guidance_call wordpress-source id)" "wordpress-source" \
+  "section id is stable across postures"
+assert_contains "$ENG_PROSE" "read-only" "engineering prose says read-only"
+assert_contains "$ENG_PROSE" "managed workspace" "engineering prose routes changes to the workspace"
+
+POSTURE=managed
+MGD_PROSE="$(guidance_call wordpress-source render)"
+assert_eq "$(guidance_call wordpress-source id)" "wordpress-source" \
+  "managed variant registers the same section id"
+assert_contains "$MGD_PROSE" '`wp-content/themes/` — **editable**' \
+  "managed prose declares themes editable, matching permission.edit"
+assert_contains "$MGD_PROSE" '`wp-includes/` — WordPress core, **read-only**' \
+  "managed prose keeps core read-only, matching permission.edit"
+assert_contains "$MGD_PROSE" "live the moment you save" \
+  "managed prose states that edits reach production immediately"
+assert_contains "$MGD_PROSE" "never recorded" \
+  "managed prose warns about paths a capture silently skips"
+assert_contains "$MGD_PROSE" "no pull request step" \
+  "managed prose rules out the review workflow rather than leaving it implied"
+refute_contains "$MGD_PROSE" "Make code changes in the configured managed workspace" \
+  "managed prose never routes work to a workspace that does not exist"
+
+# The homeboy unit is engineering-only: its routing advice is about cooking
+# tracked changes in managed worktrees, which does not exist under managed.
+POSTURE=managed
+if guidance_call homeboy applies; then
+  echo "  FAIL homeboy guidance must not apply under managed"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   homeboy guidance does not apply under managed"
+fi
+
+# ===========================================================================
+echo "==> opencode.json reconciler honours posture"
+# ===========================================================================
+
+RECON_IN="$(mktemp)"
+cat > "$RECON_IN" <<'JSON'
+{"permission":{"edit":{"wp-content/plugins/**":"deny","wp-content/themes/**":"deny","wp-includes/**":"deny","custom/**":"ask"}}}
+JSON
+RECON_OUT="$(python3 - "$RECON_IN" <<'PY'
+import importlib.util, json, sys, pathlib
+spec = importlib.util.spec_from_file_location("repair", pathlib.Path("lib/repair-opencode-json.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+data = json.load(open(sys.argv[1]))
+print(json.dumps(mod.expected_edit_permission(data, "managed"), sort_keys=True))
+PY
+)"
+assert_eq "$RECON_OUT" \
+  '{"custom/**": "ask", "wp-content/plugins/**": "allow", "wp-content/themes/**": "allow", "wp-includes/**": "deny"}' \
+  "reconciler rewrites managed rules and preserves operator rules"
+rm -f "$RECON_IN"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo
+  echo "FAILED: $FAILED assertion(s)"
+  exit 1
+fi
+
+echo
+echo "OK: all posture assertions passed"

--- a/tests/worktree-context-projections.sh
+++ b/tests/worktree-context-projections.sh
@@ -8,6 +8,9 @@ trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$TMP/site/wp-content/mu-plugins" "$TMP/worktree/.git"
 export SITE_PATH="$TMP/site" DRY_RUN=false
 source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+POSTURE="${POSTURE:-engineering}"
 source "$SCRIPT_DIR/lib/runtime-signature.sh"
 log() { :; }
 warn() { :; }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature agents-md-guidance agents-md-backups; do
+for lib in common detect source-policy wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature agents-md-guidance agents-md-backups; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -75,6 +75,11 @@ done
 # render templates, sync, systemd/launchd update, and summary blocks.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/bridges/_dispatch.sh"
+
+# Guidance dispatcher — auto-discovers guidance/*.sh AGENTS.md section units.
+# Adding a section is "drop a file in guidance/" — no edit here.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/guidance/_dispatch.sh"
 source "$SCRIPT_DIR/services/datamachine-worker.sh"
 
 # Discover available runtimes
@@ -99,6 +104,8 @@ WITH_AI_GATEWAY=false
 WITH_CLAUDE_CODE_AUTH=true
 ROTATE_AI_GATEWAY_TOKEN=false
 SHOW_HELP=false
+POSTURE=""
+POSTURE_EXPLICIT=false
 
 # Defaults setup.sh expects (detect.sh reads these)
 LOCAL_MODE=false
@@ -139,6 +146,7 @@ while [[ $# -gt 0 ]]; do
     --ai-gateway-model) AI_GATEWAY_ROUTE_MODEL="$2"; shift 2 ;;
     --ai-gateway-opencode-model) AI_GATEWAY_MODEL_ID="$2"; shift 2 ;;
     --rotate-ai-gateway-token) ROTATE_AI_GATEWAY_TOKEN=true; shift ;;
+    --posture)       POSTURE="$2"; POSTURE_EXPLICIT=true; shift 2 ;;
     --runtime)       RUNTIME="$2"; shift 2 ;;
     --wp-path)       EXISTING_WP="$2"; shift 2 ;;
     --agent-slug)    AGENT_SLUG="$2"; AGENT_SLUG_EXPLICIT=true; shift 2 ;;
@@ -180,6 +188,8 @@ USAGE:
                                 only adds missing managed entries, never
                                 removes user-added plugins.
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
+  ./upgrade.sh --posture <name> Force install posture: engineering | managed
+                               (default: the posture recorded at setup time)
   ./upgrade.sh --wp-path <path> Override detected WordPress path
   ./upgrade.sh --agent-slug <s> Override Data Machine agent slug
   ./upgrade.sh --kimaki-unit <u> Target Kimaki systemd unit
@@ -327,6 +337,13 @@ source "$RUNTIME_FILE"
 # Run detect_environment first — it auto-sets LOCAL_MODE=true on macOS,
 # which the chat bridge detection below depends on to pick the right branch.
 detect_environment
+
+# Posture drives the plugin set, every runtime permission surface, and the
+# AGENTS.md guidance. Resolve it from the value recorded at setup time so an
+# upgrade converges a managed install instead of silently reverting it to
+# engineering; --posture overrides and re-records.
+source_policy_resolve_posture
+source_policy_record_posture
 
 # Detect chat bridge from installed services / installed binaries via the
 # bridges/_dispatch.sh registry walk. See bridge_detect_local /
@@ -640,7 +657,7 @@ for item in data:
     if [ -n "$CLAUDE_CODE_AUTH_PLUGIN" ]; then
       claude_auth_arg_display=" --claude-code-auth-plugin $CLAUDE_CODE_AUTH_PLUGIN"
     fi
-    echo -e "${BLUE}[dry-run]${NC} Would run: python3 $HELPER --file $OPENCODE_JSON_FILE --runtime $RUNTIME_ARG --chat-bridge $BRIDGE_ARG --kimaki-plugins-dir $PLUGINS_DIR$claude_auth_arg_display$managed_arg_display $MODE_FLAG"
+    echo -e "${BLUE}[dry-run]${NC} Would run: python3 $HELPER --file $OPENCODE_JSON_FILE --runtime $RUNTIME_ARG --chat-bridge $BRIDGE_ARG --posture ${POSTURE:-engineering} --kimaki-plugins-dir $PLUGINS_DIR$claude_auth_arg_display$managed_arg_display $MODE_FLAG"
     local dry_out
     local managed_args=()
     if [ -n "$MANAGED_INSTRUCTIONS_FILE" ]; then
@@ -650,6 +667,7 @@ for item in data:
       --file "$OPENCODE_JSON_FILE" \
       --runtime "$RUNTIME_ARG" \
       --chat-bridge "$BRIDGE_ARG" \
+      --posture "${POSTURE:-engineering}" \
       --kimaki-plugins-dir "$PLUGINS_DIR" \
       "${claude_code_auth_args[@]}" \
       "${managed_args[@]}" 2>&1 || true)
@@ -667,6 +685,7 @@ for item in data:
     --file "$OPENCODE_JSON_FILE" \
     --runtime "$RUNTIME_ARG" \
     --chat-bridge "$BRIDGE_ARG" \
+    --posture "${POSTURE:-engineering}" \
     --kimaki-plugins-dir "$PLUGINS_DIR" \
     "${claude_code_auth_args[@]}" \
     "${managed_args[@]}" \
@@ -788,7 +807,7 @@ regenerate_agents_md() {
     return 0
   fi
 
-  agents_md_guidance_sync_wordpress_agent_boundaries
+  guidance_sync_all
   sync_homeboy_availability
   sync_homeboy_agents_md_guidance
 


### PR DESCRIPTION
Closes #314.

## The bug this starts from

`h44lacrosse.com` is managed agentic hosting: h44-bot edits the live theme and plugins in place, and `chubes4/h44-lacrosse` `.github/workflows/harvest.yml` captures the result into git out-of-band (`homeboy harvest --check` / `--apply`, daily + `workflow_dispatch`, read-only over SSH, deploy stays manual). The agent has no repo, no homeboy, and no role in that pipeline.

The install wp-coding-agents gave it says the opposite three times over. Live `opencode.json`:

```json
"permission": {
  "external_directory": { "/var/lib/datamachine/workspace/**": "allow" },
  "edit": {
    "wp-content/plugins/**": "deny",
    "wp-content/themes/**": "deny",
    "wp-includes/**": "deny"
  }
}
```

Hard-denied on exactly the two trees it exists to edit, while granted a workspace directory that is empty (`workspace list` → "No repos in workspace"). The AGENTS.md prose separately told it to route changes through a workspace and pull requests.

## Why a refactor rather than a flag

Posture touches five files that had independently hardcoded the same three globs:

| enforcement point | file |
| --- | --- |
| OpenCode `permission.edit` | `runtimes/opencode.sh` |
| Claude Code `permissions.deny` | `runtimes/claude-code.sh` |
| Codex filesystem profile | `runtimes/codex.sh` |
| `opencode.json` reconciliation | `lib/repair-opencode-json.py` |
| AGENTS.md prose | `lib/agents-md-guidance.sh` |

Bolting `if posture` onto each is how prose and permissions drift apart again.

## What changed

**`lib/source-policy.sh`** — one answer, five consumers. Returns the root/action matrix and whether a workspace exists for the active posture. This de-duplicates policy that was *already* duplicated before posture existed.

**`guidance/`** — AGENTS.md content split out of the mu-plugin mechanism, following the existing `runtimes/` and `bridges/_dispatch.sh` pattern. A section whose prose depends on posture ships `<id>.<posture>.sh`; posture-neutral sections ship `<id>.sh`. `lib/agents-md-guidance.sh` is now mechanism only and no longer knows what WordPress or Homeboy are. `setup.sh`/`upgrade.sh` call `guidance_sync_all`.

**`lib/data-machine.sh`** — `managed` skips data-machine-code on setup *and* upgrade. Hand-deactivating never stuck because `update_plugin_to_latest_tag` activates. AGENTS.md composition is unaffected: data-machine core registers the composable file itself behind the same `DATAMACHINE_COMPOSE_AGENTS_MD` gate, so a managed install still composes correctly, just without the workspace architecture.

**Posture persistence** — recorded as a wp option at setup (mirroring `datamachine_code_homeboy_available`), so `upgrade.sh` converges a managed box instead of silently reverting it. `--posture` on either script overrides and re-records.

**Managed guidance content** — carries the facts the engineering variant has no reason to state: edits are live on save, work is unbacked until captured, rollback is an operator action, and the paths a capture silently skips (`vendor/`, `node_modules/`, lockfiles, manifests, build output) are *destroyed by the next deploy* if edited live.

## Posture matrix

| | `engineering` (default) | `managed` |
| --- | --- | --- |
| `wp-content/themes/`, `wp-content/plugins/` | read-only | **editable** |
| `wp-includes/` | read-only | read-only |
| data-machine-code | installed | not installed |
| workspace / git / GitHub | the workflow | absent |

## Verification

- **Engineering output is unchanged.** Generated `opencode.json` and `.claude/settings.json` diffed byte-for-byte against generation from `origin/main` (modulo tmpdir paths): identical. Codex covered by the existing `tests/codex-permissions.sh`.
- **`tests/posture.sh`** (new, wired into `shell.yml`) pins both invariants: engineering byte-identity, and agreement between managed prose and managed permissions. Also covers an unknown posture degrading to read-only rather than to write, and a posture switch actively *clearing* stale Claude Code denies — leaving them behind is the exact failure mode that blocked h44-bot.
- Full `tests/*.sh` run: no new failures. Seven pre-existing failures (`agents-md-backup-retention`, `carried-claude-code-plugin`, `cli-channel-binary-path`, `datamachine-worker`, `homeboy-dmc-provider`, `homeboy-project-id`, `kimaki-agent-fallback`) fail identically on `origin/main` in this environment; none are in `shell.yml`.
- `bash -n` clean across every `.sh`.

## Follow-up, not in this PR

Applying `--posture managed` to the live h44 box is an operator action and is deliberately left out.