### PR TITLE
Set KIMAKI_NO_DEFAULT_CHANNEL on managed Kimaki services

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -123,6 +123,14 @@ jobs:
       - name: Run tests/kimaki-dispatch-helper-health.sh
         run: ./tests/kimaki-dispatch-helper-health.sh
 
+  kimaki-no-default-channel:
+    name: Kimaki default-channel opt-out (remorses/kimaki#175)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/kimaki-no-default-channel.sh
+        run: ./tests/kimaki-no-default-channel.sh
+
   posture:
     name: installed-source posture (#314)
     runs-on: ubuntu-latest

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -797,11 +797,18 @@ _kimaki_install_systemd() {
   local DATAMACHINE_WP_CMD
   DATAMACHINE_WP_CMD=$(_kimaki_datamachine_wp_cmd)
 
+# Kimaki recreates a general-purpose #kimaki-<bot> channel, welcome message,
+# and tutorial thread on every start. On a wp-coding-agents install the real
+# project channel is the site channel, so the default is pure noise. Upstream
+# added this opt-out in remorses/kimaki@7a9ab1e8 (fixes remorses/kimaki#175);
+# it is inert on kimaki builds that predate it, so setting it unconditionally
+# is safe and converges the moment the host upgrades.
   local ENV_BLOCK="Environment=HOME=$SERVICE_HOME
 Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
 Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
-Environment=DATAMACHINE_WP_CMD=$DATAMACHINE_WP_CMD"
+Environment=DATAMACHINE_WP_CMD=$DATAMACHINE_WP_CMD
+Environment=KIMAKI_NO_DEFAULT_CHANNEL=1"
   if [ -n "${AGENT_SLUG:-}" ]; then
     ENV_BLOCK="$ENV_BLOCK
 Environment=DATAMACHINE_AGENT_SLUG=$AGENT_SLUG"
@@ -1097,7 +1104,8 @@ bridge_update_systemd() {
 Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
 Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
-Environment=DATAMACHINE_WP_CMD=$(_kimaki_datamachine_wp_cmd)"
+Environment=DATAMACHINE_WP_CMD=$(_kimaki_datamachine_wp_cmd)
+Environment=KIMAKI_NO_DEFAULT_CHANNEL=1"
   if [ -n "${KIMAKI_LOCK_PORT:-}" ]; then
     TEMPLATE_ENV="$TEMPLATE_ENV
 Environment=KIMAKI_LOCK_PORT=$KIMAKI_LOCK_PORT"
@@ -1268,7 +1276,9 @@ $skill_filter_plist_args
         <key>DATAMACHINE_SITE_PATH</key>
         <string>$SITE_PATH</string>
         <key>DATAMACHINE_WP_CMD</key>
-        <string>$datamachine_wp_cmd</string>$(if [ -n "${AGENT_SLUG:-}" ]; then echo "
+        <string>$datamachine_wp_cmd</string>
+        <key>KIMAKI_NO_DEFAULT_CHANNEL</key>
+        <string>1</string>$(if [ -n "${AGENT_SLUG:-}" ]; then echo "
         <key>DATAMACHINE_AGENT_SLUG</key>
         <string>$AGENT_SLUG</string>"; fi)$(if [ -n "${KIMAKI_BOT_TOKEN:-}" ]; then echo "
         <key>KIMAKI_BOT_TOKEN</key>

--- a/tests/__snapshots__/bridges/kimaki-launchd
+++ b/tests/__snapshots__/bridges/kimaki-launchd
@@ -35,6 +35,8 @@
         <string>/var/www/site</string>
         <key>DATAMACHINE_WP_CMD</key>
         <string>wp</string>
+        <key>KIMAKI_NO_DEFAULT_CHANNEL</key>
+        <string>1</string>
         <key>DATAMACHINE_AGENT_SLUG</key>
         <string>intelligence-chubes4</string>
     </dict>

--- a/tests/kimaki-no-default-channel.sh
+++ b/tests/kimaki-no-default-channel.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# tests/kimaki-no-default-channel.sh — KIMAKI_NO_DEFAULT_CHANNEL is managed env.
+#
+# Kimaki recreates a general-purpose #kimaki-<bot> channel, welcome message, and
+# tutorial thread on every start. remorses/kimaki@7a9ab1e8 added
+# KIMAKI_NO_DEFAULT_CHANNEL=1 to opt out (fixes remorses/kimaki#175).
+#
+# The variable has to be in THREE render sites and it is easy to add it to only
+# one: the fresh systemd unit, the upgrade-time template that merges into an
+# already-installed unit, and the launchd plist. Only the launchd plist is
+# covered by tests/bridge-render.sh snapshots, because bridge_render_systemd
+# takes its env block as an argument rather than building it. That gap is what
+# this file closes — an install that only gets the variable on a fresh setup
+# leaves every existing host noisy forever.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/bridges/_dispatch.sh"
+source "$SCRIPT_DIR/bridges/kimaki.sh"
+
+FAILED=0
+check() {
+  if [ "$1" -eq 0 ]; then
+    echo "  ok   $2"
+  else
+    echo "  FAIL $2"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "==> upgrade merges the opt-out into an already-installed unit"
+
+SYSTEMD_UNIT_DIR="$TMP/systemd"
+mkdir -p "$SYSTEMD_UNIT_DIR" "$TMP/site"
+
+# A unit as it exists on a host installed before the opt-out shipped: no
+# KIMAKI_NO_DEFAULT_CHANNEL, plus an operator-owned variable that must survive.
+cat > "$SYSTEMD_UNIT_DIR/kimaki.service" <<EOF
+[Service]
+User=root
+WorkingDirectory=$TMP/site
+Environment=HOME=/root
+Environment=PATH=/usr/bin:/bin
+Environment=KIMAKI_DATA_DIR=/root/.kimaki
+Environment=DATAMACHINE_SITE_PATH=$TMP/site
+Environment=DATAMACHINE_WP_CMD=wp
+Environment=HOST_CUSTOM=preserved
+ExecStart=/usr/bin/kimaki --data-dir /root/.kimaki --auto-restart
+EOF
+
+unset KIMAKI_UNIT KIMAKI_DATA_DIR KIMAKI_LOCK_PORT AGENT_SLUG
+initialize_kimaki_overrides
+KIMAKI_UNIT=kimaki.service
+SITE_PATH="$TMP/site"
+SERVICE_USER=root
+SERVICE_HOME=/root
+SERVICE_USER_FORCED=true
+LOCAL_MODE=false
+KIMAKI_DATA_DIR=/root/.kimaki
+KIMAKI_DATA_DIR_EXPLICIT=false
+KIMAKI_LOCK_PORT=""
+KIMAKI_LOCK_PORT_EXPLICIT=false
+AGENT_SLUG=""
+AGENT_SLUG_EXPLICIT=false
+KIMAKI_CONFIG_DIR=/opt/kimaki-config
+KIMAKI_BIN=/usr/bin/kimaki
+KIMAKI_SYSTEM_PREFIX_BINS="$TMP/no-kimaki"
+PATH=/usr/bin:/bin
+DRY_RUN=false
+TIMESTAMP="test"
+UPDATED_ITEMS=()
+WP_CMD=wp
+IS_STUDIO=false
+systemctl() { :; }
+
+bridge_update_systemd
+
+UNIT="$SYSTEMD_UNIT_DIR/kimaki.service"
+[ "$(grep -c '^Environment=KIMAKI_NO_DEFAULT_CHANNEL=1$' "$UNIT")" -eq 1 ]
+check $? "upgrade adds the opt-out exactly once"
+grep -q '^Environment=HOST_CUSTOM=preserved$' "$UNIT"
+check $? "operator-owned env survives the merge"
+
+# Re-running must not accumulate duplicates.
+bridge_update_systemd
+[ "$(grep -c '^Environment=KIMAKI_NO_DEFAULT_CHANNEL=1$' "$UNIT")" -eq 1 ]
+check $? "re-running upgrade does not duplicate the opt-out"
+
+echo "==> launchd plist carries the opt-out"
+
+_kimaki_ai_gateway_launchd_env_xml() { :; }
+PLIST="$(SITE_PATH="$TMP/site" KIMAKI_DATA_DIR="$TMP/.kimaki" KIMAKI_BIN=/usr/bin/kimaki \
+  bridge_render_launchd com.wp.kimaki 2>/dev/null)"
+printf '%s' "$PLIST" | grep -q '<key>KIMAKI_NO_DEFAULT_CHANNEL</key>'
+check $? "launchd plist declares the opt-out key"
+printf '%s' "$PLIST" | grep -A1 '<key>KIMAKI_NO_DEFAULT_CHANNEL</key>' | grep -q '<string>1</string>'
+check $? "launchd plist sets it to 1"
+
+echo "==> fresh systemd install declares the opt-out"
+
+# _kimaki_install_systemd builds its env block inline and has heavy side
+# effects, so assert against the source of the block rather than executing it.
+# Both systemd env blocks must carry the key; a render site that forgets it is
+# the exact regression this guards.
+[ "$(grep -c '^Environment=KIMAKI_NO_DEFAULT_CHANNEL=1"\?$' "$SCRIPT_DIR/bridges/kimaki.sh")" -eq 2 ]
+check $? "both systemd env blocks (fresh install + upgrade template) set it"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo
+  echo "FAILED: $FAILED assertion(s)"
+  exit 1
+fi
+
+echo
+echo "OK: KIMAKI_NO_DEFAULT_CHANNEL is managed in every render site"


### PR DESCRIPTION
Kimaki recreates a general-purpose `#kimaki-<bot>` channel, welcome message, and tutorial thread on every start. On a wp-coding-agents install the real project channel is the site channel, so the default is pure noise — it has been reappearing on every restart of every managed install since setup.

`remorses/kimaki@7a9ab1e8` added `KIMAKI_NO_DEFAULT_CHANNEL=1` as the supported opt-out (fixes `remorses/kimaki#175`). This sets it.

## Three render sites, not one

| site | function |
| --- | --- |
| fresh systemd unit | `_kimaki_install_systemd` → `ENV_BLOCK` |
| upgrade-time merge into an installed unit | `bridge_update_systemd` → `TEMPLATE_ENV` |
| launchd plist | `bridge_render_launchd` |

The middle one is the one that matters most and the easiest to miss. Every host that already exists got its unit written before the opt-out was available, so an implementation that only touches the fresh-install path would fix nothing on any box currently running.

## Inert today, correct tomorrow

`7a9ab1e8` lands after `release: kimaki@0.23.1` and still carries an unconsumed changeset, so the variable is **not in any published Kimaki**. An unknown env var is ignored, so this is a no-op on current builds and self-activates the moment a host upgrades.

That is deliberate. The alternative I started with was a polling script that hunted the channel down and deleted it after startup — more moving parts, racy, and obsolete the day upstream shipped the flag. A declarative `Environment=` line has no runtime behavior to go wrong.

## Test

`tests/bridge-render.sh` snapshots only reach the launchd plist: `bridge_render_systemd` takes its env block as an *argument* rather than building it, so neither systemd path is snapshot-covered. That gap is why the new test exists.

`tests/kimaki-no-default-channel.sh` drives the real `bridge_update_systemd` against a unit written the way a pre-opt-out host has it, and asserts:

- the variable is merged in, **exactly once**
- an operator-owned `Environment=HOST_CUSTOM=` line survives the merge
- a second run does not duplicate it (the merge reports `unchanged`)
- the launchd plist declares the key and sets it to `1`
- both systemd env blocks declare it — so a future fourth render site or a dropped one is caught

Verified non-vacuous: reverting just the `TEMPLATE_ENV` line makes the suite exit 1.

The `kimaki-launchd` snapshot is refreshed for the new key. `bridge-render`, `kimaki-multi-instance`, `kimaki-launchd-start`, `service-identity-adoption`, and `posture` all still pass; `bash -n` clean across the repo.

## Follow-up

Applying this to h44lacrosse.com is an operator action and is not part of this PR. It will not silence that box until Kimaki ships a release containing `7a9ab1e8`.