### PR TITLE
feat: project the declared owned sources to a readable manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,31 @@ read-only reference there. What it buys is git and review, not latitude.
 | Runtimes | all | `opencode` only |
 | Service user | root by default | **non-root by default** (`opencode`) |
 
+### How out-of-band capture learns the editable set
+
+Owned mode rests on one invariant: **the editable set equals the set the
+operator's capture records.** A path the agent may edit but nothing captures is
+where work silently disappears, and on a live site that stays invisible until an
+update overwrites it.
+
+Capture cannot read the `wp_coding_agents_owned_sources` option that holds the
+editable set. It runs as a deliberately read-only identity that cannot read
+`wp-config.php` — wp-coding-agents hardens that file to `www-data:640` itself —
+so it can never run WP-CLI and never reach the database.
+
+So owned installs project the declaration to a plain file:
+
+```
+/var/lib/wp-coding-agents/<domain>/owned-sources
+```
+
+One wp-content-relative path per line, mode `0644`, rewritten on every upgrade,
+removed if the install leaves owned mode. It lives outside the site root because
+`SITE_PATH` is the web root and a file written there is fetchable over HTTP.
+
+A capture mechanism reads that file and derives its component list from it,
+rather than keeping a second hand-maintained copy that can drift.
+
 ### The service user is the boundary that holds
 
 The edit rules above are a guardrail, not containment. `permission.edit` gates

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -94,6 +94,33 @@ _source_policy_option_get() {
 # denied for edit, so the agent can diagnose without rewriting a log.
 SOURCE_POLICY_LOG_OPTION="wp_coding_agents_log_paths"
 
+# Where the declared owned sources are projected as a plain readable file.
+#
+# Owned mode rests on one invariant: the editable set equals the set captured by
+# the operator's out-of-band harvest. Nothing enforces that today, because the
+# two lists live in different places — this install records the editable set in
+# a wp option, and the capture mechanism keeps its own hand-maintained copy. A
+# component added to one and forgotten in the other is either an editable
+# surface nothing records (work silently lost on the next update) or a captured
+# surface the agent cannot touch.
+#
+# The capture mechanism cannot simply read the option. It is deliberately a
+# read-only identity and cannot read wp-config.php — wp-coding-agents hardens
+# that file to www-data:640 itself — so it can never run WP-CLI and never reach
+# the database. Verified on h44lacrosse.com: the harvest user gets
+# "Failed to open stream: Permission denied" from `wp option get`.
+#
+# So the option stays authoritative and this file is its projection: a derived
+# artifact, rewritten on every upgrade, that a shell with no database access can
+# `cat`. That is what lets capture derive its component list from the same
+# declaration the permissions come from, instead of duplicating it.
+#
+# DELIBERATELY OUTSIDE THE SITE ROOT. SITE_PATH is the nginx docroot, so a file
+# written there is fetchable over HTTP. This only names plugin and theme slugs,
+# but the install's component layout is not something to publish for the
+# convenience of a local reader.
+SOURCE_POLICY_MANIFEST_ROOT="${SOURCE_POLICY_MANIFEST_ROOT:-/var/lib/wp-coding-agents}"
+
 # Every installed-source root wp-coding-agents has an opinion about, in the
 # order they are emitted by every consumer. Adding a root here adds it to all
 # runtimes and to the AGENTS.md prose at once.
@@ -501,6 +528,9 @@ source_policy_recorded_owned_sources() {
 
 source_policy_record_owned_sources() {
   if ! source_policy_is_owned; then
+    # Includes the workspace-mode case, and an install switched back out of
+    # owned mode — which is exactly when a left-behind manifest starts lying.
+    source_policy_remove_owned_manifest
     return 0
   fi
 
@@ -526,6 +556,78 @@ source_policy_record_owned_sources() {
     fi
   else
     warn "Could not record managed sources — upgrades will fall back to the recorded value or none"
+  fi
+
+  source_policy_write_owned_manifest
+}
+
+# Absolute path of this install's owned-sources manifest, or '' when there is
+# nothing to key it on. Keyed by site domain so one host can serve several.
+source_policy_manifest_path() {
+  local key="${SITE_DOMAIN:-}"
+  [ -n "$key" ] || key="$(basename "${SITE_PATH:-}" 2>/dev/null)"
+  [ -n "$key" ] || return 0
+  printf '%s/%s/owned-sources' "$SOURCE_POLICY_MANIFEST_ROOT" "$key"
+}
+
+# Project the declared owned sources to that path: one wp-content-relative path
+# per line, no header, so a consumer with only `cat` and a read loop can use it.
+#
+# Written 0644 on purpose. The reader is a different, unprivileged, deliberately
+# read-only identity; making this file secret would defeat the reason it exists.
+# It contains nothing the site's own directory listing does not already show to
+# anyone with a shell.
+source_policy_write_owned_manifest() {
+  local path sources
+  path="$(source_policy_manifest_path)"
+  [ -n "$path" ] || return 0
+
+  # Local installs have no out-of-band capture to inform, and no reason to
+  # require write access to /var/lib on someone's laptop.
+  [ "${LOCAL_MODE:-false}" = true ] && return 0
+
+  sources="${OWNED_SOURCES:-}"
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} write owned-sources manifest: $path"
+    return 0
+  fi
+
+  if ! mkdir -p "$(dirname "$path")" 2>/dev/null; then
+    warn "Could not create $(dirname "$path") — out-of-band capture cannot read the declared sources"
+    return 0
+  fi
+
+  if printf '%s\n' "$sources" | sed '/^[[:space:]]*$/d' > "$path.tmp" 2>/dev/null &&
+     mv "$path.tmp" "$path" 2>/dev/null; then
+    chmod 0644 "$path" 2>/dev/null || true
+    log "  Owned-sources manifest: $path"
+  else
+    rm -f "$path.tmp" 2>/dev/null || true
+    warn "Could not write $path — out-of-band capture cannot read the declared sources"
+  fi
+}
+
+# Remove a manifest left behind by an install that is no longer in owned mode.
+#
+# A stale manifest is worse than none: it keeps asserting an editable set that
+# the permission layer has stopped granting, and a capture mechanism reading it
+# would go on harvesting components the agent can no longer touch — reporting
+# health for a relationship that no longer exists.
+source_policy_remove_owned_manifest() {
+  local path
+  path="$(source_policy_manifest_path)"
+  [ -n "$path" ] || return 0
+  [ "${LOCAL_MODE:-false}" = true ] && return 0
+  [ -e "$path" ] || return 0
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} remove stale owned-sources manifest: $path"
+    return 0
+  fi
+
+  if rm -f "$path" 2>/dev/null; then
+    log "  Removed stale owned-sources manifest: $path"
   fi
 }
 

--- a/tests/source-mode.sh
+++ b/tests/source-mode.sh
@@ -581,3 +581,114 @@ assert_contains "$(cat "$PROBE")" "option update wp_coding_agents_source_mode wo
   source_policy_record_mode >/dev/null 2>&1
 )
 assert_eq "$(cat "$PROBE")" "" "record_mode does not rewrite an already-migrated install"
