### PR TITLE
feat: owned mode defaults to a non-root service user

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -147,6 +147,14 @@ jobs:
       - name: Run tests/source-mode.sh
         run: ./tests/source-mode.sh
 
+  service-identity-defaults:
+    name: owned mode defaults to non-root (#327)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/service-identity-defaults.sh
+        run: ./tests/service-identity-defaults.sh
+
   service-migration:
     name: root -> non-root service identity migration (#93)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -206,6 +206,25 @@ read-only reference there. What it buys is git and review, not latitude.
 | Workspace, git, GitHub | the agent's workflow | not present |
 | How changes reach version control | the agent commits and opens pull requests | captured out-of-band by the operator |
 | Runtimes | all | `opencode` only |
+| Service user | root by default | **non-root by default** (`opencode`) |
+
+### The service user is the boundary that holds
+
+The edit rules above are a guardrail, not containment. `permission.edit` gates
+the runtime's edit tool; `bash` is a separate permission key, unset and
+therefore allowed. A service running as root reaches every denied path through
+`bash -c`, `wp eval`, or a PHP one-liner regardless of what the edit rules say.
+
+So owned installs default to a dedicated non-root service user. That one is
+enforced by the kernel rather than a config file: a non-root agent cannot
+`apt install`, cannot rewrite a systemd unit, cannot read another site's
+credentials, and cannot write `wp-admin/` whichever tool it reaches for.
+
+Workspace installs keep the root default — that box belongs to a developer who
+chose it. Existing installs of either mode are never flipped implicitly, since
+that would strand the agent's state in the old home; migrate deliberately with
+`sudo ./upgrade.sh --migrate-non-root`, which moves the agent's runtime state
+across and leaves SSH keys and secret stores behind in root-owned `/root`.
 
 Both modes point the agent at the installed WordPress source as reference —
 that is the section's purpose, and it is why a small model can be competent

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -177,21 +177,91 @@ detect_environment() {
   WP_ADMIN_PASS="${WP_ADMIN_PASS:-$(openssl rand -base64 16)}"
   WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL:-admin@$SITE_DOMAIN}"
 
-  # Service user configuration
+  detect_service_identity
+}
+
+# Derive SERVICE_USER / SERVICE_HOME / KIMAKI_DATA_DIR / DM_WORKSPACE_DIR from
+# LOCAL_MODE and RUN_AS_ROOT.
+#
+# Split out of detect_environment so it can be re-derived. setup.sh resolves the
+# source mode AFTER detection — the mode is read from the site, which detection
+# is what finds — and the owned mode defaults to a non-root service user (#327).
+# Without a way to recompute, that default could only flip RUN_AS_ROOT and would
+# leave SERVICE_USER, the service home, and the data dir all still pointing at
+# root: exactly the half-applied identity that #204 and #93 are both about.
+#
+# Idempotent. KIMAKI_DATA_DIR is recomputed unless the operator set it
+# explicitly (env var or --kimaki-data-dir), so a second call cannot pin the
+# data dir to the home of the identity that was current on the first call.
+detect_service_identity() {
   if [ "$LOCAL_MODE" = true ]; then
     SERVICE_USER="$(whoami)"
     SERVICE_HOME="$HOME"
-    KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-$HOME/.kimaki}"
+    _detect_default_kimaki_data_dir "$HOME/.kimaki"
     DM_WORKSPACE_DIR="${DATAMACHINE_WORKSPACE_PATH:-$HOME/.datamachine/workspace}"
   elif [ "$RUN_AS_ROOT" = true ]; then
     SERVICE_USER="root"
     SERVICE_HOME="/root"
-    KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-/root/.kimaki}"
+    _detect_default_kimaki_data_dir "/root/.kimaki"
     DM_WORKSPACE_DIR="${DATAMACHINE_WORKSPACE_PATH:-/var/lib/datamachine/workspace}"
   else
     SERVICE_USER="opencode"
     SERVICE_HOME="/home/opencode"
