### PR TITLE
fix: reconcile the manifest and migrate the sibling option keys

### DIFF
--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -62,6 +62,29 @@ SOURCE_POLICY_LEGACY_OPTION="wp_coding_agents_posture"
 SOURCE_POLICY_LEGACY_OWNED_OPTION="wp_coding_agents_managed_sources"
 SOURCE_POLICY_LEGACY_WRITABLE_OPTION="wp_coding_agents_managed_writable"
 
+# Read a wp option WITHOUT going through run_cmd.
+#
+# wp_cmd routes through run_cmd, which under --dry-run ECHOES the command
+# instead of running it. Every recorded_* reader used it, so during a dry run
+# they returned the echoed command text rather than the stored value, and the
+# resolver fell through to defaults. On h44lacrosse.com that made
+# `./upgrade.sh --dry-run` report `--source-mode workspace` and a full deny set
+# for a site recorded as owned — advertising precisely the destructive outcome
+# an operator runs a dry run to rule out.
+#
+# Reads are side-effect free, so they should happen in a dry run, not be
+# simulated. Only writes belong behind run_cmd.
+_source_policy_option_read() {
+  local key="$1"
+  [ -n "${SITE_PATH:-}" ] || return 0
+  if [ "${IS_STUDIO:-false}" = true ]; then
+    studio wp option get "$key" --path="$SITE_PATH" 2>/dev/null || true
+    return 0
+  fi
+  # shellcheck disable=SC2086
+  $WP_CMD option get "$key" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
+}
+
 # Read an option, falling back to its pre-rename name.
 #
 # Not a one-shot migration on upgrade: an operator can run a NEWER upgrade.sh
@@ -72,13 +95,13 @@ SOURCE_POLICY_LEGACY_WRITABLE_OPTION="wp_coding_agents_managed_writable"
 _source_policy_option_get() {
   local key="$1" legacy="$2" value=""
 
-  value="$(wp_cmd option get "$key" 2>/dev/null || true)"
+  value="$(_source_policy_option_read "$key" 2>/dev/null || true)"
   if [ -n "$(printf '%s' "$value" | tr -d '[:space:]')" ]; then
     printf '%s' "$value"
     return 0
   fi
 
-  wp_cmd option get "$legacy" 2>/dev/null || true
+  _source_policy_option_read "$legacy" 2>/dev/null || true
 }
 # Paths OUTSIDE the site root the agent may read — server logs, almost always.
 #
