### PR TITLE
Scope managed posture to declared owned sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ operator-entrypoints/wp-coding-agents-setup/setup.md
 | --- | --- |
 | `--runtime <name>` | Coding runtime: `opencode`, `claude-code`, or `codex`. Auto-detected when omitted. |
 | `--posture <name>` | `engineering` (default) or `managed`. See [Install Posture](#install-posture). |
+| `--managed-source <path>` | wp-content path the site owns and may edit under `--posture managed`. Repeatable. |
 | `--local` | Local machine mode. Skips server infrastructure. |
 | `--existing` | Add to an existing WordPress install. |
 | `--wp-path <path>` | WordPress root path. Implies `--existing`. |
@@ -191,25 +192,52 @@ guidance the agent reads.
 
 | | `engineering` (default) | `managed` |
 | --- | --- | --- |
-| `wp-content/themes/`, `wp-content/plugins/` | read-only reference | **editable in place** |
+| `wp-content/themes/`, `wp-content/plugins/` | read-only reference | read-only **except declared owned paths** |
 | `wp-includes/` | read-only | read-only |
 | Data Machine Code | installed | not installed |
 | Workspace, git, GitHub | the agent's workflow | not present |
 | How changes reach version control | the agent commits and opens pull requests | captured out-of-band by the operator |
+| Runtimes | all | `opencode` only |
 
 **Engineering** is the developer setup: the installed tree is reference
 material, and every code change happens in a Data Machine Code workspace so it
 is tracked in git and reviewed through GitHub.
 
 **Managed** is for managed agentic hosting, where a non-technical owner should
-never have to deal with pull requests. The agent edits the live theme and
+never have to deal with pull requests. The agent edits the site's own theme and
 plugins directly and its changes are live on save; something outside the box —
 for example a scheduled `homeboy harvest` — captures them into git as restore
 points.
 
+Managed does **not** open `wp-content`. Those directories also hold commerce and
+payment plugins, third-party code, the stock themes, and the agent's own Data
+Machine runtime — none of which the site owns, none of which the operator's
+capture records, and all of which an update would overwrite anyway. Instead you
+declare exactly what the site owns:
+
+```bash
+./setup.sh --posture managed \
+  --managed-source wp-content/themes/acme \
+  --managed-source wp-content/plugins/acme-core
+```
+
+Everything else stays read-only. **The declared set must match what the
+operator's capture records** — a path the agent can edit but nothing records is
+a path where it silently loses work. Declaring nothing fails closed: the agent
+gets no editable source and the generated guidance says so.
+
 A single source of truth (`lib/source-policy.sh`) derives the runtime
-permissions and the generated guidance from the chosen posture, so the prose
-cannot tell the agent to do something the permissions then block.
+permissions and the generated guidance from the chosen posture and that
+declared set, so the prose cannot tell the agent to do something the
+permissions then block — or imply a directory is editable when only two paths
+inside it are.
+
+Managed is currently supported on the `opencode` runtime only. OpenCode
+evaluates permissions with `findLast` over rules in config key order, so a
+narrow allow written after a broad deny wins. Claude Code treats deny as
+absolute and Codex has no documented precedence for overlapping filesystem
+entries, so both refuse managed posture rather than emit a permission set whose
+behavior on a production site is unverified.
 
 The chosen posture is recorded on the install, so `./upgrade.sh` converges to it
 without repeating the flag. Pass `--posture` to either script to change it.

--- a/guidance/wordpress-source.managed.sh
+++ b/guidance/wordpress-source.managed.sh
@@ -1,51 +1,75 @@
 #!/bin/bash
 # guidance/wordpress-source.managed.sh — installed WordPress source, managed posture.
 #
-# Managed agentic hosting: the agent edits the live theme and plugins in place at
-# the owner's request. There is no workspace, no git, and no GitHub in its world.
-# Matches the permissions lib/source-policy.sh hands the runtimes for this
-# posture: themes and plugins editable, wp-includes still read-only.
+# Managed agentic hosting: the agent edits the site's OWN theme and plugins in
+# place at the owner's request. There is no workspace, no git, and no GitHub in
+# its world.
 #
-# This prose deliberately carries facts the engineering variant has no reason to
-# state. An agent editing production needs to know that its changes are live on
-# save, that they are unbacked until captured, and which paths a capture will
-# silently skip. Omitting those is how an agent loses a day of work in a path
-# nobody told it was excluded.
+# The editable set is enumerated from source_policy_owned_sources, never
+# described as a directory. An earlier version of this file said "this site's
+# theme and plugins" while the permission layer opened `wp-content/plugins/**`
+# wholesale — which on a real install meant WooCommerce, a payment gateway, and
+# the agent's own Data Machine runtime. Prose that generalises where the policy
+# enumerates is how that gap opens. If a path is not in the declared set it is
+# not editable, and this section must say so by name.
 
 guidance_id() { printf 'wordpress-source'; }
 guidance_priority() { printf '1'; }
 guidance_label() { printf 'WordPress Source'; }
-guidance_description() { printf 'Live-edit boundaries and production contract for installed WordPress source.'; }
-guidance_freshness() { printf 'static'; }
-guidance_conditions() { printf 'Registered by wp-coding-agents on managed-posture installations, where the agent edits live site source directly.'; }
+guidance_description() { printf 'Editable owned source, read-only everything else, and the live-production contract.'; }
+guidance_freshness() { printf 'conditional'; }
+guidance_conditions() { printf 'Registered on managed-posture installations; the editable path list is generated from the declared managed sources.'; }
 
 guidance_render() {
-  cat <<'MD'
-## WordPress Source (Live, Editable)
+  local owned
+  owned="$(source_policy_owned_sources)"
 
-This site's theme and plugins are yours to edit directly. The installed tree is the working tree — there is no separate checkout, no workspace, and no pull request step.
+  printf '%s\n' '## WordPress Source'
+  printf '\n'
 
-- `wp-content/themes/` — **editable**, this site's own theme source
-- `wp-content/plugins/` — **editable**, this site's own plugin source
-- `wp-includes/` — WordPress core, **read-only**. Never edit core; change your theme or plugin instead.
+  if [ -z "$owned" ]; then
+    # Fail closed, loudly. Never imply a directory is editable.
+    printf '%s\n' 'This install declares no editable source. Every file under `wp-content/` and `wp-includes/` is **read-only** to you.'
+    printf '\n'
+    printf '%s\n' 'Read them freely to verify APIs, hooks, and runtime behavior. If a task requires changing code, stop and tell the operator that no editable source is configured.'
+    return 0
+  fi
 
-Read the installed source directly to verify APIs, hooks, and runtime behavior rather than relying on assumptions.
-
-### Working on production
-
-- **Your edits are live the moment you save them.** There is no staging environment, no review gate, and no deploy step between you and the public site. A syntax error is a down site.
-- **Verify before you leave a change in place.** Load the affected page or run the relevant WP-CLI command. You are the only check that runs before visitors see it.
-- **Work is unbacked until it is captured.** Changes are harvested into version control out-of-band on a schedule the operator owns, and each capture becomes a restore point. Between your edit and the next capture, the live file is the only copy.
-- **Rollback is an operator action.** You cannot revert to a previous restore point yourself. If something breaks and you cannot fix it forward, say so plainly and immediately rather than continuing to edit.
-
-### Changes that will not be captured
-
-Dependency trees, lockfiles, and build output are installed or generated rather than authored, so a capture skips them. Editing them on the live site produces a change that is **never recorded and is destroyed by the next deploy**:
-
-- `vendor/` and `node_modules/` — installed dependency trees
-- `composer.lock`, `package-lock.json`, `package.json` — dependency manifests
-- generated build output
-
-If a task genuinely requires changing one of these, stop and tell the operator. It needs to happen in the source repository, not here.
-MD
+  printf '%s\n' 'You edit this site directly. There is no separate checkout, no workspace, and no pull request step.'
+  printf '\n'
+  printf '%s\n' '### Editable — this is the complete list'
+  printf '\n'
+  printf '%s\n' 'These are the source trees this site owns. Nothing else is editable, no matter where it lives:'
+  printf '\n'
+  printf '%s\n' "$owned" | while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    printf -- '- `%s/`\n' "$path"
+  done
+  printf '\n'
+  printf '%s\n' '### Read-only — everything else'
+  printf '\n'
+  printf '%s\n' 'Read these to verify APIs, hooks, conventions, and runtime behavior. Never edit them:'
+  printf '\n'
+  printf '%s\n' '- `wp-includes/` — WordPress core.'
+  printf '%s\n' '- The rest of `wp-content/plugins/` — third-party plugins, including commerce and payment code, and the runtime that gives you memory and tools. Editing these breaks your own environment or the site'"'"'s ability to take money, and an update erases the change anyway.'
+  printf '%s\n' '- The rest of `wp-content/themes/` — bundled and third-party themes.'
+  printf '\n'
+  printf '%s\n' 'To change behavior that lives in code you may not edit, change the site'"'"'s own theme or plugin instead — a hook, a filter, or a template override. If that is genuinely impossible, say so rather than editing outside the list.'
+  printf '\n'
+  printf '%s\n' '### Working on production'
+  printf '\n'
+  printf '%s\n' '- **Your edits are live the moment you save them.** There is no staging environment, no review gate, and no deploy step between you and the public site. A syntax error is a down site.'
+  printf '%s\n' '- **Verify before you leave a change in place.** Load the affected page or run the relevant WP-CLI command. You are the only check that runs before visitors see it.'
+  printf '%s\n' '- **Work is unbacked until it is captured.** The editable list above is exactly what the operator'"'"'s out-of-band capture records, and each capture is a restore point. Between your edit and the next capture, the live file is the only copy.'
+  printf '%s\n' '- **Rollback is an operator action.** You cannot restore a previous capture yourself. If something breaks and you cannot fix it forward, say so plainly and immediately rather than continuing to edit.'
+  printf '\n'
+  printf '%s\n' '### Changes that are never captured'
+  printf '\n'
+  printf '%s\n' 'Dependency trees, lockfiles, and build output are installed or generated rather than authored, so a capture skips them even inside the editable list. Editing them produces a change that is **never recorded and is destroyed by the next deploy**:'
+  printf '\n'
+  printf '%s\n' '- `vendor/` and `node_modules/` — installed dependency trees'
+  printf '%s\n' '- `composer.lock`, `package-lock.json`, `package.json` — dependency manifests'
+  printf '%s\n' '- generated build output'
+  printf '\n'
+  printf '%s\n' 'If a task genuinely requires changing one of these, stop and tell the operator. It needs to happen in the source repository, not here.'
 }

--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -77,24 +77,16 @@ MANAGED_KIMAKI_PLUGIN_NAMES = {"dm-context-filter.ts", "dm-agent-sync.ts"}
 OBSOLETE_KIMAKI_PLUGIN_NAMES = {"homeboy-notification-context.ts"}
 DM_MEMORY_MARKER = "/datamachine-files/"
 # Every installed-source root wp-coding-agents manages, in canonical order.
-# Kept in lockstep with lib/source-policy.sh: that file is the single source of
-# truth for which of these the active posture denies, this list is only the key
-# set the reconciler owns and may therefore overwrite.
-MANAGED_EDIT_RULES = (
+# These are denied under BOTH postures. wp-content/plugins holds WooCommerce,
+# payment gateways, and the agent's own Data Machine runtime; wp-content/themes
+# holds the stock bundled themes. Managed hosting does not open these
+# directories — it opens declared paths inside them.
+MANAGED_ROOTS = (
     "wp-content/plugins/**",
     "wp-content/themes/**",
     "wp-includes/**",
 )
-
-# Roots that stay read-only under each posture. `wp-includes` is WordPress core
-# and is never editable; managed hosting hands the agent its own theme and
-# plugins only.
-POSTURE_DENIED_EDIT_RULES = {
-    "engineering": MANAGED_EDIT_RULES,
-    "managed": ("wp-includes/**",),
-}
 DEFAULT_POSTURE = "engineering"
-
 
 def expected_plugins(
     runtime: str,
@@ -373,13 +365,20 @@ def apply_instruction_sync(data: dict, desired: List[str]) -> dict:
     return result
 
 
-def expected_edit_permission(data: dict, posture: str = DEFAULT_POSTURE) -> dict:
-    """Return user edit rules followed by the posture's managed rules.
+def expected_edit_permission(
+    data: dict,
+    posture: str = DEFAULT_POSTURE,
+    managed_sources: List[str] | None = None,
+) -> dict:
+    """Return user edit rules, then the managed roots, then owned-source allows.
 
-    The managed key set is constant across postures so switching an install
-    rewrites every rule rather than leaving a stale deny behind.
+    KEY ORDER IS THE PRECEDENCE MECHANISM. OpenCode evaluates permissions with
+    findLast over a ruleset built in JSON key order, so the broad root denies
+    have to come before the narrower allows that carve exceptions out of them.
+    Emitting the allows first would silently invert the policy.
     """
-    denied = POSTURE_DENIED_EDIT_RULES.get(posture, POSTURE_DENIED_EDIT_RULES[DEFAULT_POSTURE])
+    sources = list(managed_sources or []) if posture == "managed" else []
+    managed_keys = set(MANAGED_ROOTS) | {f"{path}/**" for path in sources}
 
     permission = data.get("permission", {})
     if isinstance(permission, str):
@@ -395,31 +394,51 @@ def expected_edit_permission(data: dict, posture: str = DEFAULT_POSTURE) -> dict
         rules = {
             pattern: action
             for pattern, action in current.items()
-            if pattern not in MANAGED_EDIT_RULES
+            if pattern not in managed_keys and not _is_stale_managed_key(pattern)
         }
     else:
         rules = {}
 
-    for pattern in MANAGED_EDIT_RULES:
-        rules[pattern] = "deny" if pattern in denied else "allow"
+    for pattern in MANAGED_ROOTS:
+        rules[pattern] = "deny"
+    for path in sources:
+        rules[f"{path}/**"] = "allow"
     return rules
 
 
-def check_edit_permission(data: dict, runtime: str, posture: str = DEFAULT_POSTURE) -> dict:
+def _is_stale_managed_key(pattern: str) -> bool:
+    """True for an owned-source allow this install no longer declares.
+
+    Without this a path dropped from --managed-source would keep its allow rule
+    forever, which is the drift the reconciler exists to prevent.
+    """
+    return pattern.startswith(("wp-content/plugins/", "wp-content/themes/")) and pattern.endswith("/**")
+
+
+def check_edit_permission(
+    data: dict,
+    runtime: str,
+    posture: str = DEFAULT_POSTURE,
+    managed_sources: List[str] | None = None,
+) -> dict:
     if runtime != "opencode":
         return {"status": "ok"}
 
     permission = data.get("permission", {})
     current = permission.get("edit") if isinstance(permission, dict) else None
-    expected = expected_edit_permission(data, posture)
+    expected = expected_edit_permission(data, posture, managed_sources)
     return {
         "status": "ok" if current == expected else "needed",
         "expected": expected,
     }
 
 
-def apply_edit_permission(data: dict, posture: str = DEFAULT_POSTURE) -> None:
-    expected = expected_edit_permission(data, posture)
+def apply_edit_permission(
+    data: dict,
+    posture: str = DEFAULT_POSTURE,
+    managed_sources: List[str] | None = None,
+) -> None:
+    expected = expected_edit_permission(data, posture, managed_sources)
     permission = data.get("permission", {})
     if isinstance(permission, str):
         permission = {"*": permission}
@@ -445,8 +464,15 @@ def main() -> int:
     parser.add_argument(
         "--posture",
         default=DEFAULT_POSTURE,
-        choices=sorted(POSTURE_DENIED_EDIT_RULES),
+        choices=["engineering", "managed"],
         help="Installed-source posture for this install (see lib/source-policy.sh)",
+    )
+    parser.add_argument(
+        "--managed-source",
+        action="append",
+        default=[],
+        dest="managed_sources",
+        help="wp-content path this site owns and may edit under managed posture. Repeatable.",
     )
     parser.add_argument(
         "--kimaki-plugins-dir",
@@ -517,7 +543,7 @@ def main() -> int:
     agent_cleanup_result = check_agent_cleanup(data)
     managed_instructions = read_managed_instructions(args.managed_instructions_file)
     instruction_sync_result = check_instruction_sync(data, managed_instructions)
-    edit_permission_result = check_edit_permission(data, args.runtime, args.posture)
+    edit_permission_result = check_edit_permission(data, args.runtime, args.posture, args.managed_sources)
 
     # --- Plugin array check ---
     expected = expected_plugins(
@@ -644,7 +670,7 @@ def main() -> int:
 
     edit_permission_status = "ok"
     if has_edit_permission_drift:
-        apply_edit_permission(data, args.posture)
+        apply_edit_permission(data, args.posture, args.managed_sources)
         edit_permission_status = "synced"
 
     with open(args.file, "w", encoding="utf-8") as fh:

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -44,6 +44,8 @@
 # upgrade.sh has to be able to rediscover without asking again.
 SOURCE_POLICY_OPTION="wp_coding_agents_posture"
 SOURCE_POLICY_DEFAULT_POSTURE="engineering"
+# Newline-separated wp-content paths the site owns under managed posture.
+SOURCE_POLICY_OWNED_OPTION="wp_coding_agents_managed_sources"
 
 # Every installed-source root wp-coding-agents has an opinion about, in the
 # order they are emitted by every consumer. Adding a root here adds it to all
@@ -134,31 +136,171 @@ source_policy_record_posture() {
   fi
 }
 
-# Roots the agent must NOT edit under the active posture.
+# Roots the agent must NOT edit, under EITHER posture.
 #
-# `wp-includes/` is WordPress core and is read-only in BOTH postures. Managed
-# hosting hands the agent its own theme and plugins, never core.
+# This is deliberately every root in both postures. `wp-content/plugins/` holds
+# WooCommerce, payment gateways, and the agent's own Data Machine runtime;
+# `wp-content/themes/` holds the stock bundled themes. None of those belong to
+# the site owner, none are captured by the operator's harvest, and editing them
+# in place produces a change that is destroyed by the next update.
+#
+# Managed hosting does not open these directories. It opens specific declared
+# paths INSIDE them — see source_policy_owned_sources.
 source_policy_read_only_roots() {
-  case "${POSTURE:-$SOURCE_POLICY_DEFAULT_POSTURE}" in
-    managed)
-      printf '%s\n' 'wp-includes'
-      ;;
-    *)
-      _source_policy_all_roots
-      ;;
+  _source_policy_all_roots
+}
+
+# Paths the agent may edit in place, relative to the WordPress root.
+#
+# Empty under engineering. Under managed this is the explicitly declared set of
+# source trees the site owns, e.g.:
+#
+#   wp-content/themes/acme-theme
+#   wp-content/plugins/acme-core
+#
+# INVARIANT: the editable set must equal the set captured by the operator's
+# out-of-band harvest. A path the agent may edit but nothing records is a path
+# where the agent silently loses work — and on a live site that failure is
+# invisible until an update overwrites it. Declaring these explicitly is what
+# keeps the two sets in agreement; there is no reliable way to infer which
+# plugins a site "owns" by inspection, and guessing wrong on a production site
+# is not an acceptable default.
+source_policy_owned_sources() {
+  if ! source_policy_is_managed; then
+    return 0
+  fi
+
+  printf '%s\n' "${MANAGED_SOURCES:-}" | while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    printf '%s\n' "$path"
+  done
+}
+
+source_policy_is_managed() {
+  [ "${POSTURE:-$SOURCE_POLICY_DEFAULT_POSTURE}" = managed ]
+}
+
+# Resolve the declared owned-source set into MANAGED_SOURCES.
+#
+# Precedence mirrors posture: explicit --managed-source flags, then the set
+# recorded on the install, then nothing.
+source_policy_resolve_owned_sources() {
+  if ! source_policy_is_managed; then
+    MANAGED_SOURCES=""
+    return 0
+  fi
+
+  if [ "${MANAGED_SOURCES_EXPLICIT:-false}" = true ]; then
+    MANAGED_SOURCES="$(_source_policy_normalize_sources "${MANAGED_SOURCES:-}")"
+  else
+    MANAGED_SOURCES="$(_source_policy_normalize_sources "$(source_policy_recorded_owned_sources)")"
+  fi
+
+  if [ -z "$MANAGED_SOURCES" ]; then
+    # FAIL CLOSED. A managed install with nothing declared must not fall back
+    # to opening wp-content wholesale; that is how a coding agent ends up with
+    # write access to a payment gateway. Deny everything and make the operator
+    # say what the site owns.
+    warn "Managed posture with no --managed-source declared: the agent will have NO editable source."
+    warn "Declare the site's own theme and plugins, for example:"
+    warn "  --managed-source wp-content/themes/<theme> --managed-source wp-content/plugins/<plugin>"
+    warn "These must match what the operator's harvest captures."
+  fi
+}
+
+_source_policy_normalize_sources() {
+  printf '%s\n' "${1:-}" | tr ' ' '\n' | while IFS= read -r path; do
+    path="${path#./}"
+    path="${path#/}"
+    path="${path%/}"
+    [ -n "$path" ] || continue
+    case "$path" in
+      wp-content/plugins/*/*|wp-content/themes/*/*)
+        warn "  Ignoring managed source '$path': declare the plugin or theme directory itself, not a file inside it" >&2
+        continue
+        ;;
+      wp-content/plugins/*|wp-content/themes/*) ;;
+      *)
+        warn "  Ignoring managed source '$path': must be under wp-content/plugins/ or wp-content/themes/" >&2
+        continue
+        ;;
+    esac
+    printf '%s\n' "$path"
+  done
+}
+
+source_policy_recorded_owned_sources() {
+  if [ "${DRY_RUN:-false}" = true ]; then
+    printf '%s' "${MANAGED_SOURCES:-}"
+    return 0
+  fi
+
+  if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
+    return 0
+  fi
+
+  wp_cmd option get "$SOURCE_POLICY_OWNED_OPTION" 2>/dev/null || true
+}
+
+source_policy_record_owned_sources() {
+  if ! source_policy_is_managed; then
+    return 0
+  fi
+
+  local sources="${MANAGED_SOURCES:-}"
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $SOURCE_POLICY_OWNED_OPTION '<${sources}>'"
+    return 0
+  fi
+
+  if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
+    return 0
+  fi
+
+  if [ "$(source_policy_recorded_owned_sources)" = "$sources" ]; then
+    return 0
+  fi
+
+  if printf '%s' "$sources" | wp_cmd option update "$SOURCE_POLICY_OWNED_OPTION" >/dev/null 2>&1; then
+    log "  Recorded managed sources: $(printf '%s' "$sources" | tr '\n' ' ')"
+    if [ -n "${UPDATED_ITEMS+x}" ]; then
+      UPDATED_ITEMS+=("managed sources")
+    fi
+  else
+    warn "Could not record managed sources — upgrades will fall back to the recorded value or none"
+  fi
+}
+
+# Runtimes whose permission model can express "deny a directory, then allow
+# specific paths inside it".
+#
+# OpenCode can: permission evaluation is `findLast` over a ruleset built in JSON
+# key order (packages/opencode/src/permission/index.ts), so a narrower allow
+# written AFTER a broad deny wins. Key order is therefore load-bearing.
+#
+# Claude Code cannot: deny is absolute and an allow never overrides it, so the
+# same shape would leave the owned paths unusable. Codex filesystem profiles
+# have no documented precedence for overlapping entries either. Rather than emit
+# a permission set whose behavior is unverified on a live production site, those
+# runtimes refuse managed posture outright.
+source_policy_runtime_supports_managed() {
+  case "${1:-${RUNTIME:-}}" in
+    opencode) return 0 ;;
+    *) return 1 ;;
   esac
 }
 
-# Roots the agent may edit in place under the active posture.
-source_policy_editable_roots() {
-  case "${POSTURE:-$SOURCE_POLICY_DEFAULT_POSTURE}" in
-    managed)
-      printf '%s\n' 'wp-content/plugins' 'wp-content/themes'
-      ;;
-    *)
-      : # engineering edits nothing in the installed tree
-      ;;
-  esac
+source_policy_assert_runtime_supports_posture() {
+  if ! source_policy_is_managed; then
+    return 0
+  fi
+
+  if source_policy_runtime_supports_managed "${RUNTIME:-}"; then
+    return 0
+  fi
+
+  error "Managed posture is not supported on the '${RUNTIME:-unknown}' runtime yet — only 'opencode' can express scoped source permissions safely. See lib/source-policy.sh."
 }
 
 # Whether the Data Machine Code workspace (and therefore git/GitHub) is part of
@@ -173,25 +315,27 @@ source_policy_workspace_enabled() {
   esac
 }
 
-# Every managed root paired with its action under the active posture, as
-# tab-separated `<root>\t<deny|allow>` lines in canonical root order.
+# The ordered edit ruleset for the active posture, as tab-separated
+# `<path>\t<deny|allow>` lines.
 #
-# This is the shape the runtimes consume. Policy lives here; FORMATTING stays in
-# each runtime, because each one has its own config dialect (OpenCode JSON,
-# Claude Code Edit() globs, Codex TOML filesystem profiles). Emitting every root
-# rather than only the denied ones means an install that switches posture has
-# the same key set rewritten rather than stale keys left behind.
-source_policy_root_actions() {
-  local root
-  local read_only
-  read_only="$(source_policy_read_only_roots)"
+# ORDER IS LOAD-BEARING. OpenCode resolves permissions with `findLast` over a
+# ruleset built in JSON key order, so every broad deny must be emitted BEFORE
+# the narrower allows that carve exceptions out of it. Consumers must preserve
+# this order verbatim.
+#
+# Engineering emits three denies and nothing else, which is byte-identical to
+# the pre-posture behavior. Managed emits the same three denies, then one allow
+# per declared owned source.
+source_policy_edit_rules() {
+  local path
 
-  while IFS= read -r root; do
-    [ -n "$root" ] || continue
-    if printf '%s\n' "$read_only" | grep -qxF "$root"; then
-      printf '%s\tdeny\n' "$root"
-    else
-      printf '%s\tallow\n' "$root"
-    fi
-  done < <(_source_policy_all_roots)
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    printf '%s\tdeny\n' "$path"
+  done < <(source_policy_read_only_roots)
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    printf '%s\tallow\n' "$path"
+  done < <(source_policy_owned_sources)
 }

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -212,23 +212,20 @@ runtime_install_hooks() {
       ]')
   fi
 
-  # Denies are posture-derived (lib/source-policy.sh). Roots the active posture
-  # allows are subtracted as well as added, so switching an install from
-  # engineering to managed actually clears the old denies instead of leaving
-  # the agent blocked by a rule nothing removes.
+  # Every installed root is denied. Claude Code treats deny as absolute — an
+  # allow never overrides it — so this runtime cannot express "deny the
+  # directory, allow the site's own plugin inside it". That is why
+  # source_policy_assert_runtime_supports_posture refuses managed posture here
+  # rather than emitting a permission set that would silently lock the agent
+  # out of its own source. See lib/source-policy.sh.
   local wordpress_deny_rules='[]'
-  local wordpress_allowed_rules='[]'
-  local _root _action
-  while IFS=$'\t' read -r _root _action; do
-    [ -n "$_root" ] || continue
+  local _path _action
+  while IFS=$'\t' read -r _path _action; do
+    [ -n "$_path" ] || continue
     local _rule
-    _rule=$(jq -n --arg site "$SITE_PATH" --arg root "$_root" '"Edit(\($site)/\($root)/**)"')
-    if [ "$_action" = "deny" ]; then
-      wordpress_deny_rules=$(jq -n --argjson acc "$wordpress_deny_rules" --argjson rule "$_rule" '$acc + [$rule]')
-    else
-      wordpress_allowed_rules=$(jq -n --argjson acc "$wordpress_allowed_rules" --argjson rule "$_rule" '$acc + [$rule]')
-    fi
-  done < <(source_policy_root_actions)
+    _rule=$(jq -n --arg site "$SITE_PATH" --arg root "$_path" '"Edit(\($site)/\($root)/**)"')
+    wordpress_deny_rules=$(jq -n --argjson acc "$wordpress_deny_rules" --argjson rule "$_rule" '$acc + [$rule]')
+  done < <(source_policy_read_only_roots)
 
   local legacy_wordpress_deny_rules
   legacy_wordpress_deny_rules=$(jq -n '[
@@ -248,7 +245,6 @@ runtime_install_hooks() {
     --arg cmd "$hook_cmd" \
     --argjson allow_rules "$workspace_allow_rules" \
     --argjson deny_rules "$wordpress_deny_rules" \
-    --argjson allowed_rules "$wordpress_allowed_rules" \
     --argjson legacy_deny_rules "$legacy_wordpress_deny_rules" \
     --argjson workspace_enabled "$(source_policy_workspace_enabled && echo true || echo false)" \
     '
@@ -264,7 +260,7 @@ runtime_install_hooks() {
       )
 
     | .permissions.deny = (
-        (((.permissions.deny // []) - $legacy_deny_rules - $allowed_rules + $deny_rules) | unique)
+        (((.permissions.deny // []) - $legacy_deny_rules + $deny_rules) | unique)
       )
 
     | .hooks.SessionStart = (

--- a/runtimes/codex.sh
+++ b/runtimes/codex.sh
@@ -111,12 +111,11 @@ runtime_generate_config() {
   # profile; anything the posture makes editable inherits the ":workspace"
   # default. See lib/source-policy.sh.
   local codex_read_roots=""
-  local _root _action
-  while IFS=$'\t' read -r _root _action; do
+  local _root
+  while IFS= read -r _root; do
     [ -n "$_root" ] || continue
-    [ "$_action" = "deny" ] || continue
     codex_read_roots="${codex_read_roots}${_root}"$'\n'
-  done < <(source_policy_root_actions)
+  done < <(source_policy_read_only_roots)
 
   if ! CODEX_READ_ROOTS="$codex_read_roots" python3 - "$config_file" "$CODEX_PERMISSION_START" "$CODEX_PERMISSION_END" <<'PY'
 import os

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -294,15 +294,20 @@ runtime_generate_config() {
     OPENCODE_JSON="$OPENCODE_JSON\n    },"
   fi
   OPENCODE_JSON="$OPENCODE_JSON\n    \"edit\": {"
+  # Key ORDER is the precedence mechanism here, not decoration: OpenCode
+  # evaluates with findLast over a ruleset built in JSON key order
+  # (packages/opencode/src/permission/index.ts), so the broad denies must be
+  # written before the narrower owned-source allows that carve exceptions out
+  # of them. source_policy_edit_rules emits them in exactly that order.
   local _edit_rules=""
-  local _root _action
-  while IFS=$'\t' read -r _root _action; do
-    [ -n "$_root" ] || continue
+  local _path _action
+  while IFS=$'\t' read -r _path _action; do
+    [ -n "$_path" ] || continue
     if [ -n "$_edit_rules" ]; then
       _edit_rules="${_edit_rules},"
     fi
-    _edit_rules="${_edit_rules}\n      \"${_root}/**\": \"${_action}\""
-  done < <(source_policy_root_actions)
+    _edit_rules="${_edit_rules}\n      \"${_path}/**\": \"${_action}\""
+  done < <(source_policy_edit_rules)
   OPENCODE_JSON="$OPENCODE_JSON${_edit_rules}"
   OPENCODE_JSON="$OPENCODE_JSON\n    }"
   OPENCODE_JSON="$OPENCODE_JSON\n  }"
@@ -324,6 +329,15 @@ runtime_generate_config() {
 # unexpected entries, users run `./upgrade.sh --repair-opencode-json`.
 _runtime_repair_opencode_json_additive() {
   local HELPER="$SCRIPT_DIR/lib/repair-opencode-json.py"
+
+  # Owned-source allow rules the reconciler must (re)write. Empty under
+  # engineering, so the argument list is unchanged there.
+  local _managed_source_args=()
+  local _owned_path
+  while IFS= read -r _owned_path; do
+    [ -n "$_owned_path" ] || continue
+    _managed_source_args+=(--managed-source "$_owned_path")
+  done < <(source_policy_owned_sources)
   if [ ! -f "$HELPER" ]; then
     log "opencode.json exists but repair helper not found ($HELPER) — leaving as-is"
     return
@@ -355,6 +369,7 @@ _runtime_repair_opencode_json_additive() {
     --runtime opencode \
     --chat-bridge "$BRIDGE_ARG" \
     --posture "${POSTURE:-engineering}" \
+    "${_managed_source_args[@]}" \
     --kimaki-plugins-dir "$PLUGINS_DIR" \
     "${claude_code_auth_args[@]}" \
     "${managed_args[@]}" \

--- a/setup.sh
+++ b/setup.sh
@@ -74,6 +74,8 @@ CHAT_BRIDGE_EXPLICIT=false
 HOMEBOY_MODE="auto"
 POSTURE=""
 POSTURE_EXPLICIT=false
+MANAGED_SOURCES=""
+MANAGED_SOURCES_EXPLICIT=false
 HOMEBOY_PROJECT_ID="${HOMEBOY_PROJECT_ID:-}"
 DETECTED_RUNTIMES=()
 IS_STUDIO=false
@@ -201,6 +203,11 @@ while [[ $# -gt 0 ]]; do
       POSTURE_EXPLICIT=true
       shift 2
       ;;
+    --managed-source)
+      MANAGED_SOURCES="${MANAGED_SOURCES}${MANAGED_SOURCES:+ }$2"
+      MANAGED_SOURCES_EXPLICIT=true
+      shift 2
+      ;;
     --agent-slug)
       AGENT_SLUG="$2"
       AGENT_SLUG_EXPLICIT=true
@@ -269,6 +276,14 @@ OPTIONS:
                        hosting where changes are captured out-of-band.
                      Recorded on the install so upgrades converge without
                      repeating the flag.
+  --managed-source <path>
+                     wp-content path this site owns and the agent may edit
+                     under --posture managed. Repeatable. Must be a plugin or
+                     theme directory, e.g.
+                     wp-content/themes/acme or wp-content/plugins/acme-core.
+                     Everything not declared stays read-only, including
+                     third-party plugins. Declare exactly what the operator's
+                     harvest captures.
   --agent-slug <s>   Override Data Machine agent slug (default: derived from domain)
   --agent-name <n>   Override Data Machine agent display name (default: blogname)
   --kimaki-unit <u>  Kimaki systemd unit (default: kimaki.service)
@@ -430,6 +445,8 @@ detect_environment
 # Posture must resolve BEFORE anything that enforces it: the plugin set, the
 # runtime permission surfaces, and the AGENTS.md guidance all derive from it.
 source_policy_resolve_posture
+source_policy_resolve_owned_sources
+source_policy_assert_runtime_supports_posture
 
 if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$LOCAL_MODE" = false ]; then
   bridge_load kimaki
@@ -463,6 +480,7 @@ if [ "$RUNTIME_ONLY" != true ]; then
 fi
 
 source_policy_record_posture
+source_policy_record_owned_sources
 guidance_sync_all
 setup_ai_gateway
 

--- a/tests/posture.sh
+++ b/tests/posture.sh
@@ -68,34 +68,98 @@ echo "==> source policy resolves the documented root matrix"
 # ===========================================================================
 
 POSTURE=engineering
-assert_eq "$(source_policy_root_actions | tr '\t' '=' | tr '\n' ' ')" \
+MANAGED_SOURCES=""
+assert_eq "$(source_policy_edit_rules | tr '\t' '=' | tr '\n' ' ')" \
   "wp-content/plugins=deny wp-content/themes=deny wp-includes=deny " \
   "engineering keeps every installed root read-only"
 source_policy_workspace_enabled \
   && echo "  ok   engineering has a workspace" \
   || { echo "  FAIL engineering has a workspace"; FAILED=$((FAILED + 1)); }
 
+# Managed does NOT open wp-content. It denies the same roots and then carves
+# out only the declared owned paths. The regression this pins: an earlier
+# version allowed `wp-content/plugins/**` wholesale, which on a live install
+# meant WooCommerce, a payment gateway, and the agent's own runtime.
 POSTURE=managed
-assert_eq "$(source_policy_root_actions | tr '\t' '=' | tr '\n' ' ')" \
-  "wp-content/plugins=allow wp-content/themes=allow wp-includes=deny " \
-  "managed opens themes and plugins but never core"
+MANAGED_SOURCES="wp-content/themes/acme
+wp-content/plugins/acme-core"
+assert_eq "$(source_policy_edit_rules | tr '\t' '=' | tr '\n' ' ')" \
+  "wp-content/plugins=deny wp-content/themes=deny wp-includes=deny wp-content/themes/acme=allow wp-content/plugins/acme-core=allow " \
+  "managed denies the roots and allows only declared owned paths"
+
+# Order is the precedence mechanism for OpenCode findLast; a narrower allow
+# emitted before the broad deny would be silently inverted.
+DENY_POS=$(source_policy_edit_rules | grep -n '^wp-content/plugins	deny$' | cut -d: -f1)
+ALLOW_POS=$(source_policy_edit_rules | grep -n '^wp-content/plugins/acme-core	allow$' | cut -d: -f1)
+[ "$DENY_POS" -lt "$ALLOW_POS" ]
+check_rc=$?
+if [ "$check_rc" -eq 0 ]; then
+  echo "  ok   broad deny is emitted before the narrower allow"
+else
+  echo "  FAIL broad deny is emitted before the narrower allow"
+  FAILED=$((FAILED + 1))
+fi
+
 source_policy_workspace_enabled \
   && { echo "  FAIL managed has no workspace"; FAILED=$((FAILED + 1)); } \
   || echo "  ok   managed has no workspace"
 
-# An unrecognised posture must fall back to the safe (read-only) matrix rather
-# than silently granting write access to a live site.
+# Fail closed: a managed install that declares nothing gets NO editable source
+# rather than a wide-open wp-content.
+POSTURE=managed
+MANAGED_SOURCES=""
+assert_eq "$(source_policy_edit_rules | tr '\t' '=' | tr '\n' ' ')" \
+  "wp-content/plugins=deny wp-content/themes=deny wp-includes=deny " \
+  "managed with nothing declared grants no edit access at all"
+
+# Paths outside wp-content, and files inside a component, are rejected rather
+# than silently trusted.
+MANAGED_SOURCES_EXPLICIT=true
+MANAGED_SOURCES="wp-includes/foo wp-content/plugins/acme/file.php wp-content/plugins/acme"
+source_policy_resolve_owned_sources 2>/dev/null
+assert_eq "$(source_policy_owned_sources | tr '\n' ' ')" "wp-content/plugins/acme " \
+  "only well-formed plugin/theme directories survive normalization"
+
 POSTURE=nonsense
-assert_eq "$(source_policy_root_actions | tr '\t' '=' | tr '\n' ' ')" \
+MANAGED_SOURCES=""
+assert_eq "$(source_policy_edit_rules | tr '\t' '=' | tr '\n' ' ')" \
   "wp-content/plugins=deny wp-content/themes=deny wp-includes=deny " \
   "unknown posture degrades to read-only, never to write"
+
+# ===========================================================================
+echo "==> runtimes that cannot express scoped permissions refuse managed"
+# ===========================================================================
+
+for rt in claude-code codex; do
+  rc=0
+  POSTURE=managed RUNTIME="$rt" \
+    bash -c 'source lib/common.sh; source lib/source-policy.sh; error() { exit 3; }; source_policy_assert_runtime_supports_posture' \
+    >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 3 ]; then
+    echo "  ok   $rt refuses managed posture"
+  else
+    echo "  FAIL $rt should refuse managed posture (rc=$rc)"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+rc=0
+POSTURE=managed RUNTIME=opencode \
+  bash -c 'source lib/common.sh; source lib/source-policy.sh; error() { exit 3; }; source_policy_assert_runtime_supports_posture' \
+  >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+  echo "  ok   opencode accepts managed posture"
+else
+  echo "  FAIL opencode should accept managed posture (rc=$rc)"
+  FAILED=$((FAILED + 1))
+fi
 
 # ===========================================================================
 echo "==> opencode.json permission surface follows posture"
 # ===========================================================================
 
 _opencode_config_for() {
-  local posture="$1" out="$2"
+  local posture="$1" out="$2" sources="${3:-}"
   (
     TMP="$(mktemp -d)"
     trap 'rm -rf "$TMP"' EXIT
@@ -110,6 +174,7 @@ _opencode_config_for() {
     export WITH_CLAUDE_CODE_AUTH=false RUNTIME="opencode"
     UPDATED_ITEMS=()
     POSTURE="$posture"
+    MANAGED_SOURCES="$sources"
     # shellcheck disable=SC1091
     source "$SCRIPT_DIR/runtimes/opencode.sh"
     runtime_generate_config
@@ -120,15 +185,21 @@ _opencode_config_for() {
 ENG_JSON="$(mktemp)"; MGD_JSON="$(mktemp)"
 trap 'rm -f "$ENG_JSON" "$MGD_JSON"' EXIT
 _opencode_config_for engineering "$ENG_JSON"
-_opencode_config_for managed "$MGD_JSON"
+_opencode_config_for managed "$MGD_JSON" "wp-content/themes/acme
+wp-content/plugins/acme-core"
 
 assert_eq "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["permission"]["edit"],sort_keys=True))' "$ENG_JSON")" \
   '{"wp-content/plugins/**": "deny", "wp-content/themes/**": "deny", "wp-includes/**": "deny"}' \
   "engineering opencode edit map is byte-identical to the pre-refactor rules"
 
-assert_eq "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["permission"]["edit"],sort_keys=True))' "$MGD_JSON")" \
-  '{"wp-content/plugins/**": "allow", "wp-content/themes/**": "allow", "wp-includes/**": "deny"}' \
-  "managed opencode edit map opens the live working tree"
+# sort_keys would destroy the very thing under test, so compare raw order.
+assert_eq "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["permission"]["edit"]))' "$MGD_JSON")" \
+  '{"wp-content/plugins/**": "deny", "wp-content/themes/**": "deny", "wp-includes/**": "deny", "wp-content/themes/acme/**": "allow", "wp-content/plugins/acme-core/**": "allow"}' \
+  "managed opencode edit map denies the roots then allows owned paths, in that order"
+
+MGD_EDIT="$(python3 -c 'import json,sys; print(" ".join(json.load(open(sys.argv[1]))["permission"]["edit"]))' "$MGD_JSON")"
+refute_contains "$MGD_EDIT" 'wp-content/plugins/**": "allow' \
+  "managed never opens the whole plugins directory"
 
 assert_eq "$(python3 -c 'import json,sys; print("yes" if "external_directory" in json.load(open(sys.argv[1]))["permission"] else "no")' "$ENG_JSON")" \
   "yes" "engineering grants the workspace directory"
@@ -136,7 +207,7 @@ assert_eq "$(python3 -c 'import json,sys; print("yes" if "external_directory" in
   "no" "managed grants no workspace directory (there is none)"
 
 # ===========================================================================
-echo "==> claude-code settings.json follows posture, and switching clears denies"
+echo "==> claude-code denies every installed root (managed is refused upstream)"
 # ===========================================================================
 
 _claude_settings_for() {
@@ -161,34 +232,18 @@ _claude_settings_for() {
   )
 }
 
-CC_ENG="$(mktemp)"; CC_MGD="$(mktemp)"; CC_SEED="$(mktemp)"
+CC_ENG="$(mktemp)"
 _claude_settings_for engineering "$CC_ENG"
 assert_contains "$(cat "$CC_ENG")" '"Edit(SITE_PATH/wp-content/themes/**)"' \
   "engineering denies theme edits"
+assert_contains "$(cat "$CC_ENG")" '"Edit(SITE_PATH/wp-content/plugins/**)"' \
+  "engineering denies plugin edits"
 assert_contains "$(cat "$CC_ENG")" '"Bash(wp datamachine-code workspace:*)"' \
   "engineering allows the DMC workspace bash surface"
-
-# Seed a settings.json that already carries the engineering denies, then sync
-# under managed. A posture switch has to REMOVE the stale denies; leaving them
-# is precisely the failure mode that blocked h44-bot from its own theme.
-cat > "$CC_SEED" <<'JSON'
-{"permissions":{"deny":["Read(./private/**)","Edit(SITE_PATH/wp-content/plugins/**)","Edit(SITE_PATH/wp-content/themes/**)","Edit(SITE_PATH/wp-includes/**)"]}}
-JSON
-_claude_settings_for managed "$CC_MGD" "$CC_SEED"
-refute_contains "$(cat "$CC_MGD")" '"Edit(SITE_PATH/wp-content/themes/**)"' \
-  "managed sync clears the stale theme deny"
-refute_contains "$(cat "$CC_MGD")" '"Edit(SITE_PATH/wp-content/plugins/**)"' \
-  "managed sync clears the stale plugin deny"
-assert_contains "$(cat "$CC_MGD")" '"Edit(SITE_PATH/wp-includes/**)"' \
-  "managed still denies WordPress core"
-assert_contains "$(cat "$CC_MGD")" '"Read(./private/**)"' \
-  "managed sync preserves unrelated operator denies"
-refute_contains "$(cat "$CC_MGD")" 'datamachine-code workspace' \
-  "managed grants no workspace bash surface"
-rm -f "$CC_ENG" "$CC_MGD" "$CC_SEED"
+rm -f "$CC_ENG"
 
 # ===========================================================================
-echo "==> codex filesystem profile follows posture"
+echo "==> codex filesystem profile keeps every installed root read-only"
 # ===========================================================================
 
 _codex_config_for() {
@@ -211,12 +266,9 @@ _codex_config_for() {
 }
 
 CX_ENG="$(_codex_config_for engineering)"
-CX_MGD="$(_codex_config_for managed)"
-assert_contains "$CX_ENG" '"wp-content/themes" = "read"' "engineering codex profile keeps themes read-only"
-assert_contains "$CX_ENG" '"wp-includes" = "read"' "engineering codex profile keeps core read-only"
-refute_contains "$CX_MGD" '"wp-content/themes" = "read"' "managed codex profile drops the theme read-only rule"
-refute_contains "$CX_MGD" '"wp-content/plugins" = "read"' "managed codex profile drops the plugin read-only rule"
-assert_contains "$CX_MGD" '"wp-includes" = "read"' "managed codex profile still protects core"
+assert_contains "$CX_ENG" '"wp-content/themes" = "read"' "codex profile keeps themes read-only"
+assert_contains "$CX_ENG" '"wp-content/plugins" = "read"' "codex profile keeps plugins read-only"
+assert_contains "$CX_ENG" '"wp-includes" = "read"' "codex profile keeps core read-only"
 
 # ===========================================================================
 echo "==> AGENTS.md guidance agrees with the enforced permissions"
@@ -235,21 +287,44 @@ assert_contains "$ENG_PROSE" "read-only" "engineering prose says read-only"
 assert_contains "$ENG_PROSE" "managed workspace" "engineering prose routes changes to the workspace"
 
 POSTURE=managed
+MANAGED_SOURCES="wp-content/themes/acme
+wp-content/plugins/acme-core"
 MGD_PROSE="$(guidance_call wordpress-source render)"
 assert_eq "$(guidance_call wordpress-source id)" "wordpress-source" \
   "managed variant registers the same section id"
-assert_contains "$MGD_PROSE" '`wp-content/themes/` — **editable**' \
-  "managed prose declares themes editable, matching permission.edit"
-assert_contains "$MGD_PROSE" '`wp-includes/` — WordPress core, **read-only**' \
-  "managed prose keeps core read-only, matching permission.edit"
-assert_contains "$MGD_PROSE" "live the moment you save" \
+
+# The prose must ENUMERATE, never generalise to a directory. Saying "this
+# site's theme and plugins" while the policy lists two paths is how an agent
+# concludes WooCommerce is fair game.
+assert_contains "$MGD_PROSE" '- `wp-content/themes/acme/`' \
+  "managed prose names each editable path"
+assert_contains "$MGD_PROSE" '- `wp-content/plugins/acme-core/`' \
+  "managed prose names every editable path, not just the first"
+assert_contains "$MGD_PROSE" 'this is the complete list' \
+  "managed prose states the editable list is exhaustive"
+refute_contains "$MGD_PROSE" '`wp-content/plugins/` -- **editable**' \
+  "managed prose never presents a whole directory as editable"
+assert_contains "$MGD_PROSE" 'The rest of `wp-content/plugins/`' \
+  "managed prose marks the remaining plugins read-only"
+assert_contains "$MGD_PROSE" '`wp-includes/` ' \
+  "managed prose keeps core read-only"
+assert_contains "$MGD_PROSE" 'live the moment you save' \
   "managed prose states that edits reach production immediately"
-assert_contains "$MGD_PROSE" "never recorded" \
+assert_contains "$MGD_PROSE" 'never recorded' \
   "managed prose warns about paths a capture silently skips"
-assert_contains "$MGD_PROSE" "no pull request step" \
+assert_contains "$MGD_PROSE" 'no pull request step' \
   "managed prose rules out the review workflow rather than leaving it implied"
 refute_contains "$MGD_PROSE" "Make code changes in the configured managed workspace" \
   "managed prose never routes work to a workspace that does not exist"
+
+# Fail closed in prose too: nothing declared must not read as "edit anything".
+MANAGED_SOURCES=""
+NONE_PROSE="$(guidance_call wordpress-source render)"
+assert_contains "$NONE_PROSE" 'declares no editable source' \
+  "managed prose with nothing declared says so explicitly"
+refute_contains "$NONE_PROSE" 'You edit this site directly' \
+  "managed prose with nothing declared does not invite edits"
+MANAGED_SOURCES="wp-content/themes/acme"
 
 # The homeboy unit is engineering-only: its routing advice is about cooking
 # tracked changes in managed worktrees, which does not exist under managed.
@@ -269,18 +344,19 @@ RECON_IN="$(mktemp)"
 cat > "$RECON_IN" <<'JSON'
 {"permission":{"edit":{"wp-content/plugins/**":"deny","wp-content/themes/**":"deny","wp-includes/**":"deny","custom/**":"ask"}}}
 JSON
-RECON_OUT="$(python3 - "$RECON_IN" <<'PY'
+RECON_OUT="$(python3 - "$RECON_IN" <<'PYX'
 import importlib.util, json, sys, pathlib
 spec = importlib.util.spec_from_file_location("repair", pathlib.Path("lib/repair-opencode-json.py"))
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 data = json.load(open(sys.argv[1]))
-print(json.dumps(mod.expected_edit_permission(data, "managed"), sort_keys=True))
-PY
+# json.dumps preserves insertion order, which is the property under test.
+print(json.dumps(mod.expected_edit_permission(data, "managed", ["wp-content/plugins/acme-core"])))
+PYX
 )"
 assert_eq "$RECON_OUT" \
-  '{"custom/**": "ask", "wp-content/plugins/**": "allow", "wp-content/themes/**": "allow", "wp-includes/**": "deny"}' \
-  "reconciler rewrites managed rules and preserves operator rules"
+  '{"custom/**": "ask", "wp-content/plugins/**": "deny", "wp-content/themes/**": "deny", "wp-includes/**": "deny", "wp-content/plugins/acme-core/**": "allow"}' \
+  "reconciler emits denies before owned allows and preserves operator rules"
 rm -f "$RECON_IN"
 
 if [ "$FAILED" -ne 0 ]; then

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -106,6 +106,8 @@ ROTATE_AI_GATEWAY_TOKEN=false
 SHOW_HELP=false
 POSTURE=""
 POSTURE_EXPLICIT=false
+MANAGED_SOURCES=""
+MANAGED_SOURCES_EXPLICIT=false
 
 # Defaults setup.sh expects (detect.sh reads these)
 LOCAL_MODE=false
@@ -147,6 +149,7 @@ while [[ $# -gt 0 ]]; do
     --ai-gateway-opencode-model) AI_GATEWAY_MODEL_ID="$2"; shift 2 ;;
     --rotate-ai-gateway-token) ROTATE_AI_GATEWAY_TOKEN=true; shift ;;
     --posture)       POSTURE="$2"; POSTURE_EXPLICIT=true; shift 2 ;;
+    --managed-source) MANAGED_SOURCES="${MANAGED_SOURCES}${MANAGED_SOURCES:+ }$2"; MANAGED_SOURCES_EXPLICIT=true; shift 2 ;;
     --runtime)       RUNTIME="$2"; shift 2 ;;
     --wp-path)       EXISTING_WP="$2"; shift 2 ;;
     --agent-slug)    AGENT_SLUG="$2"; AGENT_SLUG_EXPLICIT=true; shift 2 ;;
@@ -190,6 +193,10 @@ USAGE:
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
   ./upgrade.sh --posture <name> Force install posture: engineering | managed
                                (default: the posture recorded at setup time)
+  ./upgrade.sh --managed-source <path>
+                               wp-content path this site owns and may edit under
+                               managed posture. Repeatable. Replaces the
+                               recorded set when supplied.
   ./upgrade.sh --wp-path <path> Override detected WordPress path
   ./upgrade.sh --agent-slug <s> Override Data Machine agent slug
   ./upgrade.sh --kimaki-unit <u> Target Kimaki systemd unit
@@ -343,7 +350,10 @@ detect_environment
 # upgrade converges a managed install instead of silently reverting it to
 # engineering; --posture overrides and re-records.
 source_policy_resolve_posture
+source_policy_resolve_owned_sources
+source_policy_assert_runtime_supports_posture
 source_policy_record_posture
+source_policy_record_owned_sources
 
 # Detect chat bridge from installed services / installed binaries via the
 # bridges/_dispatch.sh registry walk. See bridge_detect_local /
@@ -578,6 +588,15 @@ check_opencode_json_drift() {
   fi
 
   local HELPER="$SCRIPT_DIR/lib/repair-opencode-json.py"
+
+  # Owned-source allow rules the reconciler must (re)write. Empty under
+  # engineering, so the argument list is unchanged there.
+  local _managed_source_args=()
+  local _owned_path
+  while IFS= read -r _owned_path; do
+    [ -n "$_owned_path" ] || continue
+    _managed_source_args+=(--managed-source "$_owned_path")
+  done < <(source_policy_owned_sources)
   if [ ! -f "$HELPER" ]; then
     warn "Phase 3b: $HELPER not found — skipping drift check"
     return 0
@@ -668,6 +687,7 @@ for item in data:
       --runtime "$RUNTIME_ARG" \
       --chat-bridge "$BRIDGE_ARG" \
       --posture "${POSTURE:-engineering}" \
+      "${_managed_source_args[@]}" \
       --kimaki-plugins-dir "$PLUGINS_DIR" \
       "${claude_code_auth_args[@]}" \
       "${managed_args[@]}" 2>&1 || true)
@@ -686,6 +706,7 @@ for item in data:
     --runtime "$RUNTIME_ARG" \
     --chat-bridge "$BRIDGE_ARG" \
     --posture "${POSTURE:-engineering}" \
+    "${_managed_source_args[@]}" \
     --kimaki-plugins-dir "$PLUGINS_DIR" \
     "${claude_code_auth_args[@]}" \
     "${managed_args[@]}" \


### PR DESCRIPTION
Closes #318.

`--posture managed` (shipped in v1.11.0) granted edit on **all of** `wp-content/plugins/` and `wp-content/themes/`. On h44lacrosse.com that put WooCommerce, the Stripe gateway, Data Machine, and the agent's own `data-machine-code` runtime inside an autonomous agent's write surface — on a site taking real card payments.

Three paths there are actually the site's own (`h44-core`, `h44-forms`, `h44-lacrosse-theme`), and those three are exactly what its `harvest.yml` captures.

## Why this was worse than "too broad"

The managed guidance tells the agent its edits are captured as restore points. Outside the harvested set that is **false** — an edit to WooCommerce is never recorded and is erased by the next update. The agent was told a safety property that did not hold for most of what it was granted.

Root cause is the prose-vs-permission split #314 existed to eliminate, reintroduced one level down: the guidance enumerated ("this site's theme and plugins"), the policy generalised (two directories).

## The invariant

> **The editable set must equal the set the operator's capture records.**

A path the agent can edit but nothing records is a path where it silently loses work, invisibly, until an update overwrites it. There is no reliable way to infer which plugins a site "owns", and guessing wrong on production is not an acceptable default — so it is declared:

```bash
./setup.sh --posture managed \
  --managed-source wp-content/themes/acme \
  --managed-source wp-content/plugins/acme-core
```

Recorded as `wp_coding_agents_managed_sources` so upgrades converge. Managed now denies all three roots exactly as engineering does, then emits one allow per declared path.

**Fails closed.** Managed with nothing declared grants no editable source, and the guidance says so explicitly rather than implying a directory is editable. Malformed declarations (outside `wp-content`, or a file inside a component) are rejected with a reason.

## Rule order is now load-bearing

Verified against **opencode 1.18.4 source**, not the docs — the two disagree, which is the subject of several open upstream issues (#7029, #13872, #24335, #24999, #36765):

```js
// packages/opencode/src/permission/index.ts
.findLast((rule) => Wildcard.match(permission, rule.permission) && Wildcard.match(pattern, rule.pattern))
// fromConfig(): iterates Object.entries(value) — JSON key order
```

`findLast` over a ruleset built in config key order, with **no specificity sorting** in `evaluate` (`Wildcard.all`'s length sort is used elsewhere). So a narrower allow written *after* a broad deny wins. Both the generator and the reconciler preserve deny-before-allow, and the tests assert the ordering rather than comparing sorted keys — `sort_keys=True` would have destroyed the property under test.

## Runtime support narrowed, deliberately

Managed is now `opencode`-only. Claude Code treats deny as absolute so an allow cannot carve an exception out of it; Codex has no documented precedence for overlapping filesystem entries. Both now **refuse** managed posture with a clear error rather than emit a permission set whose behavior on a production site I could not verify. Their engineering paths are untouched.

## Guidance rewritten

Enumerates the declared paths by name, states the list is exhaustive, and marks the remainder of `wp-content` read-only — naming commerce/payment code and the agent's own runtime as things it must not touch, with the reason (an update erases the change anyway). The heading no longer labels the whole category editable.

## Verification

- **Engineering output unchanged** — generated `opencode.json` diffed byte-for-byte against generation from `v1.11.0`: identical.
- `tests/posture.sh` extended: ordering (deny index < allow index), fail-closed with nothing declared, normalization rejecting bad paths, the three runtimes' managed support, prose enumerating every declared path, prose never presenting a directory as editable, and fail-closed prose.
- Reconciler covered for insertion order, operator-rule preservation, and dropping a stale allow when a source is undeclared.
- Full `tests/*.sh`: no new failures (same 7 pre-existing environment failures as `main`, none in `shell.yml`). `bash -n` clean.

## Follow-up

Re-applying to h44lacrosse.com is an operator action, not part of this PR. That box currently has the over-broad grant live.