### PR TITLE
Guard the agent runtime against admin-UI deactivation on managed installs

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -131,6 +131,14 @@ jobs:
       - name: Run tests/kimaki-no-default-channel.sh
         run: ./tests/kimaki-no-default-channel.sh
 
+  runtime-guard:
+    name: runtime deactivation guard (#328)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/runtime-guard.sh
+        run: ./tests/runtime-guard.sh
+
   posture:
     name: installed-source posture (#314)
     runs-on: ubuntu-latest

--- a/lib/runtime-guard.sh
+++ b/lib/runtime-guard.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# lib/runtime-guard.sh — protect the agent runtime from admin-UI deactivation.
+#
+# On a managed install the site owner has wp-admin access and no reason to
+# understand the plugins list. Deactivating Data Machine there costs them their
+# assistant's memory and tools, with no obvious way back.
+#
+# This guards the ADMIN UI only. `wp plugin deactivate data-machine` stays
+# available because that is the operator's recovery path. The accident happens
+# in wp-admin; the recovery happens on the CLI. See #328.
+#
+# Deliberately NOT an mu-plugin move (#323): WordPress fatal-error recovery
+# pauses a plugin that fatals and cannot do that for an mu-plugin, so relocating
+# the runtime would turn a broken assistant into a white screen on a live site.
+#
+# Public surface:
+#   runtime_guard_mu_plugin_path
+#   runtime_guard_sync            # installs under managed, removes otherwise
+#
+# Honors DRY_RUN (logs intent, makes no changes).
+
+runtime_guard_mu_plugin_path() {
+  if [ -z "${SITE_PATH:-}" ]; then
+    return 1
+  fi
+  printf '%s' "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-runtime-guard.php"
+}
+
+# Plugin basenames to protect, one per line.
+#
+# `data-machine` is guarded unconditionally because wp-coding-agents installs it
+# on every agent install — it is a property of the product, not of one site.
+# Companions vary per install, so they are DISCOVERED from what is actually
+# active rather than assumed. Naming a stack this tool has not inspected is the
+# #320 mistake.
+runtime_guard_plugins() {
+  if [ "${DRY_RUN:-false}" = true ] || [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
+    printf '%s\n' 'data-machine/data-machine.php'
+    return 0
+  fi
+
+  local discovered
+  discovered="$(wp_cmd eval 'foreach ( (array) get_option( "active_plugins", array() ) as $p ) { if ( 0 === strpos( $p, "data-machine" ) ) { echo $p, "\n"; } }' 2>/dev/null || true)"
+
+  if [ -z "$discovered" ]; then
+    printf '%s\n' 'data-machine/data-machine.php'
+    return 0
+  fi
+
+  printf '%s\n' "$discovered" | tr -d '\r' | sed '/^$/d' | sort -u
+}
+
+runtime_guard_sync() {
+  local file
+  file="$(runtime_guard_mu_plugin_path)" || {
+    warn "  runtime_guard_sync: SITE_PATH not set — skipping"
+    return 1
+  }
+
+  # Engineering installs have a developer at the keyboard; the guard would be
+  # noise. Remove any guard left behind by a posture switch.
+  if ! source_policy_is_managed; then
+    if [ -f "$file" ]; then
+      if [ "${DRY_RUN:-false}" = true ]; then
+        echo -e "${BLUE}[dry-run]${NC} Would remove runtime guard mu-plugin $file"
+        return 0
+      fi
+      rm -f "$file"
+      log "  Removed runtime guard mu-plugin (posture is ${POSTURE:-engineering}): $file"
+      if [ -n "${UPDATED_ITEMS+x}" ]; then
+        UPDATED_ITEMS+=("runtime guard removed")
+      fi
+    fi
+    return 0
+  fi
+
+  local template="$SCRIPT_DIR/templates/wp-coding-agents-runtime-guard.php"
+  if [ ! -f "$template" ]; then
+    warn "  runtime_guard_sync: missing template $template"
+    return 1
+  fi
+
+  local entries=""
+  local plugin
+  while IFS= read -r plugin; do
+    [ -n "$plugin" ] || continue
+    entries="${entries}		'$(printf '%s' "$plugin" | sed "s/'/\\\\'/g")',"$'\n'
+  done < <(runtime_guard_plugins)
+
+  if [ -z "$entries" ]; then
+    warn "  runtime_guard_sync: no runtime plugins resolved — not writing an empty guard"
+    return 1
+  fi
+
+  local rendered
+  rendered="$(RUNTIME_GUARD_ENTRIES="$entries" python3 - "$template" <<'PY'
+import os, pathlib, sys
+template = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+begin = "\t\t// BEGIN wp-coding-agents-guarded-plugins\n"
+end = "\t\t// END wp-coding-agents-guarded-plugins"
+start = template.index(begin) + len(begin)
+stop = template.index(end)
+sys.stdout.write(template[:start] + os.environ["RUNTIME_GUARD_ENTRIES"] + template[stop:])
+PY
+)" || {
+    warn "  runtime_guard_sync: could not render guard template"
+    return 1
+  }
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would install runtime guard mu-plugin at $file guarding:"
+    printf '%s' "$entries" | sed 's/^/    /'
+    return 0
+  fi
+
+  local dir="${file%/*}"
+  mkdir -p "$dir"
+
+  if [ -f "$file" ] && printf '%s\n' "$rendered" | cmp -s - "$file"; then
+    service_file_normalize_perms "$file"
+    return 0
+  fi
+
+  printf '%s\n' "$rendered" > "$file"
+  service_file_normalize_perms "$file"
+  log "  Installed runtime guard mu-plugin: $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("runtime deactivation guard")
+  fi
+}

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect source-policy wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature agents-md-guidance; do
+for lib in common detect source-policy wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -512,6 +512,7 @@ runtime_generate_instructions
 runtime_merge_mcp_servers
 install_skills
 cli_transport_install
+runtime_guard_sync
 install_chat_bridge
 datamachine_worker_install
 print_summary

--- a/templates/wp-coding-agents-runtime-guard.php
+++ b/templates/wp-coding-agents-runtime-guard.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Plugin Name: wp-coding-agents — runtime deactivation guard
+ * Description: Prevents the agent runtime from being deactivated or deleted
+ *              through the wp-admin plugins screen on managed installs.
+ *              Managed by wp-coding-agents setup/upgrade — do not edit by hand.
+ *
+ * WHY THIS EXISTS
+ *
+ * On a managed install the site owner has wp-admin access and no reason to
+ * understand the plugins list. Deactivating Data Machine there costs them their
+ * assistant's memory and tools, with no obvious way back for a non-technical
+ * user.
+ *
+ * WHY NOT AN MU-PLUGIN MOVE
+ *
+ * Relocating the runtime into mu-plugins would also prevent deactivation, but
+ * WordPress fatal-error recovery PAUSES a plugin that fatals and cannot do that
+ * for an mu-plugin. Making the runtime unkillable would also make it
+ * unpausable, turning a broken assistant into a white screen on a live site.
+ * See Extra-Chill/wp-coding-agents#328 and #323.
+ *
+ * WP-CLI IS DELIBERATELY NOT GUARDED
+ *
+ * `wp plugin deactivate data-machine` stays available. That is the operator's
+ * recovery path and was used during the managed-posture rollout. This guard
+ * targets the admin UI, which is where the accident happens, not the CLI, which
+ * is where recovery happens.
+ *
+ * @package wp-coding-agents
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Plugin basenames this install protects.
+ *
+ * Written by wp-coding-agents at setup/upgrade time between the markers below.
+ *
+ * @return string[]
+ */
+function wp_coding_agents_guarded_runtime_plugins(): array {
+	$guarded = array(
+		// BEGIN wp-coding-agents-guarded-plugins
+		// END wp-coding-agents-guarded-plugins
+	);
+
+	/**
+	 * Filters the plugins protected from admin-UI deactivation.
+	 *
+	 * @param string[] $guarded Plugin basenames, e.g. 'data-machine/data-machine.php'.
+	 */
+	$filtered = apply_filters( 'wp_coding_agents_guarded_runtime_plugins', $guarded );
+
+	return is_array( $filtered ) ? array_values( array_filter( array_map( 'strval', $filtered ) ) ) : $guarded;
+}
+
+/**
+ * Replace the Deactivate and Delete links with a short explanation.
+ *
+ * The owner is told why rather than shown a row with missing controls, which
+ * reads as a broken page.
+ *
+ * @param string[] $actions     Action links keyed by action.
+ * @param string   $plugin_file Plugin basename.
+ * @return string[]
+ */
+function wp_coding_agents_guard_plugin_action_links( $actions, $plugin_file ) {
+	if ( ! is_array( $actions ) || ! in_array( (string) $plugin_file, wp_coding_agents_guarded_runtime_plugins(), true ) ) {
+		return $actions;
+	}
+
+	unset( $actions['deactivate'], $actions['delete'] );
+
+	$actions['wp-coding-agents-guard'] = '<span aria-label="' . esc_attr__( 'Required by this site\'s AI assistant', 'wp-coding-agents' ) . '">'
+		. esc_html__( 'Required by your assistant', 'wp-coding-agents' )
+		. '</span>';
+
+	return $actions;
+}
+add_filter( 'plugin_action_links', 'wp_coding_agents_guard_plugin_action_links', 100, 2 );
+add_filter( 'network_admin_plugin_action_links', 'wp_coding_agents_guard_plugin_action_links', 100, 2 );
+
+/**
+ * Reject a guarded deactivation or deletion request.
+ *
+ * Hiding the links is presentation only — the request can still be issued by
+ * URL, by a bulk action, or by any code calling deactivate_plugins(). This is
+ * the half that actually holds.
+ *
+ * Only wp-admin requests are refused. WP-CLI, WP-Cron, and REST are left alone
+ * so operator recovery and programmatic management keep working.
+ *
+ * @param string|string[] $plugins Plugin basename(s) being acted on.
+ * @return void
+ */
+function wp_coding_agents_block_guarded_deactivation( $plugins ): void {
+	if ( ( defined( 'WP_CLI' ) && WP_CLI ) || wp_doing_cron() ) {
+		return;
+	}
+
+	if ( ! function_exists( 'is_admin' ) || ! is_admin() ) {
+		return;
+	}
+
+	$guarded  = wp_coding_agents_guarded_runtime_plugins();
+	$requested = is_array( $plugins ) ? $plugins : array( $plugins );
+	$blocked   = array_intersect( array_map( 'strval', $requested ), $guarded );
+
+	if ( empty( $blocked ) ) {
+		return;
+	}
+
+	wp_die(
+		esc_html__(
+			'This plugin runs your site\'s AI assistant and cannot be deactivated or deleted from here. Ask your site operator if you need it changed.',
+			'wp-coding-agents'
+		),
+		esc_html__( 'Action not permitted', 'wp-coding-agents' ),
+		array( 'response' => 403, 'back_link' => true )
+	);
+}
+add_action( 'deactivate_plugin', 'wp_coding_agents_block_guarded_deactivation', 1 );
+add_action( 'delete_plugin', 'wp_coding_agents_block_guarded_deactivation', 1 );

--- a/tests/runtime-guard.sh
+++ b/tests/runtime-guard.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# tests/runtime-guard.sh — the agent runtime must survive the wp-admin plugins screen.
+#
+# Hiding the Deactivate link is presentation only; the request can still arrive
+# by URL, bulk action, or any caller of deactivate_plugins(). The server-side
+# refusal is the half that actually holds, so it is asserted behaviourally
+# rather than by grepping for the hook. See #328.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILED=0
+check() { if [ "$1" -eq 0 ]; then echo "  ok   $2"; else echo "  FAIL $2"; FAILED=$((FAILED + 1)); fi; }
+
+export SITE_PATH="$TMP/site"
+mkdir -p "$SITE_PATH/wp-content/mu-plugins"
+touch "$SITE_PATH/wp-config.php"
+export SCRIPT_DIR DRY_RUN=false
+export SITE="$SITE_PATH"
+UPDATED_ITEMS=()
+log() { :; }
+warn() { printf '%s\n' "$*" >&2; }
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/runtime-guard.sh"
+service_file_normalize_perms() { :; }
+wp_cmd() { printf 'data-machine/data-machine.php\ndata-machine-business/data-machine-business.php\n'; }
+
+GUARD="$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-runtime-guard.php"
+
+echo "==> the guard is posture-scoped"
+POSTURE=engineering runtime_guard_sync
+[ ! -f "$GUARD" ]; check $? "engineering installs no guard"
+
+POSTURE=managed runtime_guard_sync
+[ -f "$GUARD" ]; check $? "managed installs the guard"
+php -l "$GUARD" >/dev/null 2>&1; check $? "generated guard parses"
+
+grep -q "data-machine-business/data-machine-business.php" "$GUARD"
+check $? "companion plugins are discovered, not assumed"
+
+# A posture switch must clean up, or an engineering install keeps a guard
+# nothing maintains.
+POSTURE=engineering runtime_guard_sync
+[ ! -f "$GUARD" ]; check $? "switching to engineering removes the guard"
+POSTURE=managed runtime_guard_sync >/dev/null
+
+echo "==> behaviour: links hidden, request refused"
+php -r '
+$site = getenv("SITE");
+$died = null;
+$actions_seen = null;
+function add_filter($h,$c,$p=10,$a=1){ $GLOBALS["f"][$h][]=$c; }
+function add_action($h,$c,$p=10,$a=1){ $GLOBALS["f"][$h][]=$c; }
+function apply_filters($h,$v){ foreach(($GLOBALS["f"][$h]??[]) as $c){ $v=$c($v); } return $v; }
+// Dispatch through the registry. Calling the functions directly would pass
+// even if nobody had wired them to a hook.
+function fire($h, ...$args){
+  if (empty($GLOBALS["f"][$h])) { fwrite(STDERR, "NOT_HOOKED:$h\n"); exit(20); }
+  foreach ($GLOBALS["f"][$h] as $c) { $c(...$args); }
+}
+function filter_links($plugin, $actions){
+  if (empty($GLOBALS["f"]["plugin_action_links"])) { fwrite(STDERR,"NOT_HOOKED:plugin_action_links\n"); exit(21); }
+  foreach ($GLOBALS["f"]["plugin_action_links"] as $c) { $actions = $c($actions, $plugin); }
+  return $actions;
+}
+function esc_attr($s){ return $s; } function esc_html($s){ return $s; }
+function esc_attr__($s,$d=null){ return $s; } function esc_html__($s,$d=null){ return $s; }
+function is_admin(){ return true; }
+function wp_doing_cron(){ return false; }
+function wp_die($m,$t="",$a=[]){ throw new RuntimeException("WPDIE:".$m); }
+define("ABSPATH", "/");
+require $site."/wp-content/mu-plugins/wp-coding-agents-runtime-guard.php";
+
+// action links for a guarded plugin
+$a = ["activate"=>"x","deactivate"=>"<a>Deactivate</a>","delete"=>"<a>Delete</a>"];
+$out = filter_links("data-machine/data-machine.php", $a);
+if (isset($out["deactivate"]) || isset($out["delete"])) { fwrite(STDERR,"LINKS_PRESENT\n"); exit(2); }
+if (!isset($out["wp-coding-agents-guard"])) { fwrite(STDERR,"NO_EXPLANATION\n"); exit(3); }
+
+// an unrelated plugin keeps its links
+$b = filter_links("akismet/akismet.php", $a);
+if (!isset($b["deactivate"])) { fwrite(STDERR,"UNRELATED_STRIPPED\n"); exit(4); }
+
+// a forged deactivation of a guarded plugin is refused
+try { fire("deactivate_plugin", "data-machine/data-machine.php"); fwrite(STDERR,"NOT_BLOCKED\n"); exit(5); }
+catch (RuntimeException $e) { if (strpos($e->getMessage(),"WPDIE:")!==0) { exit(6); } }
+
+// an unrelated plugin deactivates normally
+try { fire("deactivate_plugin", "akismet/akismet.php"); }
+catch (RuntimeException $e) { fwrite(STDERR,"UNRELATED_BLOCKED\n"); exit(7); }
+
+// bulk action containing a guarded plugin is refused
+try { fire("delete_plugin", "data-machine/data-machine.php"); fwrite(STDERR,"DELETE_NOT_BLOCKED\n"); exit(8); }
+catch (RuntimeException $e) {}
+echo "OK\n";
+' >/dev/null 2>"$TMP/err"
+check $? "links removed, explanation shown, forged and bulk requests refused, unrelated plugins untouched"
+[ -s "$TMP/err" ] && sed 's/^/    /' "$TMP/err"
+
+echo "==> WP-CLI recovery stays open"
+php -r '
+$site = getenv("SITE");
+function add_filter($h,$c,$p=10,$a=1){} function add_action($h,$c,$p=10,$a=1){ $GLOBALS["f"][$h][]=$c; }
+function apply_filters($h,$v){ return $v; }
+function fire($h, ...$args){ foreach (($GLOBALS["f"][$h]??[]) as $c) { $c(...$args); } }
+function esc_attr($s){return $s;} function esc_html($s){return $s;}
+function esc_attr__($s,$d=null){return $s;} function esc_html__($s,$d=null){return $s;}
+function is_admin(){ return true; }
+function wp_doing_cron(){ return false; }
+function wp_die($m,$t="",$a=[]){ throw new RuntimeException("WPDIE"); }
+define("ABSPATH","/"); define("WP_CLI", true);
+require $site."/wp-content/mu-plugins/wp-coding-agents-runtime-guard.php";
+try { fire("deactivate_plugin", "data-machine/data-machine.php"); }
+catch (RuntimeException $e) { fwrite(STDERR,"CLI_BLOCKED\n"); exit(1); }
+echo "OK\n";
+' >/dev/null 2>&1
+check $? "wp plugin deactivate is not blocked — operator recovery is preserved"
+
+[ "$FAILED" -eq 0 ] || { echo; echo "FAILED: $FAILED"; exit 1; }
+echo
+echo "OK: runtime guard assertions passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature agents-md-guidance agents-md-backups; do
+for lib in common detect source-policy wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance agents-md-backups; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -481,6 +481,7 @@ sync_cli_transport_runtime() {
 
   log "Phase 2b: Syncing CLI dispatch transport..."
   cli_transport_install
+  runtime_guard_sync
 }
 
 update_ai_gateway() {


### PR DESCRIPTION
Closes #328. Supersedes #323.

On a managed install the site owner has wp-admin access and no reason to understand the plugins list. Deactivating Data Machine there costs them their assistant's memory and tools, with no obvious way back.

## Why not the mu-plugin move

#323 proposed relocating the runtime into `wp-content/mu-plugins/`. It would work, and it is the wrong instrument.

**WordPress fatal-error recovery *pauses* a plugin that fatals. It cannot do that for an mu-plugin.**

| | Data Machine fatals |
| --- | --- |
| regular plugin | WP pauses it — **site stays up**, agent gone, operator restores |
| mu-plugin | **white screen** — store down, no checkout |

Making the runtime unkillable also makes it unpausable. On a site taking card payments that trades "the assistant stopped working" for "the shop stopped taking money", and it moves a failure out of the range the agent can recover from into one only the operator can — the inverse of what the managed posture is for.

It would also fork the install layout on posture across `install_plugin`, `update_plugin_to_latest_tag`, and the recovery procedure, plus a loader stub since mu-plugins do not autoload subdirectories. #318, #320, and #322 were each posture leaking somewhere that should have stayed uniform.

Worth recording: the move only ever bought *deactivation* protection. Editing is already denied for both `wp-content/plugins/**` and `wp-content/mu-plugins/**` under managed (#322).

## What this does

A guard in the mu-plugin layer wp-coding-agents already installs:

- Deactivate and Delete links replaced with a short explanation, so the owner understands rather than seeing a row with missing controls
- **the request refused server-side** — hiding links is presentation only; the request can still arrive by URL, by bulk action, or from any caller of `deactivate_plugins()`

Both `deactivate_plugin` and `delete_plugin` fire immediately *before* the mutation in core, so `wp_die` prevents it.

## WP-CLI stays open, deliberately

`wp plugin deactivate data-machine` is the operator's recovery path — it was used on h44lacrosse.com during the managed-posture rollout. The guard targets wp-admin, where the accident happens, not the CLI, where recovery happens. `WP_CLI` and cron are exempted explicitly.

## Which plugins

`data-machine` unconditionally — wp-coding-agents installs it on every agent install, so that is a property of the product, not of one site. Companions are **discovered** from what is actually active rather than assumed, per the #320 rule about not naming a stack the tool has not inspected.

Written only under managed posture, and removed on a switch back so an engineering install cannot keep a guard nothing maintains.

## Tests

`tests/runtime-guard.sh` dispatches through the **captured hook registry** rather than calling the functions directly, so the `add_action`/`add_filter` wiring is part of what is tested.

That mattered: an earlier version called the functions directly and passed even with the hooks unregistered. Verified non-vacuous against four regressions —

| removed | result |
| --- | --- |
| `deactivate_plugin` hook | fails |
| `delete_plugin` hook | fails |
| `plugin_action_links` filter | fails |
| WP-CLI escape | fails |

Also covered: posture scoping, cleanup on switch, generated PHP parses, companions discovered, unrelated plugins untouched.

Full suite: no new failures (same 7 pre-existing environment failures as `main`). `bash -n` and `php -l` clean.