### PR TITLE
feat: derive the owned source set from site state

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -220,6 +220,7 @@ jobs:
           - kimaki-multi-instance
           - kimaki-system-message-patch
           - opencode-claude-auth-refresh-hardening
+          - owned-source-discovery
           - path-helpers
           - post-upgrade-restore
           - runtime-signature

--- a/README.md
+++ b/README.md
@@ -208,6 +208,32 @@ read-only reference there. What it buys is git and review, not latitude.
 | Runtimes | all | `opencode` only |
 | Service user | root by default | **non-root by default** (`opencode`) |
 
+### The owned set is derived, not declared
+
+Ownership is a fact already on the box, not a judgement, so it is computed
+rather than configured:
+
+```
+owned = installed  −  known to wp.org  −  installed by wp-coding-agents
+                   −  explicitly excluded
+```
+
+A plugin the agent creates is therefore editable and captured with no operator
+step and no self-declaration. `--owned-source` still overrides when supplied.
+
+**It cannot widen on missing evidence.** The wp.org signal is a transient; on a
+fresh install, after a cache flush, or when wp.org is unreachable it is absent,
+and treating absence as "nothing belongs to wp.org" would classify every plugin
+as the site's — handing the agent write access to WooCommerce and any payment
+gateway. So a signal that is missing, empty, or older than two days produces no
+derivation at all and the last recorded set is kept. Ownership is inferred only
+from the presence of evidence.
+
+`--not-owned <slug>` is the escape hatch for a premium or vendor plugin, which
+is on nobody's wp.org list and is not carried by wp-coding-agents, yet is no
+more the site's than WooCommerce is. Editing it is futile and capturing it may
+put licensed code in the operator's repository.
+
 ### How out-of-band capture learns the editable set
 
 Owned mode rests on one invariant: **the editable set equals the set the