-    KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-/home/opencode/.kimaki}"
+    _detect_default_kimaki_data_dir "/home/opencode/.kimaki"
     DM_WORKSPACE_DIR="${DATAMACHINE_WORKSPACE_PATH:-/var/lib/datamachine/workspace}"
   fi
+}
+
+_detect_default_kimaki_data_dir() {
+  # An operator-set data dir is never relocated.
+  if [ "${KIMAKI_DATA_DIR_EXPLICIT:-}" = true ]; then
+    return 0
+  fi
+
+  # This used to be `KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-<default>}"`, which
+  # cannot be re-derived: the second call sees the value the first one wrote and
+  # keeps the old identity's home. The EXPLICIT flag replaces it, and both real
+  # entry points set that flag (initialize_kimaki_overrides) before detecting.
+  # When the flag machinery has not run at all, fall back to the historical
+  # behaviour rather than silently relocating a caller that only exported the
+  # variable.
+  if [ -z "${KIMAKI_DATA_DIR_EXPLICIT+x}" ] && [ -n "${KIMAKI_DATA_DIR:-}" ]; then
+    return 0
+  fi
+
+  KIMAKI_DATA_DIR="$1"
+}
+
+# Owned mode defaults to a non-root service user (#327).
+#
+# The edit denies are a guardrail, not containment: `permission.edit` gates the
+# runtime's edit tool only, `bash` is a separate key that is unset (and so
+# allowed), and a root service reaches every denied path through `bash -c`,
+# `wp eval`, or a PHP one-liner. The service user is the lever that actually
+# holds, because the kernel enforces it rather than a config file.
+#
+# Scoped to owned mode deliberately. That is the shape aimed at owners who
+# cannot evaluate the risk — a site whose operator never opens a terminal should
+# not carry an agent with an unrestricted root shell. A workspace install
+# belongs to a developer who chose it, so its default is left alone and the
+# migration (upgrade.sh --migrate-non-root) is offered instead.
+#
+# A DEFAULT only: --root and --non-root both set SERVICE_USER_FORCED, which
+# means the operator already decided and is not second-guessed. Applies to fresh
+# installs; an existing install is never flipped implicitly (#204), because that
+# would strand the agent's state in the old home.
+#
+# Lives here rather than inline in setup.sh because setup.sh resolves the source
+# mode AFTER detection — the mode is read from the site, which detection is what
+# finds — so this has to re-derive the identity, and a re-derivation is worth
+# testing directly.
+detect_apply_source_mode_identity_default() {
+  [ "${SOURCE_MODE:-}" = "owned" ] || return 0
+  [ "${SERVICE_USER_FORCED:-false}" = false ] || return 0
+  [ "${LOCAL_MODE:-false}" = false ] || return 0
+  [ "${RUN_AS_ROOT:-true}" = true ] || return 0
+
+  RUN_AS_ROOT=false
+  detect_service_identity
+  log "Owned mode: defaulting to non-root service user '$SERVICE_USER' (pass --root to override)"
 }

--- a/setup.sh
+++ b/setup.sh
@@ -468,6 +468,11 @@ source_policy_resolve_writable_paths
 source_policy_resolve_log_paths
 source_policy_assert_runtime_supports_mode
 
+# Owned mode defaults to a non-root service user (#327). Must run after the mode
+# resolves and before create_service_user / setup_service_permissions, both of
+# which branch on RUN_AS_ROOT.
+detect_apply_source_mode_identity_default
+
 if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$LOCAL_MODE" = false ]; then
   bridge_load kimaki
   _kimaki_resolve_instance