@@ -237,11 +260,8 @@ source_policy_resolve_mode() {
 # Deliberately quiet: a fresh install, a dry run, or a site whose database is
 # not reachable yet must fall through to the default rather than fail.
 source_policy_recorded_mode() {
-  if [ "${DRY_RUN:-false}" = true ]; then
-    printf '%s' "${SOURCE_MODE:-}"
-    return 0
-  fi
-
+  # No DRY_RUN short-circuit: reads are side-effect free, and faking one here
+  # made a dry run on an owned install report the workspace default.
   if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
     return 0
   fi
@@ -267,7 +287,7 @@ source_policy_record_mode() {
   # `engineering` IS `workspace` — and leave it recorded under the old key
   # forever, so the migration would never actually happen.
   local current=""
-  current="$(wp_cmd option get "$SOURCE_POLICY_OPTION" 2>/dev/null | tr -d '[:space:]' || true)"
+  current="$(_source_policy_option_read "$SOURCE_POLICY_OPTION" 2>/dev/null | tr -d '[:space:]' || true)"
   if [ "$current" = "$mode" ]; then
     return 0
   fi
@@ -358,7 +378,7 @@ source_policy_recorded_log_paths() {
   if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
     return 0
   fi
-  wp_cmd option get "$SOURCE_POLICY_LOG_OPTION" 2>/dev/null || true
+  _source_policy_option_read "$SOURCE_POLICY_LOG_OPTION" 2>/dev/null || true
 }
 
 source_policy_record_log_paths() {
@@ -371,7 +391,10 @@ source_policy_record_log_paths() {
   if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
     return 0
   fi
-  if [ "$(source_policy_recorded_log_paths)" = "$paths" ]; then
+  # New key only — see source_policy_record_owned_sources.
+  local current=""
+  current="$(_source_policy_option_read "$SOURCE_POLICY_LOG_OPTION" 2>/dev/null || true)"
+  if [ "$current" = "$paths" ]; then
     return 0
   fi
   if printf '%s' "$paths" | wp_cmd option update "$SOURCE_POLICY_LOG_OPTION" >/dev/null 2>&1; then
@@ -465,7 +488,10 @@ source_policy_record_writable_paths() {
   if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
     return 0
   fi
-  if [ "$(source_policy_recorded_writable_paths)" = "$paths" ]; then
+  # New key only — see source_policy_record_owned_sources.
+  local current=""
+  current="$(_source_policy_option_read "$SOURCE_POLICY_WRITABLE_OPTION" 2>/dev/null || true)"
+  if [ "$current" = "$paths" ]; then
     return 0
   fi
   if printf '%s' "$paths" | wp_cmd option update "$SOURCE_POLICY_WRITABLE_OPTION" >/dev/null 2>&1; then
@@ -545,7 +571,20 @@ source_policy_record_owned_sources() {
     return 0
   fi
 
-  if [ "$(source_policy_recorded_owned_sources)" = "$sources" ]; then
+  # The manifest is reconciled unconditionally, BEFORE the no-change return.
+  # It is a projection of the declaration, not a record of a change to it: an
+  # install whose sources never change would otherwise never get one, and a
+  # manifest deleted by hand would never come back.
+  source_policy_write_owned_manifest
+
+  # Compare against the NEW key only. Comparing through the legacy-aware reader
+  # sees a pre-rename install as already correct — the legacy key holds exactly
+  # these paths — and returns before writing, leaving the install recorded under
+  # the old key forever. Same defect this file already fixed for the mode; the
+  # sibling recorders inherited it.
+  local current=""
+  current="$(_source_policy_option_read "$SOURCE_POLICY_OWNED_OPTION" 2>/dev/null || true)"
+  if [ "$current" = "$sources" ]; then
     return 0
   fi
 
@@ -557,8 +596,6 @@ source_policy_record_owned_sources() {
   else
     warn "Could not record managed sources — upgrades will fall back to the recorded value or none"
   fi
-
-  source_policy_write_owned_manifest
 }
 
 # Absolute path of this install's owned-sources manifest, or '' when there is

--- a/tests/source-mode.sh
+++ b/tests/source-mode.sh
@@ -692,3 +692,88 @@ else
   echo "  FAIL dry-run wrote the manifest"
   FAILED=$((FAILED + 1))
 fi
+
+# ===========================================================================
+echo "==> manifest and option reconciliation (#336 follow-up)"
+# ===========================================================================
+
+# Found by verifying the v1.13.0 upgrade on h44lacrosse.com: the mode migrated
+# to the new key, the sources did not, and no manifest was written.
+#
+# source_policy_record_owned_sources compared through the legacy-aware reader,
+# which on a pre-rename install returns exactly the paths about to be written —
+# so it returned early, never wrote the new key, and never reached the manifest
+# call sitting after it. The same defect record_mode already fixed; the sibling
+# recorders inherited it.
+
+RECON="$TMPD/reconcile"
+mkdir -p "$RECON/site"; : > "$RECON/site/wp-config.php"
+
+# Legacy key populated, new key empty — the shape every existing install has.
+record_probe=$(
+  PROBE="$RECON/writes"; : > "$PROBE"
+  SOURCE_POLICY_MANIFEST_ROOT="$RECON/manifest"
+  SITE_PATH="$RECON/site" SITE_DOMAIN=example.com LOCAL_MODE=false DRY_RUN=false
+  SOURCE_MODE=owned
+  OWNED_SOURCES="wp-content/plugins/acme-core"
+  log() { :; }; warn() { :; }
+  _source_policy_option_read() {
+    case "$1" in
+      wp_coding_agents_owned_sources) return 0 ;;
+      wp_coding_agents_managed_sources) echo "wp-content/plugins/acme-core" ;;
+    esac
+  }
+  wp_cmd() { echo "$*" >> "$PROBE"; cat >/dev/null 2>&1 || true; return 0; }
+  source_policy_record_owned_sources
+  cat "$PROBE"
+)
+assert_contains "$record_probe" "option update wp_coding_agents_owned_sources" \
+  "a legacy install is migrated onto the new sources key"
+
+if [ -f "$RECON/manifest/example.com/owned-sources" ]; then
+  echo "  ok   the manifest is written on a legacy install"
+else
+  echo "  FAIL no manifest written for a legacy install (the h44 v1.13.0 failure)"
+  FAILED=$((FAILED + 1))
+fi
+
+# The manifest is a projection, not a change record: an install whose sources
+# never change must still get one, and a manifest deleted by hand must return.
+rm -f "$RECON/manifest/example.com/owned-sources"
+(
+  SOURCE_POLICY_MANIFEST_ROOT="$RECON/manifest"
+  SITE_PATH="$RECON/site" SITE_DOMAIN=example.com LOCAL_MODE=false DRY_RUN=false
+  SOURCE_MODE=owned
+  OWNED_SOURCES="wp-content/plugins/acme-core"
+  log() { :; }; warn() { :; }
+  # Already migrated: new key holds exactly what we are about to write.
+  _source_policy_option_read() { echo "wp-content/plugins/acme-core"; }
+  wp_cmd() { return 0; }
+  source_policy_record_owned_sources
+) >/dev/null 2>&1
+if [ -f "$RECON/manifest/example.com/owned-sources" ]; then
+  echo "  ok   a deleted manifest is restored even when the option is unchanged"
+else
+  echo "  FAIL manifest not reconciled when the option needs no write"
+  FAILED=$((FAILED + 1))
+fi
+
+# Reads must work under --dry-run. wp_cmd routes through run_cmd, which echoes
+# instead of executing, so a dry run reported the workspace default for an owned
+# install — advertising exactly the destructive outcome a dry run exists to rule
+# out. Reads are side-effect free; only writes belong behind run_cmd.
+# Strip comments before asserting: the code must have no short-circuit, and the
+# comment explaining why legitimately names DRY_RUN.
+reader_code=$(sed -n '/^source_policy_recorded_mode()/,/^}/p' lib/source-policy.sh | sed 's/#.*//')
+refute_contains "$reader_code" 'DRY_RUN' "the mode reader has no dry-run short-circuit"
+
+dry_mode=$(
+  SITE_PATH="$RECON/site" DRY_RUN=true SOURCE_MODE_EXPLICIT=false
+  log() { :; }; error() { echo "ERR"; exit 1; }
+  _source_policy_option_read() {
+    case "$1" in wp_coding_agents_posture) echo managed ;; *) return 0 ;; esac
+  }
+  source_policy_resolve_mode >/dev/null 2>&1
+  printf '%s' "$SOURCE_MODE"
+)
+assert_eq "$dry_mode" "owned" "a dry run reports the mode the install actually has"


### PR DESCRIPTION
Found by verifying the v1.13.0 upgrade on h44lacrosse.com rather than trusting it.

## What the live check showed

```
wp_coding_agents_source_mode      owned          <- migrated
wp_coding_agents_owned_sources    (empty)        <- NOT migrated
/var/lib/wp-coding-agents/.../owned-sources      <- NOT WRITTEN
```

The manifest was the entire point of the release, and it did not appear.

## Cause

`source_policy_record_owned_sources` compared through the **legacy-aware reader**, which on a pre-rename install returns exactly the paths about to be written. So it returned early, never wrote the new key, and never reached the manifest call sitting after it.

This is the same defect `source_policy_record_mode` already carries a comment about:

> Compare against the NEW key only. Comparing through the legacy-aware reader would see a pre-rename install as already correct […] and leave it recorded under the old key forever, so the migration would never actually happen.

I wrote that, fixed it in one place, and didn't apply it to the siblings. `record_writable_paths` and `record_log_paths` had it too.

**The manifest now reconciles before any no-change return.** It's a projection of the declaration, not a record of a change to it — an install whose sources never change would otherwise never get one, and a manifest deleted by hand would never come back.

## Second bug: dry runs lie

`wp_cmd` routes through `run_cmd`, which **echoes** its arguments instead of executing them under `DRY_RUN`. So every `recorded_*` reader returned echoed command text and the resolver fell through to defaults.

The mode reader papered over this with its own `DRY_RUN` short-circuit returning the not-yet-resolved variable. Net effect on h44:

```
./upgrade.sh --dry-run
  --source-mode workspace
  edit_permission_expected: { wp-content/plugins/**: deny, wp-content/themes/**: deny, ... }
  external_directory_expected: { /var/lib/datamachine/workspace/**: allow }
```

For a site recorded as **owned**. The dry run advertised exactly the destructive outcome an operator runs a dry run to rule out — I nearly aborted a correct upgrade over it.

Reads are side-effect free and should *happen* during a dry run, not be simulated. Only writes belong behind `run_cmd`.

## Coverage

Four new assertions in `tests/source-mode.sh`: a legacy install migrates onto the new sources key; the manifest is written for one; a manifest deleted by hand is restored even when the option needs no write; and a dry run reports the mode the install actually has.