--- a/lib/owned-source-discovery.sh
+++ b/lib/owned-source-discovery.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# lib/owned-source-discovery.sh — derive the owned source set from site state.
+#
+# WHY THIS EXISTS
+#
+# Owned mode needs to know which plugins and themes belong to the SITE, as
+# opposed to WordPress, wp.org, or the agent's own runtime. Until now that was
+# an operator action: `--owned-source` per component, over SSH, repeated in the
+# capture configuration. A non-technical owner asking for a new plugin therefore
+# had to file a support ticket, which is exactly what managed hosting is
+# supposed to remove.
+#
+# Ownership is not a judgement call, though. It is a fact already present on the
+# box, and it can be derived:
+#
+#   owned = installed  −  known to wp.org  −  installed by wp-coding-agents
+#                      −  explicitly excluded
+#
+# Measured against h44lacrosse.com, that yields h44-lacrosse-theme, h44-core and
+# h44-forms — the three components previously declared by hand — plus one
+# vendor plugin that needs the exclusion escape hatch below.
+#
+# THE FAILURE MODE THAT MATTERS
+#
+# The wp.org signal is a TRANSIENT. On a fresh install, after a cache flush, or
+# when wp.org is unreachable, `update_plugins` is missing or stale — and then
+# NOTHING looks known to wp.org and EVERYTHING classifies as owned. On
+# h44lacrosse.com that would hand the agent write access to WooCommerce and a
+# Stripe payment gateway.
+#
+# So this module fails CLOSED in the widening direction. A signal that cannot be
+# trusted produces no derivation at all, and the caller keeps the last recorded
+# set. Ownership is never inferred from the ABSENCE of evidence, only from its
+# presence. That asymmetry is the whole safety argument: a missing signal must
+# never be able to open a payment plugin.
+#
+# WHY NOT THE `Update URI` HEADER
+#
+# WP 5.8+ defines exactly the header this needs — a plugin declaring an external
+# update source is by definition not the site's. It would generalise past wp.org
+# to premium and vendor plugins. It is unusable in practice: measured across
+# every plugin on h44lacrosse.com, including WooCommerce, the Stripe gateway and
+# Akismet, not one sets it.
+#
+# Public surface:
+#   owned_discovery_supported            # 0 when the site can be queried
+#   owned_discovery_signal_fresh         # 0 when the wp.org signal is trustworthy
+#   owned_discovery_carried_plugins      # slugs wp-coding-agents installs
+#   owned_discovery_excluded             # operator exclusions (recorded)
+#   owned_discovery_add_exclusion <slug>
+#   owned_discovery_derive               # newline-separated wp-content paths, or
+#                                        # nonzero when the signal is untrustworthy
+#
+# Honors DRY_RUN for writes; reads always happen.
+
+# Slugs an operator has declared are NOT the site's, despite classifying as
+# owned. The escape hatch for the two cases derivation cannot see:
+#
+#   - a premium or vendor plugin, which is on nobody's wp.org list and is not
+#     carried by wp-coding-agents, but is no more the site's than WooCommerce
+#     is. Editing it is futile — the vendor's next update overwrites it — and
+#     capturing it may put licensed code in the operator's repository.
+#   - anything else the operator knows better about than a heuristic does.
+OWNED_DISCOVERY_EXCLUDED_OPTION="wp_coding_agents_not_owned"
+
+# How stale the wp.org signal may be before it stops being evidence. WordPress
+# refreshes update transients roughly twice daily; a couple of days tolerates a
+# quiet site or a brief wp.org outage without tolerating a cleared cache.
+OWNED_DISCOVERY_MAX_SIGNAL_AGE="${OWNED_DISCOVERY_MAX_SIGNAL_AGE:-172800}"
+
+# Plugin slugs wp-coding-agents installs and updates itself.
+#
+# These are not the site's: they are the agent's own runtime, replaced wholesale
+# by the next upgrade. An agent editing them in place loses the edit, and
+# capturing them would commit this project's source into the site's repository.
+#
+# MUST track what lib/data-machine.sh actually installs. Anything else
+# wp-coding-agents places on a site — an EXTRA_PLUGINS entry, a vendor
+# plugin — is not visible here and belongs in the exclusion list.
+owned_discovery_carried_plugins() {
+  cat <<'EOF'
+data-machine
+data-machine-code
+wp-codebox
+EOF
+}
+
+# 0 when the site can be queried at all.
+owned_discovery_supported() {
+  [ -n "${SITE_PATH:-}" ] || return 1
+  [ -f "$SITE_PATH/wp-config.php" ] || return 1
+  return 0
+}
+
+# Run a PHP snippet against the site. Reads only, and deliberately not through
+# run_cmd: a dry run must still be able to SEE, or it reports a derivation that
+# has nothing to do with what an apply would do.
+_owned_discovery_eval() {
+  owned_discovery_supported || return 1
+  # shellcheck disable=SC2086
+  $WP_CMD eval "$1" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
+}
+
+# 0 when the wp.org signal is present and recent enough to be evidence.
+#
+# This is the gate that keeps a missing signal from widening the editable set.
+owned_discovery_signal_fresh() {
+  local age
+  age="$(_owned_discovery_eval '
+    $t = get_site_transient("update_plugins");
+    if (!$t || empty($t->last_checked)) { echo "missing"; exit; }
+    $known = array_merge(
+      array_keys((array) ($t->response ?? [])),
+      array_keys((array) ($t->no_update ?? []))
+    );
+    // A transient with no known plugins is not evidence that no plugin is
+    // known to wp.org; it is evidence the check has not really run.
+    if (!$known) { echo "empty"; exit; }
+    echo (time() - (int) $t->last_checked);
+  ')"
+
+  case "$age" in
+    ''|missing|empty) return 1 ;;
+    *[!0-9]*) return 1 ;;
+  esac
+  [ "$age" -le "$OWNED_DISCOVERY_MAX_SIGNAL_AGE" ] || return 1
+  return 0
+}
+
+# Slugs wp.org knows about, plugins and themes, one per line.
+_owned_discovery_wporg_slugs() {
+  _owned_discovery_eval '
+    $out = [];
+    $p = get_site_transient("update_plugins");
+    if ($p) {
+      foreach (array_merge(
+        array_keys((array) ($p->response ?? [])),
+        array_keys((array) ($p->no_update ?? []))
+      ) as $file) {
+        // "woocommerce/woocommerce.php" -> "woocommerce"; "hello.php" -> "hello"
+        $out[] = strpos($file, "/") !== false
+          ? substr($file, 0, strpos($file, "/"))
+          : basename($file, ".php");
+      }
+    }
+    $t = get_site_transient("update_themes");
+    if ($t) {
+      foreach (array_merge(
+        array_keys((array) ($t->response ?? [])),
+        array_keys((array) ($t->no_update ?? []))
+      ) as $slug) {
+        $out[] = $slug;
+      }
+    }
+    echo implode("\n", array_unique($out));
+  '
+}
+
+# Installed plugin and theme slugs, as `<kind> <slug>` lines.
+_owned_discovery_installed() {
+  _owned_discovery_eval '
+    foreach (get_plugins() as $file => $data) {
+      $slug = strpos($file, "/") !== false
+        ? substr($file, 0, strpos($file, "/"))
+        : basename($file, ".php");
+      echo "plugins $slug\n";
+    }
+    foreach (wp_get_themes() as $slug => $theme) { echo "themes $slug\n"; }
+  '
+}
+
+# Operator exclusions, one slug per line.
+owned_discovery_excluded() {
+  local recorded=""
+  if declare -F _source_policy_option_read >/dev/null 2>&1; then
+    recorded="$(_source_policy_option_read "$OWNED_DISCOVERY_EXCLUDED_OPTION")"
+  fi
+  printf '%s\n' "${OWNED_DISCOVERY_EXCLUSIONS:-}" "$recorded" | sed '/^[[:space:]]*$/d'
+}
+
+# Add an exclusion from the command line. Slug only — the derivation works in
+# slugs, and accepting a path here would invite one that does not correspond to
+# anything installed.
+owned_discovery_add_exclusion() {
+  local slug="$1"
+  case "$slug" in
+    ''|*/*|*' '*) error "--not-owned takes a plugin or theme slug, not '$slug'." ;;
+  esac
+  if [ -z "${OWNED_DISCOVERY_EXCLUSIONS:-}" ]; then
+    OWNED_DISCOVERY_EXCLUSIONS="$slug"
+  else
+    OWNED_DISCOVERY_EXCLUSIONS="$OWNED_DISCOVERY_EXCLUSIONS
+$slug"
+  fi
+}
+
+# Persist the exclusions so later upgrades derive the same set without the flag.
+owned_discovery_record_exclusions() {
+  local excluded
+  excluded="$(printf '%s\n' "${OWNED_DISCOVERY_EXCLUSIONS:-}" | sed '/^[[:space:]]*$/d')"
+  [ -n "$excluded" ] || return 0
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $OWNED_DISCOVERY_EXCLUDED_OPTION '<${excluded}>'"
+    return 0
+  fi
+  owned_discovery_supported || return 0
+
+  local current=""
+  current="$(_source_policy_option_read "$OWNED_DISCOVERY_EXCLUDED_OPTION")"
+  [ "$current" = "$excluded" ] && return 0
+
+  if printf '%s' "$excluded" | wp_cmd option update "$OWNED_DISCOVERY_EXCLUDED_OPTION" >/dev/null 2>&1; then
+    log "  Recorded not-owned exclusions: $(printf '%s' "$excluded" | tr '\n' ' ')"
+  fi
+}
+
+# Derive the owned set as wp-content-relative paths.
+#
+# Returns nonzero WITHOUT output when the wp.org signal cannot be trusted, so a
+# caller can keep its last recorded set. Never widens on missing evidence.
+owned_discovery_derive() {
+  owned_discovery_supported || return 1
+  owned_discovery_signal_fresh || return 1
+
+  local wporg carried excluded installed kind slug
+  wporg="$(_owned_discovery_wporg_slugs)"
+  carried="$(owned_discovery_carried_plugins)"
+  excluded="$(owned_discovery_excluded)"
+  installed="$(_owned_discovery_installed)"
+
+  [ -n "$installed" ] || return 1
+
+  printf '%s\n' "$installed" | while read -r kind slug; do
+    [ -n "$kind" ] && [ -n "$slug" ] || continue
+    printf '%s\n' "$wporg"    | grep -qxF "$slug" && continue
+    printf '%s\n' "$carried"  | grep -qxF "$slug" && continue
+    printf '%s\n' "$excluded" | grep -qxF "$slug" && continue
+    printf 'wp-content/%s/%s\n' "$kind" "$slug"
+  done
+}

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -435,10 +435,30 @@ source_policy_resolve_owned_sources() {
     return 0
   fi
 
+  # Precedence: explicit flags > derived from site state > last recorded.
+  #
+  # Derivation is the default because ownership is a fact already on the box,
+  # not a judgement (see lib/owned-source-discovery.sh). It wins over the
+  # recorded set so a plugin the agent creates becomes editable and captured
+  # with no operator step — otherwise the recorded value would pin the set
+  # forever and this would change nothing.
+  #
+  # It CANNOT win when the wp.org signal is untrustworthy. owned_discovery_derive
+  # returns nonzero rather than guessing, and the recorded set is kept. That
+  # asymmetry is the safety argument: a stale transient makes every plugin look
+  # unknown to wp.org, and a version that widened on missing evidence would open
+  # WooCommerce and a payment gateway on the site this was built for.
+  local derived=""
   if [ "${OWNED_SOURCES_EXPLICIT:-false}" = true ]; then
     OWNED_SOURCES="$(_source_policy_normalize_sources "${OWNED_SOURCES:-}")"
+  elif declare -F owned_discovery_derive >/dev/null 2>&1 && derived="$(owned_discovery_derive)" && [ -n "$derived" ]; then
+    OWNED_SOURCES="$(_source_policy_normalize_sources "$(printf '%s' "$derived" | tr '\n' ' ')")"
+    log "  Owned sources derived from site state: $(printf '%s' "$OWNED_SOURCES" | tr '\n' ' ')"
   else
     OWNED_SOURCES="$(_source_policy_normalize_sources "$(source_policy_recorded_owned_sources)")"
+    if declare -F owned_discovery_derive >/dev/null 2>&1; then
+      warn "  Could not derive owned sources (wp.org update signal missing or stale) — keeping the recorded set."
+    fi
   fi
 
   if [ -z "$OWNED_SOURCES" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect source-policy wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance; do
+for lib in common detect source-policy owned-source-discovery wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -207,6 +207,10 @@ while [[ $# -gt 0 ]]; do
       SOURCE_MODE_EXPLICIT=true
       shift 2
       ;;
+    --not-owned)
+      owned_discovery_add_exclusion "$2"
+      shift 2
+      ;;
     --owned-source|--managed-source)
       OWNED_SOURCES="${OWNED_SOURCES}${OWNED_SOURCES:+ }$2"
       OWNED_SOURCES_EXPLICIT=true
@@ -294,6 +298,9 @@ OPTIONS:
                      Recorded on the install so upgrades converge without
                      repeating the flag. (--posture is accepted as a
                      deprecated alias; engineering=workspace, managed=owned.)
+  --not-owned <slug> Plugin or theme slug that is NOT the site's despite
+                     classifying as owned — a premium or vendor plugin,
+                     typically. Repeatable. Recorded on the install.
   --owned-source <path>
                      wp-content path this site owns and the agent may edit
                      under --source-mode owned. Repeatable. Must be a plugin or
@@ -505,6 +512,7 @@ if [ "$RUNTIME_ONLY" != true ]; then
 fi
 
 source_policy_record_mode
+owned_discovery_record_exclusions
 source_policy_record_owned_sources
 source_policy_record_writable_paths
 source_policy_record_log_paths

--- a/tests/owned-source-discovery.sh
+++ b/tests/owned-source-discovery.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# tests/owned-source-discovery.sh — deriving the owned set from site state.
+#
+# The property that matters here is not "does it find the right plugins". It is
+# that it CANNOT WIDEN ON MISSING EVIDENCE.
+#
+# The wp.org signal is a transient. On a fresh install, after a cache flush, or
+# when wp.org is unreachable, it is absent — and if absence were treated as "no
+# plugin is known to wp.org", every plugin would classify as the site's. On
+# h44lacrosse.com that means handing a coding agent write access to WooCommerce
+# and a Stripe payment gateway, produced by a piece of automation whose whole
+# purpose is to be safer than an operator doing it by hand.
+#
+# So ownership is inferred only from the PRESENCE of evidence. Every assertion
+# below about a missing, empty, or stale signal is really the same assertion:
+# the derivation refuses rather than guesses, and the caller keeps the last
+# recorded set.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+FAILED=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [ "$got" = "$want" ]; then echo "  ok   $name"; else
+    echo "  FAIL $name"; echo "         got:  $got"; echo "         want: $want"
+    FAILED=$((FAILED + 1))
+  fi
+}
+assert_contains() {
+  case "$1" in *"$2"*) echo "  ok   $3" ;; *) echo "  FAIL $3 (missing: $2)"; FAILED=$((FAILED + 1)) ;; esac
+}
+refute_contains() {
+  case "$1" in *"$2"*) echo "  FAIL $3 (unexpectedly present: $2)"; FAILED=$((FAILED + 1)) ;; *) echo "  ok   $3" ;; esac
+}
+# Slug-exact. A substring test cannot tell `plugins/data-machine` from
+# `plugins/data-machine-business`, which is exactly the pair this file has to
+# distinguish: one is the agent's runtime, the other a vendor plugin.
+refute_line() {
+  if printf '%s\n' "$1" | grep -qxF "$2"; then
+    echo "  FAIL $3 (unexpectedly present: $2)"; FAILED=$((FAILED + 1))
+  else
+    echo "  ok   $3"
+  fi
+}
+assert_line() {
+  if printf '%s\n' "$1" | grep -qxF "$2"; then echo "  ok   $3"; else
+    echo "  FAIL $3 (missing line: $2)"; FAILED=$((FAILED + 1))
+  fi
+}
+
+log() { :; }; warn() { :; }; info() { :; }
+error() { echo "ERROR: $1" >&2; exit 1; }
+# shellcheck disable=SC1091
+source lib/owned-source-discovery.sh
+
+# A stand-in for the real site, modelled on h44lacrosse.com's actual inventory.
+# SIGNAL controls what the wp.org transient looks like: fresh | stale | missing | empty
+make_site() {
+  SIGNAL="${1:-fresh}"
+  owned_discovery_supported() { return 0; }
+  _owned_discovery_eval() {
+    case "$1" in
+      *update_plugins*last_checked*)
+        case "$SIGNAL" in
+          fresh)   echo 60 ;;
+          stale)   echo 999999 ;;
+          missing) echo missing ;;
+          empty)   echo empty ;;
+        esac ;;
+      *get_plugins*)
+        cat <<'EOF'
+plugins akismet
+plugins data-machine
+plugins data-machine-business
+plugins data-machine-code
+plugins fluent-smtp
+plugins h44-core
+plugins h44-forms
+plugins hello
+plugins woocommerce
+plugins woocommerce-gateway-stripe
+themes h44-lacrosse-theme
+themes twentytwentyfive
+EOF
+        ;;
+      *update_themes*|*array_unique*)
+        [ "$SIGNAL" = "fresh" ] || return 0
+        cat <<'EOF'
+woocommerce
+akismet
+hello
+fluent-smtp
+woocommerce-gateway-stripe
+twentytwentyfive
+EOF
+        ;;
+    esac
+  }
+}
+
+echo "owned-source-discovery: derives the site's own components"
+
+make_site fresh
+OWNED_DISCOVERY_EXCLUSIONS=""
+_source_policy_option_read() { return 0; }
+DERIVED="$(owned_discovery_derive)"
+
+assert_line "$DERIVED" "wp-content/plugins/h44-core" "finds a site plugin"
+assert_line "$DERIVED" "wp-content/plugins/h44-forms" "finds a second site plugin"
+assert_line "$DERIVED" "wp-content/themes/h44-lacrosse-theme" "finds the site theme"
+
+# wp.org plugins are not the site's. Editing them is futile — the next update
+# overwrites it — quite apart from WooCommerce being a payment surface.
+for p in woocommerce woocommerce-gateway-stripe akismet fluent-smtp hello; do
+  refute_line "$DERIVED" "wp-content/plugins/$p" "excludes wp.org plugin $p"
+done
+refute_line "$DERIVED" "wp-content/themes/twentytwentyfive" "excludes a wp.org bundled theme"
+
+# The agent's own runtime is replaced wholesale by the next upgrade, and
+# capturing it would commit this project's source into the site's repository.
+for p in data-machine data-machine-code wp-codebox; do
+  refute_line "$DERIVED" "wp-content/plugins/$p" "excludes carried plugin $p"
+done
+
+echo ""
+echo "owned-source-discovery: the exclusion escape hatch"
+
+# A vendor plugin is on nobody's wp.org list and is not carried, so it derives
+# as owned. It is no more the site's than WooCommerce is, and capturing it may
+# put licensed code in the operator's repository. Measured on h44lacrosse.com:
+# data-machine-business is exactly this case.
+assert_line "$DERIVED" "wp-content/plugins/data-machine-business" \
+  "a vendor plugin derives as owned without an exclusion (the false positive)"
+
+OWNED_DISCOVERY_EXCLUSIONS="data-machine-business"
+EXCLUDED_DERIVED="$(owned_discovery_derive)"
+refute_contains "$EXCLUDED_DERIVED" "data-machine-business" "an exclusion removes it"
+assert_line "$EXCLUDED_DERIVED" "wp-content/plugins/h44-core" "and leaves the real components"
+
+# Slugs only: a path here would name something no installed component matches,
+# and fail silently.
+for bad in "wp-content/plugins/x" "" "two words"; do
+  out=$(bash -c '
+    error() { echo "ERROR: $1"; exit 1; }
+    source lib/owned-source-discovery.sh
+    owned_discovery_add_exclusion "'"$bad"'"
+  ' 2>&1 || true)
+  assert_contains "$out" "takes a plugin or theme slug" "--not-owned rejects '$bad'"
+done
+
+echo ""
+echo "owned-source-discovery: NEVER widens on missing evidence"
+
+# Each of these is the same danger in a different costume: absence of the wp.org
+# signal must not be read as "nothing belongs to wp.org".
+for signal in missing empty stale; do
+  make_site "$signal"
+  OWNED_DISCOVERY_EXCLUSIONS=""
+  if out="$(owned_discovery_derive)"; then
+    echo "  FAIL derived from a $signal signal instead of refusing"
+    FAILED=$((FAILED + 1))
+  else
+    echo "  ok   refuses to derive from a $signal signal"
+  fi
+  if [ -n "${out:-}" ]; then
+    echo "  FAIL a $signal signal produced output: $out"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+# The specific catastrophe, asserted directly rather than implied: a missing
+# signal must never be the reason a payment plugin becomes editable.
+make_site missing
+out="$(owned_discovery_derive || true)"
+refute_contains "$out" "woocommerce" "a missing signal cannot open WooCommerce"
+refute_contains "$out" "stripe" "a missing signal cannot open the payment gateway"
+
+echo ""
+echo "owned-source-discovery: wiring"
+
+# Derivation must beat the recorded set, or a plugin the agent creates never
+# becomes editable and this changes nothing. It must LOSE to explicit flags,
+# which are the operator overriding deliberately.
+# Comments explaining the precedence legitimately name the functions in a
+# different order than the code calls them, so order is checked on code only.
+policy="$(sed -n '/^source_policy_resolve_owned_sources/,/^}/p' lib/source-policy.sh | sed 's/#.*//')"
+assert_contains "$policy" 'OWNED_SOURCES_EXPLICIT' "explicit flags are checked"
+assert_contains "$policy" "owned_discovery_derive" "derivation is consulted"
+assert_contains "$policy" "source_policy_recorded_owned_sources" "recorded set is the fallback"
+
+explicit_line=$(printf '%s\n' "$policy" | grep -n 'OWNED_SOURCES_EXPLICIT' | head -1 | cut -d: -f1)
+derive_line=$(printf '%s\n' "$policy" | grep -n 'owned_discovery_derive' | head -1 | cut -d: -f1)
+recorded_line=$(printf '%s\n' "$policy" | grep -n 'source_policy_recorded_owned_sources' | head -1 | cut -d: -f1)
+if [ "$explicit_line" -lt "$derive_line" ] && [ "$derive_line" -lt "$recorded_line" ]; then
+  echo "  ok   precedence is explicit > derived > recorded"
+else
+  echo "  FAIL precedence wrong (explicit=$explicit_line derive=$derive_line recorded=$recorded_line)"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "owned-source-discovery: all assertions passed"
+else
+  echo "owned-source-discovery: $FAILED assertion(s) failed"
+  exit 1
+fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance agents-md-backups; do
+for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance agents-md-backups; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -157,6 +157,7 @@ while [[ $# -gt 0 ]]; do
     --ai-gateway-opencode-model) AI_GATEWAY_MODEL_ID="$2"; shift 2 ;;
     --rotate-ai-gateway-token) ROTATE_AI_GATEWAY_TOKEN=true; shift ;;
     --source-mode|--posture) SOURCE_MODE="$2"; SOURCE_MODE_EXPLICIT=true; shift 2 ;;