--- a/tests/service-identity-defaults.sh
+++ b/tests/service-identity-defaults.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# tests/service-identity-defaults.sh — owned mode defaults to non-root (#327).
+#
+# The claim in #327 is that every install, including the managed ones, runs an
+# unrestricted root shell — and that the edit denies shipped in #314/#318/#322
+# do not change that, because `permission.edit` gates the runtime's edit tool
+# while `bash` is a separate, unset, therefore allowed key. A root service
+# reaches every denied path through `bash -c`, `wp eval`, or PHP. The service
+# user is the only lever in that list the kernel enforces.
+#
+# What must hold:
+#
+#   1. A fresh owned install lands on a non-root service user, with the service
+#      home and the Kimaki data dir moved to match. Flipping RUN_AS_ROOT alone
+#      would leave SERVICE_USER and the data dir pointing at /root — the
+#      half-applied identity behind both #204 and #93.
+#   2. An operator who said --root or --non-root is not second-guessed.
+#   3. Workspace mode is untouched. That install belongs to a developer who
+#      chose it; changing its default here would be an unrelated behaviour
+#      change smuggled in under a security fix.
+#   4. Re-derivation is idempotent and does not clobber an explicit
+#      --kimaki-data-dir.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+FAILED=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    echo "         got:  $got"
+    echo "         want: $want"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" name="$3"
+  case "$haystack" in
+    *"$needle"*) echo "  ok   $name" ;;
+    *) echo "  FAIL $name (missing: $needle)"; FAILED=$((FAILED + 1)) ;;
+  esac
+}
+
+# Evaluate the default in a subshell and report the resulting identity.
+# Args: SOURCE_MODE SERVICE_USER_FORCED LOCAL_MODE RUN_AS_ROOT [KIMAKI_DATA_DIR]
+identity_after_default() {
+  (
+    SOURCE_MODE="$1"
+    SERVICE_USER_FORCED="$2"
+    LOCAL_MODE="$3"
+    RUN_AS_ROOT="$4"
+    KIMAKI_DATA_DIR_EXPLICIT=false
+    if [ -n "${5:-}" ]; then
+      KIMAKI_DATA_DIR="$5"
+      KIMAKI_DATA_DIR_EXPLICIT=true
+    fi
+    log() { :; }
+    # shellcheck disable=SC1091
+    source lib/detect.sh
+    detect_service_identity
+    detect_apply_source_mode_identity_default
+    printf '%s|%s|%s|%s' "$RUN_AS_ROOT" "$SERVICE_USER" "$SERVICE_HOME" "$KIMAKI_DATA_DIR"
+  )
+}
+
+echo "owned mode defaults to a non-root service user"
+
+assert_eq "$(identity_after_default owned false false true)" \
+  "false|opencode|/home/opencode|/home/opencode/.kimaki" \
+  "fresh owned install lands fully on the opencode identity"
+
+echo ""
+echo "the operator's explicit choice wins"
+
+# --root: SERVICE_USER_FORCED=true with RUN_AS_ROOT=true.
+assert_eq "$(identity_after_default owned true false true)" \
+  "true|root|/root|/root/.kimaki" \
+  "--root is not overridden by the owned default"
+
+# --non-root: already non-root, nothing to do.
+assert_eq "$(identity_after_default owned true false false)" \
+  "false|opencode|/home/opencode|/home/opencode/.kimaki" \
+  "--non-root is left as it is"
+
+echo ""
+echo "workspace mode is untouched"
+
+assert_eq "$(identity_after_default workspace false false true)" \
+  "true|root|/root|/root/.kimaki" \
+  "workspace mode keeps its existing root default"
+
+assert_eq "$(identity_after_default workspace false false false)" \
+  "false|opencode|/home/opencode|/home/opencode/.kimaki" \
+  "workspace mode still honours an explicit non-root"
+
+echo ""
+echo "local installs are unaffected"
+
+# LOCAL_MODE has no systemd and no service user to create; the identity is
+# whoever is running the install.
+local_result="$(identity_after_default owned false true true)"
+assert_contains "$local_result" "$(whoami)" "local mode keeps the invoking user"
+
+echo ""
+echo "re-derivation is safe"
+
+# Idempotence: applying the default twice must not drift.
+once="$(identity_after_default owned false false true)"
+twice="$(
+  (
+    SOURCE_MODE=owned SERVICE_USER_FORCED=false LOCAL_MODE=false RUN_AS_ROOT=true
+    KIMAKI_DATA_DIR_EXPLICIT=false
+    log() { :; }
+    # shellcheck disable=SC1091
+    source lib/detect.sh
+    detect_service_identity
+    detect_apply_source_mode_identity_default
+    detect_apply_source_mode_identity_default
+    detect_service_identity
+    printf '%s|%s|%s|%s' "$RUN_AS_ROOT" "$SERVICE_USER" "$SERVICE_HOME" "$KIMAKI_DATA_DIR"
+  )
+)"
+assert_eq "$twice" "$once" "applying the default repeatedly is idempotent"
+
+# An explicit --kimaki-data-dir must survive the re-derivation. Without the
+# guard, the second detect_service_identity call would silently relocate the
+# operator's data dir to the new home.
+assert_eq "$(identity_after_default owned false false true /srv/kimaki-data)" \
+  "false|opencode|/home/opencode|/srv/kimaki-data" \
+  "an explicit --kimaki-data-dir is not relocated"
+
+# A caller that only exported KIMAKI_DATA_DIR, without the flag machinery, keeps
+# the historical `${KIMAKI_DATA_DIR:-default}` behaviour rather than being
+# silently relocated by the re-derivation.
+legacy_env=$(
+  (
+    unset KIMAKI_DATA_DIR_EXPLICIT
+    SOURCE_MODE=owned SERVICE_USER_FORCED=false LOCAL_MODE=false RUN_AS_ROOT=true
+    KIMAKI_DATA_DIR=/opt/preset-data
+    log() { :; }
+    # shellcheck disable=SC1091
+    source lib/detect.sh
+    detect_service_identity
+    printf '%s' "$KIMAKI_DATA_DIR"
+  )
+)
+assert_eq "$legacy_env" "/opt/preset-data" "a bare exported KIMAKI_DATA_DIR is respected"
+
+echo ""
+echo "wiring"
+
+# The default has to run after the source mode resolves and before the phases
+# that branch on RUN_AS_ROOT, or it decides nothing.
+apply_line=$(grep -n '^detect_apply_source_mode_identity_default' setup.sh | head -1 | cut -d: -f1)
+mode_line=$(grep -n '^source_policy_resolve_mode' setup.sh | head -1 | cut -d: -f1)
+user_line=$(grep -n '^  create_service_user' setup.sh | head -1 | cut -d: -f1)
+perms_line=$(grep -n '^  setup_service_permissions' setup.sh | head -1 | cut -d: -f1)
+if [ -n "$apply_line" ] && [ -n "$mode_line" ] && [ -n "$user_line" ] && [ -n "$perms_line" ] &&
+   [ "$apply_line" -gt "$mode_line" ] && [ "$apply_line" -lt "$user_line" ] && [ "$apply_line" -lt "$perms_line" ]; then
+  echo "  ok   setup.sh applies the default after the mode resolves and before it is used"
+else
+  echo "  FAIL setup.sh ordering wrong (apply=${apply_line:-?} mode=${mode_line:-?} user=${user_line:-?} perms=${perms_line:-?})"
+  FAILED=$((FAILED + 1))
+fi
+
+# An EXISTING owned install must be advised, never flipped. Flipping it here
+# would re-render the unit against an identity whose home holds none of the
+# agent's state — the #93 footgun, arrived at from the other direction.
+assert_contains "$(cat upgrade.sh)" "--migrate-non-root" \
+  "upgrade.sh points an owned root install at the migration"
+upgrade_owned_block=$(sed -n '/SOURCE_MODE" = "owned" \]/,/^fi/p' upgrade.sh)
+if printf '%s' "$upgrade_owned_block" | grep -q 'RUN_AS_ROOT=false'; then
+  echo "  FAIL upgrade.sh flips an existing owned install implicitly"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   upgrade.sh does not flip an existing install implicitly"
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "service-identity-defaults: all assertions passed"
+else
+  echo "service-identity-defaults: $FAILED assertion(s) failed"
+  exit 1
+fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -486,6 +486,16 @@ if [ "$MIGRATE_NON_ROOT" = true ]; then
     service_migration_run "$MIGRATE_TARGET_USER" "/root" "$SOURCE_MODE"
     UPDATED_ITEMS+=("Service identity migrated: root -> $SERVICE_USER")
   fi