+
+# ===========================================================================
+echo "==> the owned-sources manifest (#336)"
+# ===========================================================================
+
+# Owned mode's invariant is that the editable set equals the set the operator's
+# out-of-band capture records. Capture cannot read the wp option that holds the
+# editable set: it runs as a deliberately read-only identity that cannot read
+# wp-config.php — wp-coding-agents hardens that file to www-data:640 itself — so
+# it can never run WP-CLI. Measured on h44lacrosse.com, `wp option get` as the
+# harvest user fails with "Failed to open stream: Permission denied".
+#
+# The manifest is the option's projection for exactly that reader.
+
+MANI_ROOT="$TMPD/manifest"
+
+manifest_for() {
+  # Args: SOURCE_MODE OWNED_SOURCES [LOCAL_MODE]
+  (
+    SOURCE_POLICY_MANIFEST_ROOT="$MANI_ROOT"
+    SITE_DOMAIN=example.com
+    LOCAL_MODE="${3:-false}"
+    DRY_RUN=false
+    SOURCE_MODE="$1"
+    OWNED_SOURCES="$2"
+    log() { :; }; warn() { :; }
+    source_policy_write_owned_manifest
+  )
+}
+
+rm -rf "$MANI_ROOT"
+manifest_for owned "wp-content/themes/acme
+wp-content/plugins/acme-core"
+
+MANI="$MANI_ROOT/example.com/owned-sources"
+
+if [ -f "$MANI" ]; then
+  echo "  ok   manifest is written"
+else
+  echo "  FAIL manifest was not written"
+  FAILED=$((FAILED + 1))
+fi
+
+assert_eq "$(cat "$MANI" 2>/dev/null)" \
+"wp-content/themes/acme
+wp-content/plugins/acme-core" \
+  "manifest is one declared path per line"
+
+# The reader is an unprivileged identity that is not us. A mode that keeps it
+# out defeats the only reason the file exists.
+assert_eq "$(stat -c '%a' "$MANI" 2>/dev/null)" "644" "manifest is world-readable"
+
+# SITE_PATH is the nginx docroot on a real install (verified on
+# h44lacrosse.com: `root /var/www/h44lacrosse.com;`). A manifest written there
+# would be fetchable over HTTP.
+case "$(SOURCE_POLICY_MANIFEST_ROOT="$MANI_ROOT" SITE_DOMAIN=example.com source_policy_manifest_path)" in
+  "$MANI_ROOT"/*) echo "  ok   manifest lives outside the site root" ;;
+  *) echo "  FAIL manifest path is not under the manifest root"; FAILED=$((FAILED + 1)) ;;
+esac
+
+# A manifest left behind by an install that has since moved to workspace mode
+# keeps asserting an editable set the permission layer no longer grants, and a
+# capture reading it would report health for a relationship that ended.
+(
+  SOURCE_POLICY_MANIFEST_ROOT="$MANI_ROOT"
+  SITE_DOMAIN=example.com LOCAL_MODE=false DRY_RUN=false
+  SOURCE_MODE=workspace
+  log() { :; }; warn() { :; }
+  source_policy_record_owned_sources
+) >/dev/null 2>&1
+if [ ! -e "$MANI" ]; then
+  echo "  ok   leaving owned mode removes the stale manifest"
+else
+  echo "  FAIL a stale manifest survived the switch to workspace mode"
+  FAILED=$((FAILED + 1))
+fi
+
+# Local installs have no out-of-band capture to inform, and no business
+# requiring write access to /var/lib on a laptop.
+rm -rf "$MANI_ROOT"
+manifest_for owned "wp-content/plugins/acme-core" true
+if [ ! -e "$MANI" ]; then
+  echo "  ok   local installs write no manifest"
+else
+  echo "  FAIL local mode wrote a manifest"
+  FAILED=$((FAILED + 1))
+fi
+
+# Blank lines would become empty component ids downstream.
+rm -rf "$MANI_ROOT"
+manifest_for owned "wp-content/plugins/a
+
+wp-content/plugins/b
+"
+assert_eq "$(grep -c . "$MANI" 2>/dev/null)" "2" "blank lines are stripped"
+assert_eq "$(wc -l < "$MANI" 2>/dev/null | tr -d ' ')" "2" "no trailing blank line"
+
+# DRY_RUN must not touch the filesystem.
+rm -rf "$MANI_ROOT"
+(
+  SOURCE_POLICY_MANIFEST_ROOT="$MANI_ROOT"
+  SITE_DOMAIN=example.com LOCAL_MODE=false DRY_RUN=true
+  OWNED_SOURCES="wp-content/plugins/acme-core"
+  source_policy_write_owned_manifest
+) >/dev/null 2>&1
+if [ ! -e "$MANI" ]; then
+  echo "  ok   dry-run writes nothing"
+else
+  echo "  FAIL dry-run wrote the manifest"
+  FAILED=$((FAILED + 1))
+fi


### PR DESCRIPTION
Implements the missing half of #336 — the part that lets out-of-band capture derive its component list instead of duplicating it.

## The invariant, and why nothing held it

Owned mode rests on: **the editable set equals the set the operator's capture records.** A path the agent may edit but nothing captures is where work silently disappears — invisible on a live site until an update overwrites it.

The two lists lived in different places. h44lacrosse.com had three components declared in `wp_coding_agents_owned_sources`, and the same three hardcoded *twice* in its harvest workflow, kept in agreement by nothing but memory.

## Why capture can't just read the option

Because it runs as a deliberately read-only identity that **cannot read `wp-config.php`** — a file wp-coding-agents hardens to `www-data:640` itself. So it can never run WP-CLI and never reach the database:

```
$ su h44harvest -c 'wp --path=/var/www/h44lacrosse.com option get wp_coding_agents_owned_sources'
PHP Warning: file_get_contents(/var/www/h44lacrosse.com/wp-config.php): Failed to open stream: Permission denied
```

I learned this the direct way: I landed a read-the-option version on h44 and watched it fail closed, having tested the SSH with a **root** key rather than the harvest key. Testing as the wrong principal is how a permissions assumption survives verification. Reverted within minutes; the daily harvest never missed a window.

Granting that identity database access would dismantle a good boundary to work around it.

## The projection

The option stays authoritative and gains a derived artifact:

```
/var/lib/wp-coding-agents/<domain>/owned-sources
```

One wp-content-relative path per line, rewritten on every upgrade, readable by a shell with no database access.

**Outside the site root** — `SITE_PATH` is the nginx web root (verified on h44: `root /var/www/h44lacrosse.com;`), so a file written there is fetchable over HTTP. The component layout isn't something to publish for a local reader's convenience.

**Mode 0644** — the reader is an unprivileged identity that is not us. A mode that keeps it out defeats the only reason the file exists.

**Removed when the install leaves owned mode.** A stale manifest is worse than none: it keeps asserting an editable set the permission layer has stopped granting, and a capture reading it would harvest components the agent can no longer touch — reporting health for a relationship that ended.

## Coverage

Added to `tests/source-mode.sh`: written and formatted correctly, world-readable, outside the site root, blank lines stripped, no trailing newline artifact, dry-run touches nothing, local installs write nothing, and leaving owned mode removes it.

## Next

With this landed and released, h44's harvest change relands unchanged except for its source — `cat` the manifest over the SSH it already has, instead of `wp option get` it cannot run.