### PR TITLE
Reconcile external_directory and pass every declaration to the reconciler

### DIFF
--- a/lib/repair-opencode-json.py
+++ b/lib/repair-opencode-json.py
@@ -455,6 +455,87 @@ def _is_stale_managed_key(pattern: str) -> bool:
     )
 
 
+def expected_external_directory(
+    data: dict,
+    workspace_dir: str = "",
+    log_paths: List[str] | None = None,
+) -> dict:
+    """Return user external_directory rules followed by the managed grants.
+
+    #316: the reconciler owned permission.edit only, so an engineering->managed
+    upgrade kept a stale workspace grant, and log paths declared at upgrade time
+    never landed at all. Both halves of the policy have to be reconciled or the
+    upgrade path silently diverges from a fresh install.
+    """
+    logs = list(log_paths or [])
+    managed: dict[str, str] = {}
+    if workspace_dir:
+        managed[f"{workspace_dir}/**"] = "allow"
+    for path in logs:
+        # Directory or single file; see the log-path rules in edit permissions.
+        managed[path] = "allow"
+        managed[f"{path}/**"] = "allow"
+
+    permission = data.get("permission", {})
+    current = permission.get("external_directory") if isinstance(permission, dict) else None
+
+    if isinstance(current, dict):
+        rules = {
+            pattern: action
+            for pattern, action in current.items()
+            if pattern not in managed and not _is_managed_external_key(pattern)
+        }
+    else:
+        rules = {}
+
+    rules.update(managed)
+    return rules
+
+
+def _is_managed_external_key(pattern: str) -> bool:
+    """True for a grant wp-coding-agents previously wrote and no longer declares.
+
+    Absolute paths are ours to manage here; anything relative was added by the
+    operator and is preserved.
+    """
+    return pattern.startswith("/") or pattern.startswith("~")
+
+
+def check_external_directory(
+    data: dict,
+    runtime: str,
+    workspace_dir: str = "",
+    log_paths: List[str] | None = None,
+) -> dict:
+    if runtime != "opencode":
+        return {"status": "ok"}
+    permission = data.get("permission", {})
+    current = permission.get("external_directory") if isinstance(permission, dict) else None
+    expected = expected_external_directory(data, workspace_dir, log_paths)
+    if not expected and current in (None, {}):
+        return {"status": "ok"}
+    return {
+        "status": "ok" if current == expected else "needed",
+        "expected": expected,
+    }
+
+
+def apply_external_directory(
+    data: dict,
+    workspace_dir: str = "",
+    log_paths: List[str] | None = None,
+) -> None:
+    expected = expected_external_directory(data, workspace_dir, log_paths)
+    permission = data.get("permission", {})
+    if not isinstance(permission, dict):
+        permission = {}
+    if expected:
+        permission["external_directory"] = expected
+    else:
+        permission.pop("external_directory", None)
+    data["permission"] = permission
+
+
 def check_edit_permission(
     data: dict,
     runtime: str,
@@ -524,6 +605,11 @@ def main() -> int:
         default=[],
         dest="managed_writable",
         help="Denied path this install explicitly re-opens for editing. Not captured. Repeatable.",
+    )
+    parser.add_argument(
+        "--workspace-dir",
+        default="",
+        help="DMC workspace root to grant via external_directory (engineering only).",
     )
     parser.add_argument(
         "--log-path",
@@ -602,6 +688,7 @@ def main() -> int:
     managed_instructions = read_managed_instructions(args.managed_instructions_file)
     instruction_sync_result = check_instruction_sync(data, managed_instructions)
     edit_permission_result = check_edit_permission(data, args.runtime, args.posture, args.managed_sources, args.managed_writable, args.log_paths)
+    external_directory_result = check_external_directory(data, args.runtime, args.workspace_dir, args.log_paths)
 
     # --- Plugin array check ---
     expected = expected_plugins(
@@ -643,12 +730,14 @@ def main() -> int:
     has_agent_cleanup_drift = agent_cleanup_result["status"] == "needed"
     has_instruction_drift = instruction_sync_result["status"] == "needed"
     has_edit_permission_drift = edit_permission_result["status"] == "needed"
+    has_external_directory_drift = external_directory_result["status"] == "needed"
     has_any_drift = (
         has_plugin_drift
         or has_prompt_drift
         or has_agent_cleanup_drift
         or has_instruction_drift
         or has_edit_permission_drift
+        or has_external_directory_drift
     )
 
     if not has_any_drift:
@@ -659,6 +748,7 @@ def main() -> int:
             "agent_cleanup": "ok",
             "instruction_sync": "ok",
             "edit_permission": "ok",
+            "external_directory": "ok",
         }
         if plugin_skipped:
             result["plugins_skipped"] = (
@@ -677,6 +767,7 @@ def main() -> int:
             "agent_cleanup": agent_cleanup_result["status"],
             "instruction_sync": instruction_sync_result["status"],
             "edit_permission": edit_permission_result["status"],
+            "external_directory": external_directory_result["status"],
         }
         if plugin_rewrites:
             result["rewritten"] = plugin_rewrites
@@ -693,6 +784,8 @@ def main() -> int:
             result["instruction_sync_current"] = instruction_sync_result.get("current_managed", [])
         if has_edit_permission_drift:
             result["edit_permission_expected"] = edit_permission_result["expected"]
+        if has_external_directory_drift:
+            result["external_directory_expected"] = external_directory_result["expected"]
         if plugin_skipped:
             result["plugins_skipped"] = (
                 f"runtime {args.runtime} does not use opencode.json plugin array"
@@ -730,6 +823,10 @@ def main() -> int:
     if has_edit_permission_drift:
         apply_edit_permission(data, args.posture, args.managed_sources, args.managed_writable, args.log_paths)
         edit_permission_status = "synced"
+    external_directory_status = "ok"
+    if has_external_directory_drift:
+        apply_external_directory(data, args.workspace_dir, args.log_paths)
+        external_directory_status = "synced"
 
     with open(args.file, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
@@ -753,6 +850,8 @@ def main() -> int:
             "agent_cleanup": "removed" if removed_agent_blocks else "ok",
             "instruction_sync": instruction_sync_status,
             "edit_permission": edit_permission_status,
+        "external_directory": external_directory_status,
+            "external_directory": external_directory_status,
         }
         if plugin_rewrites:
             result["rewritten"] = plugin_rewrites

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -369,6 +369,17 @@ _runtime_repair_opencode_json_additive() {
     [ -n "$_owned_path" ] || continue
     _managed_source_args+=(--managed-source "$_owned_path")
   done < <(source_policy_owned_sources)
+  while IFS= read -r _owned_path; do
+    [ -n "$_owned_path" ] || continue
+    _managed_source_args+=(--managed-writable "$_owned_path")
+  done < <(source_policy_writable_paths)
+  while IFS= read -r _owned_path; do
+    [ -n "$_owned_path" ] || continue
+    _managed_source_args+=(--log-path "$_owned_path")
+  done < <(source_policy_log_paths)
+  if source_policy_workspace_enabled; then
+    _managed_source_args+=(--workspace-dir "$DM_WORKSPACE_DIR")
+  fi
   if [ ! -f "$HELPER" ]; then
     log "opencode.json exists but repair helper not found ($HELPER) — leaving as-is"
     return

--- a/tests/posture.sh
+++ b/tests/posture.sh
@@ -425,6 +425,28 @@ fi
 echo "==> opencode.json reconciler honours posture"
 # ===========================================================================
 
+# #316: the reconciler owned permission.edit only, so an engineering->managed
+# upgrade kept a stale workspace grant and declared log paths never landed.
+# The upgrade path is the one every real install takes.
+EXT_OUT="$(python3 - <<'PYX'
+import importlib.util, json, pathlib
+spec = importlib.util.spec_from_file_location("repair", pathlib.Path("lib/repair-opencode-json.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+data = {"permission": {"external_directory": {
+    "/var/lib/datamachine/workspace/**": "allow",
+    "./operator-added": "allow",
+}}}
+print(json.dumps(mod.expected_external_directory(data, "", ["/var/log/site", "/var/log/one.log"])))
+PYX
+)"
+refute_contains "$EXT_OUT" 'datamachine/workspace' \
+  "managed reconcile drops the stale workspace grant"
+assert_contains "$EXT_OUT" '"./operator-added": "allow"' \
+  "managed reconcile preserves operator-added external grants"
+assert_contains "$EXT_OUT" '"/var/log/one.log": "allow"' \
+  "a log path naming a file is granted as a literal, not only as a subtree"
+
 RECON_IN="$(mktemp)"
 cat > "$RECON_IN" <<'JSON'
 {"permission":{"edit":{"wp-content/plugins/**":"deny","wp-content/themes/**":"deny","wp-includes/**":"deny","custom/**":"ask"}}}

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -607,6 +607,17 @@ check_opencode_json_drift() {
     [ -n "$_owned_path" ] || continue
     _managed_source_args+=(--managed-source "$_owned_path")
   done < <(source_policy_owned_sources)
+  while IFS= read -r _owned_path; do
+    [ -n "$_owned_path" ] || continue
+    _managed_source_args+=(--managed-writable "$_owned_path")
+  done < <(source_policy_writable_paths)
+  while IFS= read -r _owned_path; do
+    [ -n "$_owned_path" ] || continue
+    _managed_source_args+=(--log-path "$_owned_path")
+  done < <(source_policy_log_paths)
+  if source_policy_workspace_enabled; then
+    _managed_source_args+=(--workspace-dir "$DM_WORKSPACE_DIR")
+  fi
   if [ ! -f "$HELPER" ]; then
     warn "Phase 3b: $HELPER not found — skipping drift check"
     return 0


### PR DESCRIPTION
Closes #316.

Fresh installs go through `runtime_generate_config`. **Every existing install** goes through `_runtime_repair_opencode_json_additive` instead — and that path only reconciled `permission.edit`. So the upgrade path silently diverged from a fresh install in two ways:

**1. Stale workspace grant.** An engineering→managed upgrade kept `"/var/lib/datamachine/workspace/**": "allow"` — a grant to a directory that is empty by design on managed. That is exactly the drift #314 set out to eliminate; I removed it by hand on h44 at the time rather than fixing the cause.

**2. New declarations never arrived.** `--managed-writable` and `--log-path` were added to the Python helper's argparse but never passed from bash. Applying the first real log grant to h44 produced:

```
--- external_directory ---
                              ← empty
--- edit ---
  wp-admin/**: deny
  ...                         ← no /var/log entries either
```

The flags were accepted, recorded as options, reflected in AGENTS.md, and had no effect on the permission set.

## Fix

`expected_external_directory` owns the managed grants the same way `expected_edit_permission` owns the edit rules:

- absolute and `~` paths are wp-coding-agents' to write **and remove**
- relative entries are operator-added and preserved
- the workspace dir arrives via `--workspace-dir`, so the reconciler adds it under engineering and drops it under managed

And the bash callers now pass `--managed-writable`, `--log-path`, and `--workspace-dir` alongside `--managed-source`.

## Tests

`tests/posture.sh` covers the reconcile path specifically — stale workspace grant dropped, operator-added grant preserved, and a log path naming a **file** granted as a literal rather than only as a subtree.

That last one matters: `/var/log/php8.5-fpm.log/**` matches nothing, which is why #325 emits both forms.

Full suite: no new failures (same 7 pre-existing environment failures as `main`).