+elif [ "$LOCAL_MODE" = false ] && [ "$SOURCE_MODE" = "owned" ] && \
+     [ "$INSTALLED_SERVICE_USER" = "root" ]; then
+  # Owned mode now defaults to non-root on fresh installs (#327), but an
+  # existing install is NEVER flipped implicitly — that is the #204 rule, and
+  # here it would additionally strand the agent's state in /root. Recommend the
+  # migration and let the operator choose when to take the service down.
+  warn "This owned-mode install runs as root. Fresh owned installs now default to"
+  warn "a non-root service user: the edit denies are a guardrail, not containment,"
+  warn "and a root service can reach every denied path through bash or wp eval."
+  warn "Migrate when convenient:  sudo ./upgrade.sh --migrate-non-root"
 fi
 
 # Set true when opencode.json is found to have plugin-array drift and the


### PR DESCRIPTION
Addresses #327 (item 1). Builds on #330's migration and #331's rename.

## Why the edit rules were never the boundary

#327's claim, verified: the denies shipped in #314/#318/#322 are a guardrail, not containment.

`permission.edit` gates the runtime's **edit tool**. `bash` is a separate permission key, unset and therefore allowed. A service running as root reaches every denied path via `bash -c 'cat > wp-includes/x.php'`, `wp eval`, or a PHP one-liner — regardless of what the edit rules say.

