### PR TITLE
fix: use environment for Kimaki lock port

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -1189,9 +1189,7 @@ bridge_render_systemd() {
   [ "$normalized_unit" = "$unit" ] || { echo "kimaki has no unit '$unit'" >&2; return 1; }
   local skill_filter_args
   skill_filter_args="$(_kimaki_skill_filter_args_shell)"
-  local lock_port_arg=""
   _kimaki_validate_lock_port
-  [ -z "${KIMAKI_LOCK_PORT:-}" ] || lock_port_arg=" --lock-port $KIMAKI_LOCK_PORT"
   local stale_worker_cleanup="# User-wide stale-worker cleanup omitted for instance isolation."
   if [ "$unit" = "kimaki.service" ]; then
     stale_worker_cleanup='ExecStartPre=-/usr/bin/pkill -TERM -u '$SERVICE_USER' -f "opencode-ai/bin/.*serve"'
@@ -1218,7 +1216,7 @@ $env_block
 # tolerate exit code 1 (no matches found, the happy path on a clean box).
 $stale_worker_cleanup
 ExecStartPre=$KIMAKI_CONFIG_DIR/post-upgrade.sh
-ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR$lock_port_arg --auto-restart --no-critique$skill_filter_args
+ExecStart=$KIMAKI_BIN --data-dir $KIMAKI_DATA_DIR --auto-restart --no-critique$skill_filter_args
 Restart=always
 RestartSec=10
 

--- a/tests/kimaki-multi-instance.sh
+++ b/tests/kimaki-multi-instance.sh
@@ -135,7 +135,11 @@ bridge_update_systemd
 other_after=$(cksum "$SYSTEMD_UNIT_DIR/kimaki.service")
 [ "$other_before" = "$other_after" ]
 grep -q '^WorkingDirectory=.*/site-b$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
-grep -q -- '--data-dir /home/opencode/.kimaki-site-b --lock-port 6543' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+grep -q '^Environment=KIMAKI_LOCK_PORT=6543$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
+if grep -q -- '--lock-port' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"; then
+  echo "FAIL: obsolete lock-port argument survived managed unit migration" >&2
+  exit 1
+fi
 grep -q '^Environment=DATAMACHINE_AGENT_SLUG=site-b$' "$SYSTEMD_UNIT_DIR/kimaki-site-b.service"
 
 # Explicit managed overrides replace, rather than merge-preserve, installed
@@ -177,7 +181,11 @@ wrapper_output=$(LOCAL_MODE=false SERVICE_USER=opencode SERVICE_HOME=/home/openc
 echo "$wrapper_output" | grep -q 'wp-coding-agents-kimaki-site-b-dispatch'
 
 rendered=$(bridge_render_systemd kimaki-site-b.service 'Environment=HOME=/home/opencode')
-echo "$rendered" | grep -q -- '--lock-port 6543'
+echo "$rendered" | grep -q '^Environment=KIMAKI_LOCK_PORT=6543$'
+if echo "$rendered" | grep -q -- '--lock-port'; then
+  echo "FAIL: renderer emitted obsolete lock-port argument" >&2
+  exit 1
+fi
 if echo "$rendered" | grep -q 'pkill -TERM'; then
   echo "FAIL: custom instance contains host-user-wide stale worker cleanup" >&2
   exit 1


### PR DESCRIPTION
## Summary
- stop rendering Kimaki's removed `--lock-port` CLI argument in managed systemd units
- preserve per-instance lock ports through `KIMAKI_LOCK_PORT`
- verify upgrades migrate legacy units without losing their configured port

## Tests
- `bash tests/kimaki-multi-instance.sh`
- `bash tests/bridge-render.sh`

## Production Context
This fixes the chubes.net outage where Kimaki 0.23.1 rejected `--lock-port 29988`, leaving the auto-restart parent active while every Discord bot child failed before initialization.

## AI Assistance
OpenCode investigated the renderer, implemented the focused change, updated migration assertions, and reviewed the deterministic test results. Homeboy run: `agent-task-850d8b5d-b8be-4e24-898f-d7cf37dbb784`.

Fixes #332