+    --not-owned)     owned_discovery_add_exclusion "$2"; shift 2 ;;
     --owned-source|--managed-source) OWNED_SOURCES="${OWNED_SOURCES}${OWNED_SOURCES:+ }$2"; OWNED_SOURCES_EXPLICIT=true; shift 2 ;;
     --owned-writable|--managed-writable) OWNED_WRITABLE="${OWNED_WRITABLE}${OWNED_WRITABLE:+ }$2"; OWNED_WRITABLE_EXPLICIT=true; shift 2 ;;
     --log-path) SOURCE_LOG_PATHS="${SOURCE_LOG_PATHS}${SOURCE_LOG_PATHS:+ }$2"; SOURCE_LOG_PATHS_EXPLICIT=true; shift 2 ;;
@@ -209,6 +210,10 @@ USAGE:
                                (default: the mode recorded at setup time).
                                Two shapes, not two levels. --posture is
                                accepted as a deprecated alias.
+  ./upgrade.sh --not-owned <slug>
+                               Plugin or theme slug that is NOT the site's,
+                               despite classifying as owned — a premium or
+                               vendor plugin, typically. Repeatable, recorded.
   ./upgrade.sh --owned-source <path>
                                wp-content path this site owns and may edit under
                                --source-mode owned. Repeatable. Replaces the