The service user is the only lever in that list the **kernel** enforces. A non-root agent cannot `apt install`, cannot rewrite a systemd unit, cannot read another site's credentials, and cannot write `wp-admin/` whichever tool it reaches for.

## Scope

| | default service user |
| --- | --- |
| `owned` | **non-root** (`opencode`) — new |
| `workspace` | root (unchanged) |

Owned is the shape aimed at owners who cannot evaluate the risk; a site whose operator never opens a terminal should not carry an agent with a root shell. A workspace install belongs to a developer who chose it — changing that default here would be an unrelated behaviour change smuggled in under a security fix. It gets the migration path instead.

**Existing installs are never flipped implicitly, in either mode.** That's the #204 rule, and here it would additionally strand the agent's state in `/root` — the #93 footgun from the other direction. An owned install still on root is now told to run `--migrate-non-root` and picks its own moment to take the service down.

## The mechanical part

`setup.sh` resolves the source mode **after** detection — the mode is read from the site, and detection is what finds the site. So the identity has to be re-derived once the mode is known.

Flipping `RUN_AS_ROOT` alone would leave `SERVICE_USER`, the service home, and the Kimaki data dir all still pointing at root: the half-applied identity behind both #204 and #93. `detect_service_identity` is split out of `detect_environment` for that, and the decision lives in `lib/detect.sh` rather than inline in `setup.sh` so it can be tested directly.

## One trap the re-derivation exposed

The data dir was `KIMAKI_DATA_DIR="${KIMAKI_DATA_DIR:-<default>}"` — which **cannot be recomputed**. The second call reads back what the first one wrote and keeps the old identity's home.

It now keys off `KIMAKI_DATA_DIR_EXPLICIT`, which both real entry points set before detecting, and falls back to the old behaviour when the flag machinery hasn't run at all, so a caller that only exported the variable isn't silently relocated. Both cases are pinned by tests.

## Coverage

New `tests/service-identity-defaults.sh` (CI job added): fresh owned install lands *fully* on the opencode identity; `--root`/`--non-root` are not second-guessed; workspace mode untouched in both directions; local mode unaffected; re-derivation idempotent; explicit and bare-exported data dirs both preserved; and static checks that `setup.sh` applies the default in the right window and that `upgrade.sh` does not flip an existing install.

Full suite green apart from the 3 pre-existing environmental failures that also fail on `origin/main`.

## Still open on #327

Item 3, `permission.bash` shaping per mode. The issue sequences it after this one and is explicit that it is intent-shaping rather than containment — worth having, but it is not the boundary and shouldn't be described as one.