### PR TITLE
feat: migrate an installed root agent onto a non-root service user

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -147,6 +147,14 @@ jobs:
       - name: Run tests/posture.sh
         run: ./tests/posture.sh
 
+  service-migration:
+    name: root -> non-root service identity migration (#93)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/service-migration.sh
+        run: ./tests/service-migration.sh
+
   agents-md-guidance:
     name: AGENTS.md guidance registry
     runs-on: ubuntu-latest

--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -134,6 +134,33 @@ skill_is_enabled() {
 }
 
 skills_removed=0
+skills_unremovable=0
+
+# Best-effort removal inside the npm package directory.
+#
+# This script runs as ExecStartPre, as the SERVICE user, with `set -e` and no
+# `-` prefix on the unit directive — so any non-zero exit here blocks the
+# service from starting at all. The package dir is root-owned
+# (/usr/lib/node_modules/kimaki, 0755), which a non-root service user cannot
+# unlink from. An unguarded `rm -rf` therefore turns a supported install shape
+# into a service that will not boot, and it fails LATE: only once `npm update -g
+# kimaki` has recreated a bundled skill is there anything to remove.
+#
+# These removals are hygiene against npm restoring files we do not want on the
+# skill surface, not correctness. Not being able to perform them is worth a
+# warning, never a failed start.
+try_remove_package_path() {
+  local path="$1" label="$2"
+  if rm -rf "$path" 2>/dev/null; then
+    echo "kimaki-config: removed $label"
+    skills_removed=$((skills_removed + 1))
+    return 0
+  fi
+  echo "kimaki-config: WARNING: could not remove $label at $path (owned by another user?); leaving it in place"
+  skills_unremovable=$((skills_unremovable + 1))
+  return 0
+}
+
 if [[ ! -d "$SKILLS_DIR" ]]; then
   echo "kimaki-config: skills dir not found at $SKILLS_DIR, skipping package skill surface enforcement"
 else
@@ -141,16 +168,12 @@ else
     [[ -d "$skill_dir" ]] || continue
     skill_name="$(basename "$skill_dir")"
     if is_wp_coding_agents_skill "$skill_name"; then
-      rm -rf "$skill_dir"
-      echo "kimaki-config: removed package-local duplicate skill $skill_name"
-      skills_removed=$((skills_removed + 1))
+      try_remove_package_path "$skill_dir" "package-local duplicate skill $skill_name"
       continue
     fi
 
     if [[ -n "$SKILL_ENABLES_FILE" && -f "$SKILL_ENABLES_FILE" ]] && ! skill_is_enabled "$skill_name"; then
-      rm -rf "$skill_dir"
-      echo "kimaki-config: removed package-local skill outside allowlist $skill_name"
-      skills_removed=$((skills_removed + 1))
+      try_remove_package_path "$skill_dir" "package-local skill outside allowlist $skill_name"
     fi
   done
 fi
@@ -257,8 +280,14 @@ fi
 for obsolete_dir in "$PLUGIN_SOURCE_DIR" "$PLUGINS_DIR"; do
   obsolete_plugin="$obsolete_dir/homeboy-notification-context.ts"
   if [[ -e "$obsolete_plugin" ]]; then
-    rm -f "$obsolete_plugin"
-    echo "kimaki-config: removed obsolete plugin $obsolete_plugin"
+    # Same reasoning as try_remove_package_path: on a VPS PLUGINS_DIR is
+    # /opt/kimaki-config/plugins, which is root-owned, and this runs as the
+    # service user during ExecStartPre.
+    if rm -f "$obsolete_plugin" 2>/dev/null; then
+      echo "kimaki-config: removed obsolete plugin $obsolete_plugin"
+    else
+      echo "kimaki-config: WARNING: could not remove obsolete plugin $obsolete_plugin (owned by another user?)"
+    fi
   fi
 done
 

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -575,7 +575,7 @@ configure_homeboy_wordpress_extension() {
 
 recompose_agents_md_for_homeboy() {
   if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG"
+    echo -e "${BLUE}[dry-run]${NC} (as ${SERVICE_USER:-caller}) $WP_CMD datamachine memory compose AGENTS.md"
     return 0
   fi
 
@@ -583,7 +583,10 @@ recompose_agents_md_for_homeboy() {
     return 0
   fi
 
-  if (cd "$SITE_PATH" && $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG >/dev/null 2>&1); then
+  # As the service user — see wp_run_as_service_user(). A recompose that runs as
+  # root re-bakes `wp --allow-root` into the examples and would silently undo the
+  # correct file the main compose phase just wrote.
+  if (cd "$SITE_PATH" && wp_run_as_service_user datamachine memory compose AGENTS.md >/dev/null 2>&1); then
     log "AGENTS.md recomposed after Homeboy availability sync."
   else
     homeboy_handle_failure "Could not recompose AGENTS.md after Homeboy availability sync."

--- a/lib/service-migration.sh
+++ b/lib/service-migration.sh
@@ -275,6 +275,25 @@ service_migration_preflight() {
     error "Current service home '$old_home' does not exist; refusing to migrate from a home that was never used."
   fi
 
+  # An agent that drives this from inside its own chat bridge is sitting in the
+  # unit the migration stops. `systemctl stop kimaki.service` would kill the
+  # migration mid-move, with 8 GiB of state partly relocated, no unit rendered,
+  # and nothing left running to finish or report. Recovery would be by hand, on
+  # a box whose agent is now gone.
+  #
+  # It has to be a refusal rather than a warning, because the process that would
+  # read the warning is the one that disappears.
+  local current_unit unit
+  current_unit=$(service_migration_current_unit)
+  if [ -n "$current_unit" ]; then
+    while IFS= read -r unit; do
+      [ -n "$unit" ] || continue
+      if [ "$unit" = "$current_unit" ]; then
+        error "Refusing to migrate from inside '$current_unit' — this migration stops that unit, which would kill this process partway through. Re-run it detached from the service, e.g.: systemd-run --unit=wpca-migrate --same-dir --wait $0 --migrate-non-root"
+      fi
+    done <<<"$(service_migration_units)"
+  fi
+
   # A target home that already holds runtime state means a previous attempt got
   # partway, or the user is shared with another install. Merging two runtime
   # states silently corrupts session databases, so stop and let a human look.
@@ -303,6 +322,33 @@ service_migration_preflight() {
   fi
 
   return 0
+}
+
+# The systemd unit this process is running inside, empty when it is not under
+# one. An agent driving its own upgrade is inside the very unit the migration
+# stops (`0::/system.slice/kimaki.service`), so this is how it finds out.
+service_migration_current_unit() {
+  local line
+  [ -r /proc/self/cgroup ] || return 0
+  line=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup 2>/dev/null | head -1)
+  case "$line" in
+    */*.service) echo "${line##*/}" ;;
+    *) : ;;
+  esac
+}
+
+# The units the migration would stop, newline-separated.
+service_migration_units() {
+  local unit units=""
+  if declare -F bridge_systemd_units >/dev/null 2>&1; then
+    units="$(bridge_systemd_units)"
+  fi
+  if declare -F datamachine_worker_systemd_units >/dev/null 2>&1; then
+    units="$units $(datamachine_worker_systemd_units)"
+  fi
+  for unit in $units; do
+    [ -n "$unit" ] && echo "$unit"
+  done
 }
 
 # Read the identity the install is CURRENTLY running under, straight from the
@@ -348,35 +394,59 @@ service_migration_target_home() {
 # Kimaki's session store is SQLite in WAL mode; moving it under a live writer
 # corrupts it.
 service_migration_stop_units() {
-  local unit units=""
-  if declare -F bridge_systemd_units >/dev/null 2>&1; then
-    units="$(bridge_systemd_units)"
-  fi
-  if declare -F datamachine_worker_systemd_units >/dev/null 2>&1; then
-    units="$units $(datamachine_worker_systemd_units)"
-  fi
-  for unit in $units; do
+  local unit
+  while IFS= read -r unit; do
+    [ -n "$unit" ] || continue
     [ -f "/etc/systemd/system/$unit" ] || continue
     case "$unit" in
       *.timer|*.service) run_cmd systemctl stop "$unit" ;;
     esac
-  done
+  done <<<"$(service_migration_units)"
+}
+
+# The account's primary group. `useradd -m` creates a matching group for a new
+# account, but --migrate-user may name an existing one whose primary group is
+# something else entirely (`nobody` is in `nogroup` on Debian), and
+# `chown user:user` fails outright there rather than degrading.
+service_migration_user_group() {
+  local user="$1" group
+  group=$(id -gn "$user" 2>/dev/null) || group=""
+  [ -n "$group" ] && { echo "$group"; return 0; }
+  echo "$user"
 }
 
 # Move one inventory entry, preserving the parent structure (`.config/opencode`
 # has to land under a `.config` that exists and is owned by the service user).
+#
+# Every level created on the way down is chowned, not just the immediate parent.
+# `mkdir -p ~/.local/share` run as root creates BOTH levels root-owned; chowning
+# only `.local/share` leaves `.local` itself unwritable by the service user, so
+# anything that later wants `~/.local/bin` or `~/.local/state` fails with a
+# permission error far away from here.
 service_migration_move_path() {
   local rel="$1" old_home="$2" new_home="$3" user="$4"
   local src="$old_home/$rel" dest="$new_home/$rel"
 
   [ -e "$src" ] || return 0
 
-  local parent
+  local group parent
+  group=$(service_migration_user_group "$user")
   parent=$(dirname "$dest")
   run_cmd mkdir -p "$parent"
-  run_cmd chown "$user:$user" "$parent"
+
+  # Walk new_home -> parent, chowning each component.
+  local walk="$new_home" component
+  run_cmd chown "$user:$group" "$walk"
+  while IFS= read -r component; do
+    # dirname of a top-level entry like `.kimaki` is `.` — nothing to walk.
+    [ -n "$component" ] && [ "$component" != "." ] || continue
+    walk="$walk/$component"
+    [ "$walk" = "$dest" ] && break
+    run_cmd chown "$user:$group" "$walk"
+  done <<<"$(dirname "$rel" | tr '/' '\n')"
+
   run_cmd mv "$src" "$dest"
-  run_cmd chown -R "$user:$user" "$dest"
+  run_cmd chown -R "$user:$group" "$dest"
 }
 
 # Hand the WordPress install back to www-data with group write, and put the
@@ -404,7 +474,9 @@ service_migration_reclaim_workspace() {
   [ -n "$workspace" ] || return 0
   [ -d "$workspace" ] || return 0
 
-  run_cmd chown -R "$user:$user" "$workspace"
+  local group
+  group=$(service_migration_user_group "$user")
+  run_cmd chown -R "$user:$group" "$workspace"
 }
 
 # Run the migration. Assumes service_migration_preflight has already passed.
@@ -435,8 +507,10 @@ service_migration_run() {
   service_migration_stop_units
 
   log "  Moving agent state..."
+  local target_group
+  target_group=$(service_migration_user_group "$target_user")
   run_cmd mkdir -p "$new_home"
-  run_cmd chown "$target_user:$target_user" "$new_home"
+  run_cmd chown "$target_user:$target_group" "$new_home"
   while IFS= read -r rel; do
     [ -n "$rel" ] || continue
     if [ -e "$old_home/$rel" ] || [ "${DRY_RUN:-false}" = true ]; then
@@ -468,6 +542,13 @@ service_migration_run() {
   warn "OUT of the agent's reach. That is intentional. If the agent legitimately"
   warn "needed one of them, issue it a scoped credential under $new_home instead"
   warn "of moving the operator's."
+  # upgrade.sh does not restart services; it prints a restart hint at the end.
+  # That is fine for an ordinary upgrade, where the units were never stopped —
+  # but this migration DID stop them, so say so plainly rather than let the
+  # operator infer it from a hint that looks routine.
+  warn "Services were STOPPED for the migration and have not been restarted."
+  warn "Start them once you have checked the rendered units (see the restart"
+  warn "hint at the end of this run)."
 
   return 0
 }

--- a/lib/service-migration.sh
+++ b/lib/service-migration.sh
@@ -237,8 +237,19 @@ service_migration_estimate_bytes() {
 # Preflight
 # ---------------------------------------------------------------------------
 
+# The uid the migration would run as. A function rather than a bare $EUID read
+# so tests can exercise the checks that come after the privilege gate without
+# being root — the same seam SYSTEMD_UNIT_DIR provides for unit discovery.
+service_migration_effective_uid() {
+  echo "${EUID:-$(id -u)}"
+}
+
 # Fails closed on anything that would leave a half-migrated install. Changes
 # nothing, so it is safe to call before confirming with the operator.
+#
+# Argument validation comes before the privilege gate on purpose: a mistyped
+# --migrate-user should say so, not send the operator off to re-run under sudo
+# only to be told the flag was wrong all along.
 #
 # Args: <target_user> <old_home> <posture>
 service_migration_preflight() {
@@ -248,12 +259,16 @@ service_migration_preflight() {
     error "Service identity migration is not applicable to a local install (no systemd, no service user)."
   fi
 
-  if [ "${EUID:-$(id -u)}" -ne 0 ]; then
-    error "Service identity migration must run as root (sudo ./upgrade.sh --migrate-non-root)."
-  fi
-
   if [ "$target_user" = "root" ]; then
     error "Migration target user cannot be root — that is the identity being migrated away from."
+  fi
+
+  if [ -z "$target_user" ]; then
+    error "Migration target user cannot be empty."
+  fi
+
+  if [ "$(service_migration_effective_uid)" -ne 0 ]; then
+    error "Service identity migration must run as root (sudo ./upgrade.sh --migrate-non-root)."
   fi
 
   if [ ! -d "$old_home" ]; then

--- a/lib/service-migration.sh
+++ b/lib/service-migration.sh
@@ -1,0 +1,458 @@
+#!/bin/bash
+# lib/service-migration.sh — in-place migration of an installed agent from the
+# root service identity to a dedicated non-root service user.
+#
+# WHY THIS EXISTS
+#
+# `lib/detect.sh` has always been able to install non-root (`SERVICE_USER=opencode`,
+# `create_service_user`, `User=opencode` in every unit). What has never existed is
+# a way to move an install that is ALREADY running as root onto that path. #93
+# describes the consequence — root-owned files cascading through the site until
+# WordPress auto-update fails — and closes with "existing installs running as root
+# can migrate in-place without reinstalling everything". This module is that.
+#
+# Before this file, `./upgrade.sh --non-root` on a root install was a footgun. It
+# set SERVICE_USER_FORCED=true (skipping identity adoption), re-rendered every unit
+# with `User=opencode`, and did nothing else: it never created the user, and
+# because KIMAKI_DATA_DIR is derived from the service home, it silently repointed
+# the agent at an empty `/home/opencode/.kimaki` while the live session database,
+# runtime auth, and installed toolchains stayed behind in `/root`. The service came
+# back up amnesiac, or not at all.
+#
+# THE INVENTORY IS THE CAPABILITY BOUNDARY
+#
+# The important property of this migration is not the chown. It is that the new
+# service home starts EMPTY and is filled only from an explicit allowlist. `/root`
+# is mode 0700, so every path NOT in the inventory becomes unreachable to the agent
+# the moment the identity changes. That is the point.
+#
+# On the install this was written against, `/root` held `.ssh` (with private keys
+# to other machines in the fleet), `.secrets`, per-site database passwords, and API
+# tokens — all reachable by an agent running as root, none of them anything the
+# agent needs. Migrating is what takes them away. So the inventory below is not a
+# convenience list of "stuff to copy", it is a claim about what the agent is
+# entitled to, and it is deliberately enumerated rather than globbed (#318: a glob
+# that says "the agent's files" will, on somebody else's install, mean something
+# nobody intended).
+#
+# The inventory is posture-aware, which makes it the file-axis counterpart to the
+# capability table in #327:
+#
+#   managed       runtime state only. No dev toolchain, no forge credentials —
+#                 a managed agent has no git and no GitHub in its world at all,
+#                 so migrating them would hand over reach it has no use for.
+#   engineering   runtime state plus the dev toolchain and forge auth, because
+#                 that posture's whole job is workspace/git/GitHub work.
+#
+# Neither posture migrates SSH keys, secret stores, or shell history. There is no
+# flag to opt into that. An agent that needs to reach another host should be given
+# a scoped credential deliberately, not inherit the operator's.
+#
+# WHAT THIS MODULE DOES NOT DO
+#
+# It does not render systemd units. Once it has moved state and set SERVICE_USER /
+# SERVICE_HOME / KIMAKI_DATA_DIR, the existing upgrade phases re-render units from
+# those variables the same way they always have. Duplicating unit rendering here
+# would create a second source of truth for the thing #204 already fixed.
+#
+# Public surface:
+#   service_migration_runtime_paths           # newline-separated, HOME-relative
+#   service_migration_toolchain_paths         # newline-separated, HOME-relative
+#   service_migration_inventory <posture>     # the two above, per posture
+#   service_migration_excluded_paths          # documented never-migrate list
+#   service_migration_is_excluded <rel>       # 0 = must never be migrated
+#   service_migration_preflight               # fails closed, changes nothing
+#   service_migration_estimate_bytes <home> <posture>
+#   service_migration_run                     # the migration itself
+#
+# Honors DRY_RUN (logs intent, makes no changes).
+
+# Marker recording that an install has completed the migration, so a later
+# upgrade can tell "non-root because it was installed that way" apart from
+# "non-root because it was migrated" when reporting state to the operator.
+SERVICE_MIGRATION_OPTION="wp_coding_agents_service_identity_migrated"
+
+# Default target identity. Matches lib/detect.sh's non-root branch; changing one
+# without the other would strand state under a home nothing points at.
+SERVICE_MIGRATION_DEFAULT_USER="opencode"
+
+# ---------------------------------------------------------------------------
+# Inventory
+# ---------------------------------------------------------------------------
+
+# Runtime state: the agent's own brain. Without these the migrated service is
+# amnesiac — no sessions, no runtime auth, no CLI state. Migrated under every
+# posture because they are what "the agent" IS.
+service_migration_runtime_paths() {
+  cat <<'EOF'
+.kimaki
+.opencode
+.config/opencode
+.local/share/opencode
+.local/state/opencode
+.wp-cli
+EOF
+}
+
+# Dev toolchain and forge credentials. Engineering posture only: these exist to
+# serve workspace/git/GitHub work, which is precisely what managed posture does
+# not do. Handing a managed agent GitHub auth would widen its reach for no
+# capability it is ever asked to exercise.
+service_migration_toolchain_paths() {
+  cat <<'EOF'
+.cargo
+.rustup
+.bun
+.npm
+.local/share/pnpm
+.claude
+.claude.json
+.homeboy
+.config/homeboy
+.local/share/homeboy
+.config/gh
+.gitconfig
+.composer
+.config/composer
+.local/share/composer
+.config/go
+go
+EOF
+}
+
+# Paths that must never migrate, whatever the posture. Enumerated so the
+# exclusion is reviewable and testable rather than implied by absence — an
+# inventory that merely forgets `.ssh` is one careless addition away from
+# shipping it.
+#
+# These stay owned by root under a 0700 home, which is what removes them from
+# the agent's reach. That is the migration's security payload.
+service_migration_excluded_paths() {
+  cat <<'EOF'
+.ssh
+.secrets
+.pki
+.gnupg
+.aws
+.bash_history
+.mysql_history
+EOF
+}
+
+# 0 when the given HOME-relative path must never be migrated.
+#
+# Matches the explicit list above, plus two shape-based rules that catch the
+# operator-specific secrets this was written against (`.h44-secrets`,
+# `sweatpants-api-token.txt`, `opencode-auth-backup.json`). Those particular
+# names mean nothing on another install, so they are matched by shape — anything
+# announcing itself as a secret, credential, token, or password — rather than
+# named (#320: never assert install-specific facts in shipped code).
+service_migration_is_excluded() {
+  local rel="$1" excluded
+  while IFS= read -r excluded; do
+    [ -n "$excluded" ] || continue
+    [ "$rel" = "$excluded" ] && return 0
+    case "$rel" in "$excluded"/*) return 0 ;; esac
+  done <<<"$(service_migration_excluded_paths)"
+
+  # Deliberately broad. These patterns are asymmetric in cost: a false positive
+  # means the operator moves one directory by hand, a false negative means the
+  # agent is handed a credential and the migration still reports success. `*pass*`
+  # rather than `*password*` because the install this was written against had a
+  # database password in a file called `.h44-target-dbpass`, which the narrower
+  # pattern sailed straight past.
+  case "$rel" in
+    *secret*|*credential*|*token*|*pass*|*.pem|*.key|*auth-backup*)
+      return 0 ;;
+  esac
+  return 1
+}
+
+# Operator-declared extra paths, newline-separated, HOME-relative. Set by
+# --migrate-extra.
+#
+# The shipped inventory can only name paths that mean the same thing on every
+# install (#320). Real machines accumulate install-specific state next to it —
+# the box this was developed on had `homeboy-modules`, `go-sdk`, and a `bin` on
+# the service PATH, none of which a generic list can responsibly guess at. This
+# is where the operator names those, and it is still filtered through the
+# exclusion rules: the escape hatch does not become the way SSH keys travel.
+SERVICE_MIGRATION_EXTRA_PATHS="${SERVICE_MIGRATION_EXTRA_PATHS:-}"
+
+# The inventory for a posture, as newline-separated HOME-relative paths.
+# Excluded paths are filtered unconditionally, so neither a future edit to the
+# lists above nor an operator's --migrate-extra can leak a credential.
+service_migration_inventory() {
+  local posture="${1:-engineering}" rel
+
+  {
+    service_migration_runtime_paths
+    [ "$posture" != "managed" ] && service_migration_toolchain_paths
+    [ -n "$SERVICE_MIGRATION_EXTRA_PATHS" ] && printf '%s\n' "$SERVICE_MIGRATION_EXTRA_PATHS"
+  } | while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    service_migration_is_excluded "$rel" && continue
+    echo "$rel"
+  done
+}
+
+# Reject an operator-supplied extra path outright rather than silently dropping
+# it. Someone who types `--migrate-extra .ssh` has a reason in mind and needs to
+# be told it will not happen, not left to discover the agent cannot reach its
+# keys after the service has already moved.
+service_migration_add_extra_path() {
+  local rel="$1"
+
+  case "$rel" in
+    /*|*..*)
+      error "--migrate-extra takes a path relative to the service home, not '$rel'." ;;
+  esac
+
+  if service_migration_is_excluded "$rel"; then
+    error "Refusing --migrate-extra '$rel': it matches the credential exclusion list. Moving SSH keys or secret stores onto the service user would undo the reason for migrating. Move it by hand if you are certain."
+  fi
+
+  if [ -z "$SERVICE_MIGRATION_EXTRA_PATHS" ]; then
+    SERVICE_MIGRATION_EXTRA_PATHS="$rel"
+  else
+    SERVICE_MIGRATION_EXTRA_PATHS="$SERVICE_MIGRATION_EXTRA_PATHS
+$rel"
+  fi
+}
+
+# Total bytes the inventory occupies under a given home. Used by preflight to
+# refuse a migration that would fill the disk partway through.
+service_migration_estimate_bytes() {
+  local home="$1" posture="${2:-engineering}" rel total=0 sz
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    [ -e "$home/$rel" ] || continue
+    sz=$(du -sb "$home/$rel" 2>/dev/null | cut -f1)
+    [ -n "$sz" ] && total=$((total + sz))
+  done <<<"$(service_migration_inventory "$posture")"
+  echo "$total"
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+# Fails closed on anything that would leave a half-migrated install. Changes
+# nothing, so it is safe to call before confirming with the operator.
+#
+# Args: <target_user> <old_home> <posture>
+service_migration_preflight() {
+  local target_user="$1" old_home="$2" posture="${3:-engineering}"
+
+  if [ "${LOCAL_MODE:-false}" = true ]; then
+    error "Service identity migration is not applicable to a local install (no systemd, no service user)."
+  fi
+
+  if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+    error "Service identity migration must run as root (sudo ./upgrade.sh --migrate-non-root)."
+  fi
+
+  if [ "$target_user" = "root" ]; then
+    error "Migration target user cannot be root — that is the identity being migrated away from."
+  fi
+
+  if [ ! -d "$old_home" ]; then
+    error "Current service home '$old_home' does not exist; refusing to migrate from a home that was never used."
+  fi
+
+  # A target home that already holds runtime state means a previous attempt got
+  # partway, or the user is shared with another install. Merging two runtime
+  # states silently corrupts session databases, so stop and let a human look.
+  local new_home rel
+  new_home=$(service_migration_target_home "$target_user")
+  if [ -d "$new_home" ]; then
+    while IFS= read -r rel; do
+      [ -n "$rel" ] || continue
+      if [ -e "$new_home/$rel" ]; then
+        error "Target home '$new_home' already contains '$rel'. Refusing to merge runtime state — inspect and remove it, or choose another target user."
+      fi
+    done <<<"$(service_migration_inventory "$posture")"
+  fi
+
+  # Same-filesystem moves are renames and need no headroom; a cross-filesystem
+  # move needs the full inventory size free at the destination.
+  local old_fs new_fs need avail
+  old_fs=$(df -P "$old_home" 2>/dev/null | awk 'NR==2 {print $1}')
+  new_fs=$(df -P "$(dirname "$new_home")" 2>/dev/null | awk 'NR==2 {print $1}')
+  if [ -n "$old_fs" ] && [ "$old_fs" != "$new_fs" ]; then
+    need=$(service_migration_estimate_bytes "$old_home" "$posture")
+    avail=$(df -PB1 "$(dirname "$new_home")" 2>/dev/null | awk 'NR==2 {print $4}')
+    if [ -n "$avail" ] && [ "$need" -gt 0 ] && [ "$avail" -lt "$need" ]; then
+      error "Not enough space to migrate: need $((need / 1024 / 1024)) MiB at '$new_home', $((avail / 1024 / 1024)) MiB available."
+    fi
+  fi
+
+  return 0
+}
+
+# Read the identity the install is CURRENTLY running under, straight from the
+# installed units. Read-only counterpart to adopt_service_identity_from_units:
+# --non-root / --migrate-non-root set SERVICE_USER_FORCED=true, which suppresses
+# adoption, so the migration path needs its own way to see what it is migrating
+# FROM. Echoes nothing when no unit is installed.
+service_migration_installed_user() {
+  local unit_dir="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+  local unit units="" unit_user
+  if declare -F bridge_systemd_units >/dev/null 2>&1; then
+    units="$(bridge_systemd_units)"
+  fi
+  if declare -F datamachine_worker_systemd_units >/dev/null 2>&1; then
+    units="$units $(datamachine_worker_systemd_units)"
+  fi
+  for unit in $units; do
+    [ -f "$unit_dir/$unit" ] || continue
+    if declare -F _systemd_unit_user >/dev/null 2>&1; then
+      unit_user=$(_systemd_unit_user "$unit_dir/$unit") || continue
+    else
+      unit_user=$(awk -F= '/^User=/ {print $2; exit}' "$unit_dir/$unit")
+    fi
+    [ -n "$unit_user" ] && { echo "$unit_user"; return 0; }
+  done
+  return 0
+}
+
+# Resolve the home directory for a target user — the account's real home when it
+# already exists, the useradd default when it does not.
+service_migration_target_home() {
+  local user="$1" home
+  home=$(getent passwd "$user" 2>/dev/null | cut -d: -f6)
+  [ -n "$home" ] && { echo "$home"; return 0; }
+  echo "/home/$user"
+}
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+# Stop every unit that runs under the old identity before touching its state.
+# Kimaki's session store is SQLite in WAL mode; moving it under a live writer
+# corrupts it.
+service_migration_stop_units() {
+  local unit units=""
+  if declare -F bridge_systemd_units >/dev/null 2>&1; then
+    units="$(bridge_systemd_units)"
+  fi
+  if declare -F datamachine_worker_systemd_units >/dev/null 2>&1; then
+    units="$units $(datamachine_worker_systemd_units)"
+  fi
+  for unit in $units; do
+    [ -f "/etc/systemd/system/$unit" ] || continue
+    case "$unit" in
+      *.timer|*.service) run_cmd systemctl stop "$unit" ;;
+    esac
+  done
+}
+
+# Move one inventory entry, preserving the parent structure (`.config/opencode`
+# has to land under a `.config` that exists and is owned by the service user).
+service_migration_move_path() {
+  local rel="$1" old_home="$2" new_home="$3" user="$4"
+  local src="$old_home/$rel" dest="$new_home/$rel"
+
+  [ -e "$src" ] || return 0
+
+  local parent
+  parent=$(dirname "$dest")
+  run_cmd mkdir -p "$parent"
+  run_cmd chown "$user:$user" "$parent"
+  run_cmd mv "$src" "$dest"
+  run_cmd chown -R "$user:$user" "$dest"
+}
+
+# Hand the WordPress install back to www-data with group write, and put the
+# service user in that group. This is the same end state `setup_service_permissions`
+# produces for a fresh non-root install — the difference is only that here it has
+# to undo existing root ownership rather than establish it from nothing.
+service_migration_reclaim_site() {
+  local user="$1" site_path="$2"
+
+  [ -n "$site_path" ] || return 0
+  [ -d "$site_path" ] || return 0
+
+  run_cmd chown -R www-data:www-data "$site_path"
+  run_cmd chmod -R g+w "$site_path"
+  if declare -F harden_wp_config_permissions >/dev/null 2>&1; then
+    harden_wp_config_permissions "$site_path"
+  fi
+}
+
+# The agent's code workspace, when one exists (engineering posture only —
+# managed installs have no workspace by definition).
+service_migration_reclaim_workspace() {
+  local user="$1" workspace="$2"
+
+  [ -n "$workspace" ] || return 0
+  [ -d "$workspace" ] || return 0
+
+  run_cmd chown -R "$user:$user" "$workspace"
+}
+
+# Run the migration. Assumes service_migration_preflight has already passed.
+#
+# Args: <target_user> <old_home> <posture>
+#
+# On success, sets SERVICE_USER / SERVICE_HOME / KIMAKI_DATA_DIR / RUN_AS_ROOT /
+# SERVICE_USER_FORCED for the caller so the normal upgrade phases re-render every
+# unit against the new identity.
+service_migration_run() {
+  local target_user="$1" old_home="$2" posture="${3:-engineering}"
+  local new_home rel
+
+  new_home=$(service_migration_target_home "$target_user")
+
+  log "Migrating service identity: root -> $target_user"
+  log "  State home:  $old_home -> $new_home"
+  log "  Posture:     $posture"
+
+  if ! id -u "$target_user" >/dev/null 2>&1 || [ "${DRY_RUN:-false}" = true ]; then
+    log "  Creating service user '$target_user'..."
+    run_cmd useradd -m -s /bin/bash -G www-data "$target_user"
+  else
+    run_cmd usermod -a -G www-data "$target_user"
+  fi
+
+  log "  Stopping services under the old identity..."
+  service_migration_stop_units
+
+  log "  Moving agent state..."
+  run_cmd mkdir -p "$new_home"
+  run_cmd chown "$target_user:$target_user" "$new_home"
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    if [ -e "$old_home/$rel" ] || [ "${DRY_RUN:-false}" = true ]; then
+      log "    $rel"
+      service_migration_move_path "$rel" "$old_home" "$new_home" "$target_user"
+    fi
+  done <<<"$(service_migration_inventory "$posture")"
+
+  log "  Reclaiming WordPress file ownership..."
+  service_migration_reclaim_site "$target_user" "${SITE_PATH:-}"
+
+  if [ "$posture" != "managed" ]; then
+    log "  Reclaiming code workspace..."
+    service_migration_reclaim_workspace "$target_user" "${DM_WORKSPACE_DIR:-}"
+  fi
+
+  # Re-point the caller's identity variables. Everything downstream — unit
+  # rendering, bridge config, data dir creation — derives from these.
+  SERVICE_USER="$target_user"
+  SERVICE_HOME="$new_home"
+  RUN_AS_ROOT=false
+  SERVICE_USER_FORCED=true
+  if [ "${KIMAKI_DATA_DIR_EXPLICIT:-false}" != true ]; then
+    KIMAKI_DATA_DIR="$new_home/.kimaki"
+  fi
+
+  log "Service identity migration complete: User=$SERVICE_USER, HOME=$SERVICE_HOME"
+  warn "Credentials left behind in $old_home (SSH keys, secret stores) are now"
+  warn "OUT of the agent's reach. That is intentional. If the agent legitimately"
+  warn "needed one of them, issue it a scoped credential under $new_home instead"
+  warn "of moving the operator's."
+
+  return 0
+}

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -12,6 +12,40 @@ wp_cmd() {
   fi
 }
 
+# Run a WP-CLI command as the SERVICE user rather than the caller.
+#
+# Almost nothing needs this. AGENTS.md composition does, because the generated
+# text encodes the euid of the process that generated it: both
+# data-machine's datamachine_agents_md_wp_cli_cmd() and data-machine-code's
+# resolve_wp_cli_cmd() append `--allow-root` when posix_geteuid() === 0. Since
+# upgrade.sh runs under sudo, composing there writes an AGENTS.md that tells the
+# agent to run `wp --allow-root` — describing an identity a non-root agent does
+# not have. `--allow-root` is a harmless no-op for a non-root caller, so nothing
+# breaks; the file is simply wrong about the environment, which is the failure
+# #322 was about. Prose that misdescribes the runtime misinforms the agent.
+#
+# Composing as the identity that will READ the file makes the existing euid
+# detection correct by construction, rather than adding a second signal that can
+# disagree with the first.
+#
+# Mirrors homeboy_run() in lib/homeboy.sh, including its test seam.
+wp_run_as_service_user() {
+  if [ "${LOCAL_MODE:-false}" != true ] && \
+     [ -n "${SERVICE_USER:-}" ] && \
+     [ "$SERVICE_USER" != "root" ] && \
+     [ -n "${SERVICE_HOME:-}" ] && \
+     { [ "${WP_CODING_AGENTS_TEST_ASSUME_ROOT:-false}" = true ] || [ "$(id -u)" -eq 0 ]; } && \
+     command -v sudo >/dev/null 2>&1; then
+    # No WP_ROOT_FLAG: the whole point is that this invocation is not root.
+    # shellcheck disable=SC2086
+    sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" PATH="$PATH" $WP_CMD "$@"
+    return $?
+  fi
+
+  # shellcheck disable=SC2086
+  $WP_CMD "$@" $WP_ROOT_FLAG
+}
+
 # Activate a plugin, handling multisite --url= branching.
 activate_plugin() {
   local slug="$1"

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -283,6 +283,45 @@ else
 fi
 
 echo ""
+echo "service-migration: AGENTS.md is composed as the service user"
+
+# The generated text encodes the composing process's euid: data-machine and
+# data-machine-code both append `--allow-root` to their WP-CLI examples when
+# posix_geteuid() === 0. upgrade.sh runs under sudo, so composing as the caller
+# writes an AGENTS.md telling a non-root agent to run `wp --allow-root` — a file
+# that misdescribes the agent's own environment (#322). `--allow-root` is a
+# no-op for a non-root caller so nothing breaks, which is exactly why this would
+# otherwise go unnoticed.
+assert_contains "$(cat upgrade.sh)" "wp_run_as_service_user datamachine memory compose AGENTS.md" \
+  "upgrade.sh composes AGENTS.md as the service user"
+assert_contains "$(cat lib/homeboy.sh)" "wp_run_as_service_user datamachine memory compose AGENTS.md" \
+  "homeboy recompose also drops to the service user"
+
+# Every EXECUTING compose call site must go through the helper, or the one that
+# does not silently re-bakes --allow-root over the correct file. Dry-run echoes
+# and comments are prose about the call, not the call — strip grep's
+# `file:line:` prefix before testing for a leading `#`.
+stray=$(grep -n 'datamachine memory compose AGENTS.md' upgrade.sh lib/*.sh \
+  | grep -v 'wp_run_as_service_user' \
+  | grep -v 'dry-run' \
+  | sed 's/^[^:]*:[0-9]*: *//' \
+  | grep -v '^#' || true)
+if [ -z "$stray" ]; then
+  echo "  ok   no compose call site bypasses the service-user helper"
+else
+  echo "  FAIL compose call site bypasses the service-user helper:"
+  echo "$stray" | sed 's/^/         /'
+  FAILED=$((FAILED + 1))
+fi
+
+# The helper must not pass --allow-root when it has dropped privileges: the
+# whole point of that branch is that the invocation is not root.
+helper=$(sed -n '/^wp_run_as_service_user()/,/^}/p' lib/wordpress.sh)
+sudo_branch=$(printf '%s\n' "$helper" | sed -n '/sudo -n -H -u/p')
+refute_contains "$sudo_branch" 'WP_ROOT_FLAG' "service-user branch omits --allow-root"
+assert_contains "$helper" 'WP_ROOT_FLAG' "caller branch still passes the root flag"
+
+echo ""
 if [ "$FAILED" -eq 0 ]; then
   echo "service-migration: all assertions passed"
 else

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -283,6 +283,93 @@ else
 fi
 
 echo ""
+echo "service-migration: refuses to migrate from inside the unit it stops"
+
+# An agent driving its own upgrade runs inside the chat-bridge unit
+# (0::/system.slice/kimaki.service). Stopping that unit kills the migration
+# mid-move: state partly relocated, no unit rendered, nothing left running to
+# finish or report. It must refuse, and it must be a refusal rather than a
+# warning, because the process that would read the warning is the one that dies.
+out=$(bash -c '
+  source lib/service-migration.sh
+  log() { :; }; warn() { :; }
+  error() { echo "ERROR: $1"; exit 1; }
+  service_migration_effective_uid() { echo 0; }
+  service_migration_current_unit() { echo "kimaki.service"; }
+  bridge_systemd_units() { echo "kimaki.service"; }
+  LOCAL_MODE=false
+  service_migration_preflight opencode /root engineering
+' 2>&1 || true)
+assert_contains "$out" "Refusing to migrate from inside" "refuses self-hosted migration"
+assert_contains "$out" "systemd-run" "names a detached way to re-run it"
+
+# ...and does NOT refuse when the caller is outside the service (an SSH shell,
+# or systemd-run under its own transient unit).
+out=$(bash -c '
+  source lib/service-migration.sh
+  log() { :; }; warn() { :; }
+  error() { echo "ERROR: $1"; exit 1; }
+  service_migration_effective_uid() { echo 0; }
+  service_migration_current_unit() { echo ""; }
+  bridge_systemd_units() { echo "kimaki.service"; }
+  service_migration_target_home() { echo "'"$TMP"'/fresh-home"; }
+  LOCAL_MODE=false
+  service_migration_preflight opencode /root engineering && echo PREFLIGHT_OK
+' 2>&1 || true)
+assert_contains "$out" "PREFLIGHT_OK" "allows migration from outside the unit"
+
+echo ""
+echo "service-migration: state lands owned by the service user"
+
+# Every level created on the way down must be chowned, not just the immediate
+# parent: `mkdir -p ~/.local/share` as root creates BOTH root-owned, and
+# chowning only `.local/share` leaves `.local` unwritable — which surfaces later
+# as a permission error nowhere near this code.
+MOVE=$TMP/move
+mkdir -p "$MOVE/old/.local/share/opencode" "$MOVE/old/.kimaki" "$MOVE/new"
+echo data >"$MOVE/old/.local/share/opencode/sessions.db"
+
+MOVE_USER="daemon"
+MOVE_GROUP="$(id -gn "$MOVE_USER" 2>/dev/null || echo daemon)"
+
+if [ "$(id -u)" -eq 0 ]; then
+  (
+    log() { :; }; warn() { :; }; error() { echo "ERROR: $1"; exit 1; }
+    run_cmd() { "$@"; }
+    # shellcheck disable=SC1091
+    source lib/service-migration.sh
+    service_migration_move_path ".local/share/opencode" "$MOVE/old" "$MOVE/new" "$MOVE_USER"
+    service_migration_move_path ".kimaki" "$MOVE/old" "$MOVE/new" "$MOVE_USER"
+  ) >/dev/null 2>&1
+
+  for p in ".local" ".local/share" ".local/share/opencode" ".kimaki"; do
+    owner=$(stat -c '%U' "$MOVE/new/$p" 2>/dev/null || echo MISSING)
+    assert_eq "$owner" "$MOVE_USER" "$p is owned by the service user"
+  done
+  assert_eq "$(stat -c '%U' "$MOVE/new/.local/share/opencode/sessions.db" 2>/dev/null || echo MISSING)" \
+    "$MOVE_USER" "moved file contents are owned by the service user"
+  # The source must be gone — a copy would leave the old identity's session
+  # database live alongside the new one.
+  if [ ! -e "$MOVE/old/.kimaki" ]; then
+    echo "  ok   source path is moved, not copied"
+  else
+    echo "  FAIL source path still exists after migration"
+    FAILED=$((FAILED + 1))
+  fi
+else
+  echo "  skip ownership assertions (requires root)"
+fi
+
+# `chown user:user` assumes the primary group matches the account name. That
+# holds for a useradd-created `opencode` and not for an existing account named
+# via --migrate-user (`nobody` is in `nogroup` on Debian), where chown fails
+# outright rather than degrading.
+assert_eq "$(service_migration_user_group nobody)" "$(id -gn nobody)" \
+  "primary group is read from the account, not assumed"
+assert_eq "$(service_migration_user_group definitely-no-such-user-here)" \
+  "definitely-no-such-user-here" "falls back to the user name when absent"
+
+echo ""
 echo "service-migration: AGENTS.md is composed as the service user"
 
 # The generated text encodes the composing process's euid: data-machine and

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -222,7 +222,10 @@ out=$(LOCAL_MODE=true bash -c '
 ' 2>&1 || true)
 assert_contains "$out" "not applicable to a local install" "preflight refuses local mode"
 
-# Migrating "to" root is a no-op that would silently report success.
+# Argument validation must come BEFORE the privilege gate, so these assertions
+# hold whether or not the suite is running as root. CI runs unprivileged; the
+# development box runs as root. An ordering that only passes on one of them is
+# the bug this arrangement pins.
 out=$(bash -c '
   source lib/service-migration.sh
   log() { :; }; warn() { :; }
@@ -232,6 +235,17 @@ out=$(bash -c '
 ' 2>&1 || true)
 assert_contains "$out" "cannot be root" "preflight refuses root as target"
 
+# Privilege gate itself, forced on regardless of who is running the suite.
+out=$(bash -c '
+  source lib/service-migration.sh
+  log() { :; }; warn() { :; }
+  error() { echo "ERROR: $1"; exit 1; }
+  service_migration_effective_uid() { echo 1000; }
+  LOCAL_MODE=false
+  service_migration_preflight opencode /root engineering
+' 2>&1 || true)
+assert_contains "$out" "must run as root" "preflight refuses an unprivileged run"
+
 # A target home that already holds runtime state means a previous attempt got
 # partway. Merging two session databases corrupts both.
 mkdir -p "$TMP/home/opencode/.kimaki"
@@ -239,6 +253,7 @@ out=$(bash -c '
   source lib/service-migration.sh
   log() { :; }; warn() { :; }
   error() { echo "ERROR: $1"; exit 1; }
+  service_migration_effective_uid() { echo 0; }
   service_migration_target_home() { echo "'"$TMP"'/home/opencode"; }
   LOCAL_MODE=false
   service_migration_preflight opencode /root engineering

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -370,6 +370,60 @@ assert_eq "$(service_migration_user_group definitely-no-such-user-here)" \
   "definitely-no-such-user-here" "falls back to the user name when absent"
 
 echo ""
+echo "service-migration: ExecStartPre survives a root-owned package dir"
+
+# bridges/kimaki/post-upgrade.sh runs as ExecStartPre, as the SERVICE user,
+# under `set -euo pipefail`, with no `-` prefix on the unit directive — so any
+# non-zero exit blocks the service from starting at all. It removes bundled
+# skills from the npm package dir, which is root-owned (/usr/lib/node_modules,
+# 0755) and which a non-root service user cannot unlink from.
+#
+# This predates the migration: it breaks any `--non-root` install, a shape
+# setup.sh already supports. The migration is what makes it reachable. It also
+# fails LATE — only once `npm update -g kimaki` has recreated a bundled skill is
+# there anything to remove — so it would present as a service that mysteriously
+# stops booting long after the migration looked successful.
+assert_contains "$(cat bridges/kimaki/post-upgrade.sh)" "try_remove_package_path" \
+  "package-dir removals go through the best-effort helper"
+
+unguarded=$(grep -nE '^\s*rm -(rf|f) "\$(skill_dir|obsolete_plugin)"' bridges/kimaki/post-upgrade.sh || true)
+if [ -z "$unguarded" ]; then
+  echo "  ok   no unguarded rm on a package path remains"
+else
+  echo "  FAIL unguarded rm would abort ExecStartPre under set -e:"
+  echo "$unguarded" | sed 's/^/         /'
+  FAILED=$((FAILED + 1))
+fi
+
+# Behavioural: the helper must return 0 and keep going when the path cannot be
+# removed. An assertion on the text alone would not catch a helper that warns
+# and then still fails.
+if [ "$(id -u)" -eq 0 ]; then
+  EP=$TMP/execstartpre
+  mkdir -p "$EP/skills/upgrade-wp-coding-agents"
+  echo x >"$EP/skills/upgrade-wp-coding-agents/SKILL.md"
+  chmod -R go+rX "$TMP" 2>/dev/null || true
+  helper_src=$(sed -n '/^try_remove_package_path() {/,/^}/p' bridges/kimaki/post-upgrade.sh)
+  out=$(su -s /bin/bash nobody -c "bash -c '
+set -euo pipefail
+skills_removed=0; skills_unremovable=0
+$helper_src
+try_remove_package_path \"$EP/skills/upgrade-wp-coding-agents\" \"duplicate skill\"
+echo REACHED_END
+'" 2>&1 || true)
+  assert_contains "$out" "REACHED_END" "script continues past an unremovable path"
+  assert_contains "$out" "WARNING" "and warns about it"
+  if [ -d "$EP/skills/upgrade-wp-coding-agents" ]; then
+    echo "  ok   the unremovable path is left in place"
+  else
+    echo "  FAIL path was removed in a test that should not have been able to"
+    FAILED=$((FAILED + 1))
+  fi
+else
+  echo "  skip ExecStartPre behavioural check (requires root)"
+fi
+
+echo ""
 echo "service-migration: AGENTS.md is composed as the service user"
 
 # The generated text encodes the composing process's euid: data-machine and

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+# tests/service-migration.sh — root -> non-root service identity migration (#93).
+#
+# Three properties, in descending order of how badly they fail:
+#
+#   1. THE INVENTORY NEVER CARRIES A CREDENTIAL. The migration's actual security
+#      payload is that /root stays 0700 and root-owned, so anything NOT in the
+#      inventory becomes unreachable to the agent. An inventory that quietly
+#      picks up `.ssh` doesn't fail loudly — it hands the migrated agent private
+#      keys to every other machine in the fleet and looks like a successful
+#      migration while doing it. These assertions are the reason the exclusion
+#      list is enumerated rather than implied.
+#
+#   2. MANAGED GETS LESS THAN ENGINEERING. Posture is what decides whether the
+#      dev toolchain and forge credentials come across. If the two postures ever
+#      produce the same inventory, the file axis (#314) and the capability axis
+#      (#327) have silently collapsed into one, and managed installs are running
+#      with engineering reach.
+#
+#   3. --non-root ON A ROOT INSTALL FAILS CLOSED. This is the original #93
+#      footgun: it renders User=opencode, creates no user, and repoints
+#      KIMAKI_DATA_DIR at an empty home while the live session database stays in
+#      /root. Refusing is the fix; a passing migration is no good if the broken
+#      neighbouring flag is still reachable.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+FAILED=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "         got:  $got"
+    echo "         want: $want"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  case "$haystack" in
+    *"$needle"*) echo "  ok   $name" ;;
+    *)
+      echo "  FAIL $name (missing: $needle)"
+      FAILED=$((FAILED + 1))
+      ;;
+  esac
+}
+
+refute_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  case "$haystack" in
+    *"$needle"*)
+      echo "  FAIL $name (unexpectedly present: $needle)"
+      FAILED=$((FAILED + 1))
+      ;;
+    *) echo "  ok   $name" ;;
+  esac
+}
+
+assert_excluded() {
+  local rel="$1"
+  if service_migration_is_excluded "$rel"; then
+    echo "  ok   '$rel' is excluded"
+  else
+    echo "  FAIL '$rel' is NOT excluded — the migration would carry it to the agent"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# Stubs for the helpers lib/common.sh normally provides.
+log()  { echo "$1" >/dev/null; }
+warn() { echo "$1" >/dev/null; }
+info() { echo "$1" >/dev/null; }
+error() { echo "ERROR: $1" >&2; exit 1; }
+
+# shellcheck disable=SC1091
+source lib/service-migration.sh
+
+echo "service-migration: credential exclusion"
+
+# Named exclusions.
+for p in .ssh .secrets .pki .gnupg .aws .bash_history .mysql_history; do
+  assert_excluded "$p"
+done
+
+# Anything beneath a named exclusion.
+assert_excluded ".ssh/id_ed25519"
+assert_excluded ".ssh/config"
+assert_excluded ".secrets/database"
+
+# Shape-based rules. These are what catch the operator-specific names that
+# cannot be enumerated in shipped code (#320) — the install this was written
+# against had .h44-secrets, .h44-target-dbpass, sweatpants-api-token.txt and
+# opencode-auth-backup.json sitting in /root next to the agent's own state.
+assert_excluded ".h44-secrets"
+assert_excluded ".h44-target-dbpass"
+assert_excluded "sweatpants-api-token.txt"
+assert_excluded "sweatpants-signed-token-secret.txt"
+assert_excluded "opencode-auth-backup.json"
+assert_excluded "some-service.pem"
+assert_excluded "deploy.key"
+
+# And the inventories themselves must be clean under BOTH postures, which is
+# the assertion that survives someone adding an entry to the lists later.
+for posture in engineering managed; do
+  inv="$(service_migration_inventory "$posture")"
+  for bad in .ssh .secrets .pki .gnupg .aws .bash_history; do
+    refute_contains "$inv" "$bad" "$posture inventory omits $bad"
+  done
+done
+
+echo ""
+echo "service-migration: posture shapes the inventory"
+
+eng="$(service_migration_inventory engineering)"
+man="$(service_migration_inventory managed)"
+
+# Runtime state is what the agent IS — required under every posture, or the
+# migrated service comes back with no sessions and no runtime auth.
+for p in .kimaki .config/opencode .local/share/opencode; do
+  assert_contains "$eng" "$p" "engineering carries $p"
+  assert_contains "$man" "$p" "managed carries $p"
+done
+
+# Dev toolchain and forge credentials are engineering-only. A managed agent has
+# no git, no GitHub, and no build step in its world (#314), so migrating these
+# would widen its reach for a capability it is never asked to exercise.
+for p in .cargo .rustup .bun .config/gh .gitconfig .homeboy; do
+  assert_contains "$eng" "$p" "engineering carries $p"
+  refute_contains "$man" "$p" "managed omits $p"
+done
+
+# The postures must not converge. If this fails, the capability distinction is
+# gone regardless of what the individual assertions above say.
+if [ "$eng" = "$man" ]; then
+  echo "  FAIL engineering and managed inventories are identical"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   engineering and managed inventories differ"
+fi
+
+eng_count=$(printf '%s\n' "$eng" | grep -c . || true)
+man_count=$(printf '%s\n' "$man" | grep -c . || true)
+if [ "$man_count" -lt "$eng_count" ]; then
+  echo "  ok   managed inventory is smaller ($man_count < $eng_count)"
+else
+  echo "  FAIL managed inventory ($man_count) is not smaller than engineering ($eng_count)"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+echo "service-migration: --migrate-extra escape hatch"
+
+# The hatch exists because a shipped inventory cannot name install-specific
+# state (#320). It must not become the route a credential travels.
+(
+  SERVICE_MIGRATION_EXTRA_PATHS=""
+  service_migration_add_extra_path "homeboy-modules"
+  service_migration_add_extra_path "go-sdk"
+  inv="$(service_migration_inventory engineering)"
+  assert_contains "$inv" "homeboy-modules" "extra path is carried"
+  assert_contains "$inv" "go-sdk" "second extra path is carried"
+  # And still absent from managed's runtime-only base set unless asked for.
+  assert_contains "$(service_migration_inventory managed)" "homeboy-modules" \
+    "extra paths apply under managed too"
+) || FAILED=$((FAILED + 1))
+
+for bad in .ssh .secrets deploy.key ".h44-target-dbpass"; do
+  out=$(bash -c '
+    source lib/service-migration.sh
+    error() { echo "ERROR: $1"; exit 1; }
+    service_migration_add_extra_path "'"$bad"'"
+  ' 2>&1 || true)
+  assert_contains "$out" "credential exclusion list" "--migrate-extra $bad is refused"
+done
+
+# Escaping the service home entirely would let the hatch reach anything on disk.
+for bad in "/etc/shadow" "../root/.ssh"; do
+  out=$(bash -c '
+    source lib/service-migration.sh
+    error() { echo "ERROR: $1"; exit 1; }
+    service_migration_add_extra_path "'"$bad"'"
+  ' 2>&1 || true)
+  assert_contains "$out" "relative to the service home" "--migrate-extra $bad is refused"
+done
+
+echo ""
+echo "service-migration: installed-identity read"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/units"
+bridge_systemd_units() { echo "kimaki.service"; }
+
+# No unit installed -> empty, so --migrate-non-root can tell "fresh install"
+# apart from "installed and running as root".
+SYSTEMD_UNIT_DIR="$TMP/units"
+assert_eq "$(service_migration_installed_user)" "" "no unit yields empty identity"
+
+printf '[Service]\nUser=root\nExecStart=/bin/true\n' >"$TMP/units/kimaki.service"
+assert_eq "$(service_migration_installed_user)" "root" "reads User=root"
+
+printf '[Service]\nUser=opencode\nExecStart=/bin/true\n' >"$TMP/units/kimaki.service"
+assert_eq "$(service_migration_installed_user)" "opencode" "reads User=opencode"
+
+echo ""
+echo "service-migration: preflight fails closed"
+
+# Local installs have no systemd and no service user to migrate onto.
+out=$(LOCAL_MODE=true bash -c '
+  source lib/service-migration.sh
+  log() { :; }; warn() { :; }
+  error() { echo "ERROR: $1"; exit 1; }
+  service_migration_preflight opencode /root engineering
+' 2>&1 || true)
+assert_contains "$out" "not applicable to a local install" "preflight refuses local mode"
+
+# Migrating "to" root is a no-op that would silently report success.
+out=$(bash -c '
+  source lib/service-migration.sh
+  log() { :; }; warn() { :; }
+  error() { echo "ERROR: $1"; exit 1; }
+  LOCAL_MODE=false
+  service_migration_preflight root /root engineering
+' 2>&1 || true)
+assert_contains "$out" "cannot be root" "preflight refuses root as target"
+
+# A target home that already holds runtime state means a previous attempt got
+# partway. Merging two session databases corrupts both.
+mkdir -p "$TMP/home/opencode/.kimaki"
+out=$(bash -c '
+  source lib/service-migration.sh
+  log() { :; }; warn() { :; }
+  error() { echo "ERROR: $1"; exit 1; }
+  service_migration_target_home() { echo "'"$TMP"'/home/opencode"; }
+  LOCAL_MODE=false
+  service_migration_preflight opencode /root engineering
+' 2>&1 || true)
+assert_contains "$out" "already contains" "preflight refuses to merge runtime state"
+
+echo ""
+echo "service-migration: --non-root on a root install is refused"
+
+# The #93 footgun. Reachability of the guard matters as much as its wording:
+# upgrade.sh must consult the INSTALLED unit, not the flag-derived default,
+# because --non-root suppresses identity adoption.
+assert_contains "$(cat upgrade.sh)" "Use --migrate-non-root to move it properly" \
+  "upgrade.sh refuses bare --non-root on a root install"
+assert_contains "$(cat upgrade.sh)" 'INSTALLED_SERVICE_USER="$(service_migration_installed_user)"' \
+  "upgrade.sh reads the installed identity independently of the forced flag"
+
+# The migration must run before anything renders a unit or writes into the
+# service home, and after UPDATED_ITEMS exists so it can report itself.
+mig_line=$(grep -n 'service_migration_run' upgrade.sh | head -1 | cut -d: -f1)
+items_line=$(grep -n '^UPDATED_ITEMS=()' upgrade.sh | head -1 | cut -d: -f1)
+if [ -n "$mig_line" ] && [ -n "$items_line" ] && [ "$mig_line" -gt "$items_line" ]; then
+  echo "  ok   migration runs after UPDATED_ITEMS is declared"
+else
+  echo "  FAIL migration at line ${mig_line:-?} must come after UPDATED_ITEMS at line ${items_line:-?}"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "service-migration: all assertions passed"
+else
+  echo "service-migration: $FAILED assertion(s) failed"
+  exit 1
+fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance agents-md-backups; do
+for lib in common detect source-policy service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance agents-md-backups; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -134,6 +134,10 @@ WITH_HOMEBOY="${WITH_HOMEBOY:-false}"
 # True when the operator forced the identity via --root / --non-root.
 # Suppresses adopt_service_identity_from_units (existing-unit adoption).
 SERVICE_USER_FORCED=false
+# Set by --migrate-non-root: move an already-installed root agent onto a
+# dedicated non-root service user, carrying its state across. See #93.
+MIGRATE_NON_ROOT=false
+MIGRATE_TARGET_USER="$SERVICE_MIGRATION_DEFAULT_USER"
 initialize_kimaki_overrides
 
 while [[ $# -gt 0 ]]; do
@@ -165,6 +169,9 @@ while [[ $# -gt 0 ]]; do
     --local)         LOCAL_MODE=true; RUN_AS_ROOT=false; shift ;;
     --root)          RUN_AS_ROOT=true;  SERVICE_USER_FORCED=true; shift ;;
     --non-root)      RUN_AS_ROOT=false; SERVICE_USER_FORCED=true; shift ;;
+    --migrate-non-root) MIGRATE_NON_ROOT=true; RUN_AS_ROOT=false; SERVICE_USER_FORCED=true; shift ;;
+    --migrate-user)  MIGRATE_TARGET_USER="$2"; shift 2 ;;
+    --migrate-extra) service_migration_add_extra_path "$2"; shift 2 ;;
     --help|-h)       SHOW_HELP=true; shift ;;
     *)               shift ;;
   esac
@@ -234,6 +241,28 @@ SERVICE IDENTITY:
   installed systemd unit (its User= line) rather than assuming root.
   The upgrade never changes the service identity implicitly; use
   --root / --non-root to change it deliberately.
+
+  ./upgrade.sh --migrate-non-root
+                                Move an install that currently runs as root
+                                onto a dedicated non-root service user,
+                                carrying the agent's state across. Use this
+                                rather than --non-root, which only re-renders
+                                the unit and would strand the agent's state
+                                in /root.
+  ./upgrade.sh --migrate-user <name>
+                                Target user for --migrate-non-root
+                                (default: $SERVICE_MIGRATION_DEFAULT_USER).
+  ./upgrade.sh --migrate-extra <path>
+                                Carry an additional service-home-relative path
+                                across. Repeatable. For install-specific state
+                                the shipped inventory cannot know about.
+                                Credential-shaped paths are refused.
+
+  What migrates is an explicit, posture-aware allowlist: runtime state
+  under every posture, plus the dev toolchain and forge credentials under
+  engineering posture only. SSH keys, secret stores, and shell history are
+  never migrated — they stay behind in root-owned /root, out of the agent's
+  reach. That is the point of the migration, not a side effect.
 
 SUPPORTED CHAT BRIDGES:
   kimaki, cc-connect, telegram  (auto-detected per environment)
@@ -406,6 +435,23 @@ if [ "$DRY_RUN" = false ] && [ "$LOCAL_MODE" = false ] && [ "$RUN_AS_ROOT" = tru
   error "Please run as root (sudo ./upgrade.sh), or use --non-root for installs whose service and WordPress files are writable by the current user."
 fi
 
+# Service identity, as the units on disk actually have it. --non-root and
+# --migrate-non-root both set SERVICE_USER_FORCED=true, which suppresses
+# adoption above, so this is the only thing that still knows what the install is
+# running as TODAY — which both branches below need. Read-only.
+INSTALLED_SERVICE_USER="$(service_migration_installed_user)"
+
+# --non-root alone only forces the identity the units are RENDERED with. On an
+# install already running as root that is a footgun (#93): the service user may
+# not exist, and KIMAKI_DATA_DIR is derived from the service home, so the agent
+# gets repointed at an empty home while its session database, runtime auth, and
+# toolchains stay behind in /root. Refuse early, before any mutation, and name
+# the flag that does it properly rather than render a broken unit.
+if [ "$MIGRATE_NON_ROOT" = false ] && [ "$LOCAL_MODE" = false ] && \
+   [ "$RUN_AS_ROOT" = false ] && [ "$INSTALLED_SERVICE_USER" = "root" ]; then
+  error "This install currently runs as root. --non-root only re-renders the unit; it would not create the service user or carry the agent's state across, leaving the service pointed at an empty home. Use --migrate-non-root to move it properly."
+fi
+
 log "Runtime:     $RUNTIME"
 log "Chat bridge: ${CHAT_BRIDGE:-none detected}"
 log "Site path:   $SITE_PATH"
@@ -422,6 +468,22 @@ echo ""
 
 # Track what was touched for the summary
 UPDATED_ITEMS=()
+
+# Service identity migration (#93). Runs before any phase that renders a unit or
+# writes into the service home, so everything downstream sees the new identity.
+# Deliberately after UPDATED_ITEMS is declared — it reports into the summary.
+if [ "$MIGRATE_NON_ROOT" = true ]; then
+  if [ -z "$INSTALLED_SERVICE_USER" ]; then
+    error "--migrate-non-root found no installed systemd unit to migrate. Use ./setup.sh --non-root for a fresh install."
+  elif [ "$INSTALLED_SERVICE_USER" != "root" ]; then
+    log "Install already runs as '$INSTALLED_SERVICE_USER' — nothing to migrate."
+    MIGRATE_NON_ROOT=false
+  else
+    service_migration_preflight "$MIGRATE_TARGET_USER" "/root" "$POSTURE"
+    service_migration_run "$MIGRATE_TARGET_USER" "/root" "$POSTURE"
+    UPDATED_ITEMS+=("Service identity migrated: root -> $SERVICE_USER")
+  fi
+fi
 
 # Set true when opencode.json is found to have plugin-array drift and the
 # --repair-opencode-json flag was NOT passed. Shown loudly in print_summary.

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -905,7 +905,7 @@ regenerate_agents_md() {
     echo -e "${BLUE}[dry-run]${NC} Would backup $AGENTS_MD → $BACKUP"
     echo -e "${BLUE}[dry-run]${NC} Would sync WordPress coding-agent boundary guidance mu-plugin"
     echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy AGENTS.md CLI guidance mu-plugin"
-    echo -e "${BLUE}[dry-run]${NC} Would run: $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG"
+    echo -e "${BLUE}[dry-run]${NC} Would run (as ${SERVICE_USER:-caller}): $WP_CMD datamachine memory compose AGENTS.md"
     if _runtime_detected opencode; then
       echo -e "${BLUE}[dry-run]${NC} Would symlink $CLAUDE_MD → AGENTS.md (Claude-model context)"
     fi
@@ -925,12 +925,19 @@ regenerate_agents_md() {
 
   # `datamachine memory compose AGENTS.md` writes in-place to the registered
   # composable file path. It does NOT accept an arbitrary output path —
-  # the filename must be a registered MemoryFileRegistry entry. Compose runs
-  # as the wp-coding-agents caller's identity (root during upgrade, opencode
-  # during local dev), so normalize afterward the same way every other
-  # service-file writer does — otherwise the identity that ran this upgrade
-  # is the only one that can write AGENTS.md until the next normalize.
-  if (cd "$SITE_PATH" && $WP_CMD datamachine memory compose AGENTS.md $WP_ROOT_FLAG >/dev/null 2>&1); then
+  # the filename must be a registered MemoryFileRegistry entry.
+  #
+  # Composed AS THE SERVICE USER, not as the caller. The generated text encodes
+  # the composing process's euid — data-machine and data-machine-code both
+  # append `--allow-root` to their WP-CLI examples when posix_geteuid() === 0 —
+  # and upgrade.sh runs under sudo. Composing here as root would write an
+  # AGENTS.md instructing a non-root agent to run `wp --allow-root`, i.e. a file
+  # that misdescribes the agent's own environment (#93, #322).
+  #
+  # Permissions are still normalized afterward: compose writes as whichever
+  # identity ran it, and without this every other writer is locked out until the
+  # next normalize.
+  if (cd "$SITE_PATH" && wp_run_as_service_user datamachine memory compose AGENTS.md >/dev/null 2>&1); then
     service_file_normalize_perms "$AGENTS_MD"
     if [ -f "$BACKUP" ] && cmp -s "$BACKUP" "$AGENTS_MD"; then
       log "  AGENTS.md unchanged"


### PR DESCRIPTION
Closes #93.

## The gap

`lib/detect.sh` has always been able to *install* non-root — `SERVICE_USER=opencode`, `create_service_user`, `User=opencode` in every unit. What has never existed is a way to move an install that is **already running as root** onto that path. That is why every box in the fleet is still root.

`./upgrade.sh --non-root` looked like it did this and did not:

- set `SERVICE_USER_FORCED=true` (suppressing identity adoption)
- re-rendered every unit with `User=opencode`
- **never created the user**
- and because `KIMAKI_DATA_DIR` derives from the service home, silently repointed the agent at an empty `/home/opencode/.kimaki` while the live session database, runtime auth, and installed toolchains stayed in `/root`

The service came back amnesiac, or not at all. `upgrade.sh` calls no infrastructure functions at all — `setup_service_permissions` is `setup.sh`-only — so nothing chowned anything either. That path now fails closed and names the flag that works.

## The inventory *is* the capability boundary

The important property is not the chown. The new service home starts **empty** and is filled only from an explicit allowlist. `/root` is mode `0700`, so everything outside the inventory becomes unreachable the moment the identity changes.

Measured on the development box, `/root` held:

```
.ssh/           private keys to other machines in the fleet
.secrets/
.h44-secrets, .h44-target-dbpass      per-site database credentials
sweatpants-api-token.txt, ...
opencode-auth-backup.json
```

All reachable by the agent today. None of it anything the agent needs. **Migrating is what takes them away** — that is the point of the change, not a side effect.

## Posture-aware

This makes the migration the file-axis counterpart to the capability table in #327:

| | runtime state | dev toolchain + forge auth | credentials |
|---|---|---|---|
| managed | yes | no | never |
| engineering | yes | yes | never |

A managed agent has no git, no GitHub, and no build step in its world (#314), so migrating `.cargo`/`.config/gh` would widen its reach for a capability it is never asked to exercise. There is no flag to opt into credentials.

## Exclusion has two layers

A list that merely *forgets* `.ssh` is one careless addition away from shipping it. So: named paths, plus shape-based patterns for the operator-specific names shipped code cannot responsibly guess at (#320).

The patterns are deliberately broad, because the costs are asymmetric — a false positive means the operator moves one directory by hand; a false negative hands over a credential *and still reports success*. `*pass*` rather than `*password*` because `.h44-target-dbpass` sailed straight past the narrower pattern. **The test caught that, not review.**

`--migrate-extra` covers install-specific state the shipped inventory can't know about (`homeboy-modules`, `go-sdk`), and runs through the same exclusions so the escape hatch doesn't become the route keys travel. Supplying `--migrate-extra .ssh` is refused with an explanation rather than silently dropped.

## Deliberately not included

**Unit rendering.** Once the migration sets `SERVICE_USER` / `SERVICE_HOME` / `KIMAKI_DATA_DIR`, the existing phases render from those exactly as before. A second renderer here would fork the source of truth #204 established.

## Validation

Dry-run against the real install: **8.6 GiB migrates** (same-filesystem, so renames), **every credential on the box excluded**.

New CI job `service-migration`. Siblings re-run green locally: `posture`, `service-identity-adoption`, `runtime-guard`, `bridge-render`, `repair-opencode-json`; `bash -n` clean across the repo.

## Not yet applied anywhere

This ships the mechanism. Applying it is a separate, deliberate operator step — h44 first (managed, least state), chubes.net last, since it is the box that holds the fleet keys and the one running the agent that wrote this.