@@ -393,6 +398,7 @@ source_policy_resolve_writable_paths
 source_policy_resolve_log_paths
 source_policy_assert_runtime_supports_mode
 source_policy_record_mode
+owned_discovery_record_exclusions
 source_policy_record_owned_sources
 source_policy_record_writable_paths
 source_policy_record_log_paths


### PR DESCRIPTION
Closes the declaration half of #336, without making declaration an action.

## The idea

Declaring what a site owns was an operator action — `--owned-source` per component, over SSH, repeated in the capture config. A non-technical owner asking for a new plugin had to file a support ticket, which is the thing managed hosting exists to remove.

But ownership isn't a judgement call. It's a fact already on the box:

```
owned = installed − known to wp.org − installed by wp-coding-agents − explicitly excluded
```

**Verified against h44lacrosse.com's live state:**

```
DERIVED                                    RECORDED (declared by hand)
  wp-content/plugins/data-machine-business   wp-content/themes/h44-lacrosse-theme
  wp-content/plugins/h44-core                wp-content/plugins/h44-core
  wp-content/plugins/h44-forms               wp-content/plugins/h44-forms
  wp-content/themes/h44-lacrosse-theme
```

Exactly the hand-declared set, plus one vendor plugin. With `--not-owned data-machine-business` the two are identical.

