### PR TITLE
Grant log paths as both literal and subtree

### DIFF
--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -407,7 +407,8 @@ def expected_edit_permission(
     logs = list(log_paths or [])
 
     source_keys = [f"{path}/**" for path in sources]
-    log_keys = [f"{path}/**" for path in logs]
+    # A log path may be a directory or a single file; emit both forms.
+    log_keys = [k for path in logs for k in (path, f"{path}/**")]
     managed_keys = set(MANAGED_ROOTS) | set(source_keys) | set(writable) | set(log_keys)
 
     permission = data.get("permission", {})

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -303,7 +303,11 @@ runtime_generate_config() {
     if [ -n "$_ext_rules" ]; then
       _ext_rules="${_ext_rules},"
     fi
-    _ext_rules="${_ext_rules}\n      \"${_log_path}/**\": \"allow\""
+    # Both patterns, because a log path may be a directory (/var/log/nginx) or
+    # a single file (/var/log/php8.4-fpm.log). Appending /** alone silently
+    # matches nothing for the file case, which is a grant that looks present
+    # and does nothing.
+    _ext_rules="${_ext_rules}\n      \"${_log_path}\": \"allow\",\n      \"${_log_path}/**\": \"allow\""
   done < <(source_policy_log_paths)
 
   if [ -n "$_ext_rules" ]; then
@@ -333,7 +337,7 @@ runtime_generate_config() {
     if [ -n "$_edit_rules" ]; then
       _edit_rules="${_edit_rules},"
     fi
-    _edit_rules="${_edit_rules}\n      \"${_log_path}/**\": \"deny\""
+    _edit_rules="${_edit_rules}\n      \"${_log_path}\": \"deny\",\n      \"${_log_path}/**\": \"deny\""
   done < <(source_policy_log_paths)
   OPENCODE_JSON="$OPENCODE_JSON${_edit_rules}"
   OPENCODE_JSON="$OPENCODE_JSON\n    }"

--- a/tests/posture.sh
+++ b/tests/posture.sh
@@ -248,15 +248,21 @@ import json,sys
 k=list(json.load(open(sys.argv[1]))["permission"]["edit"])
 print(k.index("wp-content/themes/**") < k.index("wp-content/themes/acme/**"))' "$MGD_JSON")" \
   "True" "managed emits the broad deny before the narrower allow"
+assert_contains "$MGD_EDIT_JSON" '"/var/log/site": "deny"' \
+  "a readable log path is denied for editing as a literal"
 assert_contains "$MGD_EDIT_JSON" '"/var/log/site/**": "deny"' \
-  "a readable log path is still denied for editing"
+  "a readable log path is denied for editing as a subtree"
 
 assert_eq "$(python3 -c 'import json,sys; print("yes" if "external_directory" in json.load(open(sys.argv[1]))["permission"] else "no")' "$ENG_JSON")" \
   "yes" "engineering grants the workspace directory"
 MGD_EXT="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))["permission"].get("external_directory",{})))' "$MGD_JSON")"
 refute_contains "$MGD_EXT" 'workspace' "managed grants no workspace directory (there is none)"
 assert_contains "$MGD_EXT" '"/var/log/site/**": "allow"' \
-  "managed grants read on the declared log path, so the agent can debug a fatal"
+  "managed grants read on the declared log directory"
+# A log path may be a single FILE (/var/log/php-fpm.log). Appending /** alone
+# matches nothing there — a grant that looks present and does nothing.
+assert_contains "$MGD_EXT" '"/var/log/site": "allow"' \
+  "the literal log path is granted too, so a file path actually works"
 
 # ===========================================================================
 echo "==> claude-code denies every installed root (managed is refused upstream)"


### PR DESCRIPTION
`--log-path` (v1.11.2, #322) appended `/**` unconditionally:

```json
"external_directory": { "/var/log/php8.5-fpm.log/**": "allow" }
```

PHP-FPM's error log is a **single file**, so that pattern matches nothing. The grant is present in the config, reads as correct, and does nothing — leaving the agent unable to read the log it was explicitly given access to.

Same class as the root-file glob trap already documented in `lib/source-policy.sh`: a pattern that looks right and silently matches the empty set. Caught while wiring the first real log grant on h44lacrosse.com, where the paths are `/var/log/nginx` (directory) and `/var/log/php8.5-fpm.log` (file).

## Fix

Emit both forms for every declared path, in `external_directory` (allow) and `edit` (deny):

```json
"/var/log/php8.5-fpm.log": "allow",
"/var/log/php8.5-fpm.log/**": "allow"
```

Covers directory and file with no detection and no over-match. The tempting one-pattern alternative, `/var/log/nginx*`, would also match `/var/log/nginx-other` — OpenCode's `*` becomes `.*` and spans anything.

## Tests

`tests/posture.sh` now asserts both the literal and the subtree form are granted for read and denied for edit, with a comment explaining why one alone is insufficient.

Full suite: no new failures (same 7 pre-existing environment failures as `main`).