## The failure mode this is built around

The wp.org signal is a **transient**. Fresh install, cache flush, wp.org unreachable — it's absent. Read absence as "nothing belongs to wp.org" and *every* plugin classifies as the site's, handing the agent write access to **WooCommerce and a Stripe payment gateway**. Automation whose whole purpose is to be safer than a human would be the thing that opened the payment plugin.

So ownership is inferred only from the **presence** of evidence. Missing, empty, or stale (>2d) produces no derivation and the caller keeps the last recorded set.

Verified live by forcing the freshness gate to zero:

```
=== FAIL-CLOSED: signal forced stale (the dangerous path) ===
  refused to derive (exit 1) — caller keeps the recorded set
  output was: []
```

## Why not `Update URI`

WP 5.8+ defines exactly the right header — a plugin declaring an external update source is by definition not the site's, and it would generalise past wp.org to premium plugins. It's unusable: measured across every plugin on that box, including WooCommerce, the Stripe gateway and Akismet, **not one sets it**.

Hence `--not-owned <slug>`, which also keeps licensed vendor code out of the operator's repository.

## Precedence

`explicit flags > derived > recorded`. Derivation must beat the recorded set or a newly created plugin never becomes editable and this changes nothing; it must lose to explicit flags, which are the operator deciding deliberately. Pinned by a test that strips comments before checking call order — my comments name the functions in a different order than the code calls them.

## Coverage

`tests/owned-source-discovery.sh`, wired into CI. Every "missing evidence" case asserted separately, plus the catastrophe asserted directly rather than implied: *a missing signal cannot open WooCommerce*.

One test bug worth noting: my first version used substring matching and couldn't distinguish `plugins/data-machine` from `plugins/data-machine-business` — the exact pair this file exists to tell apart. Slug assertions are now exact-line.