### PR TITLE
fix: the unit's environment must follow the service identity

### DIFF
--- a/bridges/_dispatch.sh
+++ b/bridges/_dispatch.sh
@@ -154,6 +154,35 @@ _compose_path_value() {
 _merge_systemd_env_lines() {
   local current_env="$1"
   local template_env="$2"
+
+  # Drop existing values that point into a service home the install has just
+  # migrated away from.
+  #
+  # This merge keeps the INSTALLED unit's value for any key the template also
+  # sets — deliberately, so operator edits survive an upgrade. But the service
+  # identity migration (#93) changes User= and the home every identity-derived
+  # value is built from, and those values are not operator edits: they describe
+  # an identity that no longer exists.
+  #
+  # Measured on h44lacrosse.com: the migration produced User=opencode alongside
+  # Environment=HOME=/root and KIMAKI_DATA_DIR=/root/.kimaki. Starting that unit
+  # runs the agent as a user that cannot read either path — /root is 0700 — so
+  # it comes up with no session database and no runtime state. The same defect
+  # #204 fixed from the other direction: there the User flipped silently while
+  # the state stayed put; here the User moved and the environment stayed put.
+  #
+  # Filtering by VALUE rather than by a list of key names is what makes this
+  # hold. PATH on a long-lived install carries /root/.kimaki/bin,
+  # /root/.cargo/bin and /root/.bun/bin; BUN_INSTALL points at /root/.bun.
+  # Enumerating keys would have fixed HOME and KIMAKI_DATA_DIR and left the
+  # agent with a PATH full of directories it can no longer read (#318: prefer
+  # the property over a list of names).
+  if [ -n "${SERVICE_MIGRATION_PREVIOUS_HOME:-}" ]; then
+    current_env="$(printf '%s\n' "$current_env" \
+      | grep -vF "=${SERVICE_MIGRATION_PREVIOUS_HOME}" \
+      | grep -vF ":${SERVICE_MIGRATION_PREVIOUS_HOME}" || true)"
+  fi
+
   local merged="$current_env"
   while IFS= read -r tmpl_line; do
     [ -z "$tmpl_line" ] && continue

--- a/lib/infrastructure.sh
+++ b/lib/infrastructure.sh
@@ -221,31 +221,6 @@ setup_ssl() {
   fi
 }
 
-# Restrict the credentials file after the site-wide grant (issue #302).
-#
-# The recursive `chmod -R g+w` above exists so the service user — a member of
-# www-data — can edit themes and plugins. Applied to the whole site path it
-# also sweeps in wp-config.php, which holds the database credentials, salts,
-# and auth keys. That leaves the file world-readable (any local account can
-# read the credentials) and agent-writable (the coding agent can rewrite the
-# site's database connection), neither of which the agent needs.
-#
-# 0640 owned by www-data keeps PHP-FPM and nginx working — both run as
-# www-data on a standard provision — while removing world read and group
-# write. Applied unconditionally so re-running provisioning corrects a mode
-# an earlier install left loosened, rather than only fixing fresh sites.
-harden_wp_config_permissions() {
-  local site_path="$1"
-  local config="$site_path/wp-config.php"
-
-  if [ "$DRY_RUN" != true ] && [ ! -f "$config" ]; then
-    return 0
-  fi
-
-  run_cmd chown www-data:www-data "$config"
-  run_cmd chmod 640 "$config"
-}
-
 setup_service_permissions() {
   if [ "$LOCAL_MODE" = true ]; then
     log "Phase 6: Local mode — skipping service user setup"

--- a/lib/service-migration.sh
+++ b/lib/service-migration.sh
@@ -469,9 +469,9 @@ service_migration_reclaim_site() {
 
   run_cmd chown -R www-data:www-data "$site_path"
   run_cmd chmod -R g+w "$site_path"
-  if declare -F harden_wp_config_permissions >/dev/null 2>&1; then
-    harden_wp_config_permissions "$site_path"
-  fi
+  # Unconditional, and deliberately AFTER the blanket g+w that would otherwise
+  # leave the database credentials group-writable.
+  harden_wp_config_permissions "$site_path"
 }
 
 # The agent's code workspace, when one exists (workspace mode only —
@@ -537,6 +537,11 @@ service_migration_run() {
 
   # Re-point the caller's identity variables. Everything downstream — unit
   # rendering, bridge config, data dir creation — derives from these.
+  # Published so the systemd env merge can invalidate values built from the old
+  # identity. Without it the merge keeps HOME, KIMAKI_DATA_DIR and PATH from the
+  # installed unit — all pointing into a home the new user cannot read.
+  SERVICE_MIGRATION_PREVIOUS_HOME="$old_home"
+
   SERVICE_USER="$target_user"
   SERVICE_HOME="$new_home"
   RUN_AS_ROOT=false

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -255,3 +255,35 @@ setup_multisite() {
     log "Phase 3.5: Existing multisite detected — skipping conversion"
   fi
 }
+
+# Moved here from lib/infrastructure.sh, which setup.sh sources and upgrade.sh
+# does not. The service-identity migration called this behind a
+# `declare -F` guard, so on an upgrade the function did not exist, the guard
+# silently skipped it, and wp-config.php was left group-writable by the blanket
+# `chmod -R g+w` that runs just before. A guard around a function you REQUIRE
+# converts a missing dependency into silent breakage; the call site is now
+# unconditional and this lives where every caller already sources it.
+# Restrict the credentials file after the site-wide grant (issue #302).
+#
+# The recursive `chmod -R g+w` above exists so the service user — a member of
+# www-data — can edit themes and plugins. Applied to the whole site path it
+# also sweeps in wp-config.php, which holds the database credentials, salts,
+# and auth keys. That leaves the file world-readable (any local account can
+# read the credentials) and agent-writable (the coding agent can rewrite the
+# site's database connection), neither of which the agent needs.
+#
+# 0640 owned by www-data keeps PHP-FPM and nginx working — both run as
+# www-data on a standard provision — while removing world read and group
+# write. Applied unconditionally so re-running provisioning corrects a mode
+# an earlier install left loosened, rather than only fixing fresh sites.
+harden_wp_config_permissions() {
+  local site_path="$1"
+  local config="$site_path/wp-config.php"
+
+  if [ "$DRY_RUN" != true ] && [ ! -f "$config" ]; then
+    return 0
+  fi
+
+  run_cmd chown www-data:www-data "$config"
+  run_cmd chmod 640 "$config"
+}

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -469,3 +469,94 @@ else
   echo "service-migration: $FAILED assertion(s) failed"
   exit 1
 fi
+
+echo ""
+echo "service-migration: the unit's environment follows the identity"
+
+# Found by migrating h44lacrosse.com and checking the rendered unit BEFORE
+# starting anything. The migration produced User=opencode alongside
+# Environment=HOME=/root and KIMAKI_DATA_DIR=/root/.kimaki: the merge keeps the
+# installed unit's value for any key the template also sets, deliberately, so
+# operator edits survive an upgrade — but identity-derived values are not
+# operator edits. Starting that unit runs the agent as a user that cannot read
+# either path (/root is 0700), so it comes up with no session database and no
+# runtime state.
+#
+# Same defect as #204 from the other direction: there the User flipped silently
+# while state stayed put; here the User moved and the environment stayed put.
+
+# shellcheck disable=SC1091
+source bridges/_dispatch.sh 2>/dev/null || true
+
+INSTALLED_ENV='Environment=HOME=/root
+Environment=PATH=/root/.kimaki/bin:/root/.cargo/bin:/usr/bin:/bin
+Environment=KIMAKI_DATA_DIR=/root/.kimaki
+Environment=BUN_INSTALL=/root/.bun
+Environment=OPERATOR_CUSTOM=keep-me'
+
+TEMPLATE_ENV='Environment=HOME=/home/opencode
+Environment=PATH=/home/opencode/.kimaki/bin:/usr/bin:/bin
+Environment=KIMAKI_DATA_DIR=/home/opencode/.kimaki'
+
+# Without a migration in flight nothing is invalidated: an ordinary upgrade must
+# not rewrite an operator's environment.
+MERGED_NORMAL=$(SERVICE_MIGRATION_PREVIOUS_HOME="" _merge_systemd_env_lines "$INSTALLED_ENV" "$TEMPLATE_ENV")
+assert_contains "$MERGED_NORMAL" "Environment=HOME=/root" \
+  "an ordinary upgrade keeps the installed HOME"
+assert_contains "$MERGED_NORMAL" "OPERATOR_CUSTOM=keep-me" \
+  "an ordinary upgrade keeps operator additions"
+
+# Mid-migration, every value built from the old home is replaced.
+MERGED_MIG=$(SERVICE_MIGRATION_PREVIOUS_HOME="/root" _merge_systemd_env_lines "$INSTALLED_ENV" "$TEMPLATE_ENV")
+assert_contains "$MERGED_MIG" "Environment=HOME=/home/opencode" "HOME follows the new identity"
+assert_contains "$MERGED_MIG" "KIMAKI_DATA_DIR=/home/opencode/.kimaki" "the data dir follows"
+refute_contains "$MERGED_MIG" "HOME=/root" "the old HOME is gone"
+refute_contains "$MERGED_MIG" "/root/.kimaki" "no value still points into the old home"
+
+# PATH is the one a key-name list would have missed: it is not obviously an
+# identity value, and a stale one leaves the agent unable to reach its binaries.
+refute_contains "$MERGED_MIG" "/root/.cargo/bin" "a stale PATH entry is dropped"
+refute_contains "$MERGED_MIG" "BUN_INSTALL=/root/.bun" "so is an unrelated tool var"
+
+# Operator additions that say nothing about identity still survive a migration.
+assert_contains "$MERGED_MIG" "OPERATOR_CUSTOM=keep-me" \
+  "a migration preserves operator additions"
+
+# The migration must publish the old home, or the filter above never engages.
+assert_contains "$(sed -n '/^service_migration_run/,/^}/p' lib/service-migration.sh)" \
+  'SERVICE_MIGRATION_PREVIOUS_HOME="$old_home"' \
+  "service_migration_run publishes the previous home"
+
+echo ""
+echo "service-migration: wp-config hardening is not optional"
+
+# The reclaim chmods the whole site g+w and then hardens wp-config back. That
+# harden lived in lib/infrastructure.sh, which setup.sh sources and upgrade.sh
+# does not, behind a `declare -F` guard — so on an upgrade the function did not
+# exist, the guard silently skipped it, and h44lacrosse.com came out of the
+# migration with its database credentials group-writable (660, not 640).
+#
+# A guard around a function you REQUIRE converts a missing dependency into
+# silent breakage.
+reclaim=$(sed -n '/^service_migration_reclaim_site/,/^}/p' lib/service-migration.sh)
+refute_contains "$reclaim" "declare -F harden_wp_config_permissions" \
+  "hardening is not behind a declare -F guard"
+assert_contains "$reclaim" "harden_wp_config_permissions" "hardening still happens"
+
+# It must be defined in a lib upgrade.sh actually sources.
+upgrade_libs=$(grep -o 'for lib in [a-z0-9 -]*' upgrade.sh)
+defined_in=$(grep -rl '^harden_wp_config_permissions()' lib/ | head -1 | xargs -r basename | sed 's/\.sh$//')
+case "$upgrade_libs" in
+  *"$defined_in"*) echo "  ok   defined in '$defined_in', which upgrade.sh sources" ;;
+  *) echo "  FAIL defined in '$defined_in', which upgrade.sh does NOT source"; FAILED=$((FAILED + 1)) ;;
+esac
+
+# And it must run AFTER the blanket g+w, or the g+w undoes it.
+chmod_line=$(printf '%s\n' "$reclaim" | grep -n 'chmod -R g+w' | head -1 | cut -d: -f1)
+harden_line=$(printf '%s\n' "$reclaim" | grep -n '^  harden_wp_config_permissions' | head -1 | cut -d: -f1)
+if [ -n "$chmod_line" ] && [ -n "$harden_line" ] && [ "$harden_line" -gt "$chmod_line" ]; then
+  echo "  ok   hardening runs after the blanket g+w"
+else
+  echo "  FAIL ordering wrong (chmod=${chmod_line:-?} harden=${harden_line:-?})"
+  FAILED=$((FAILED + 1))
+fi

--- a/tests/wp-config-permissions.sh
+++ b/tests/wp-config-permissions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # tests/wp-config-permissions.sh — Regression coverage for issue #302 in
-# lib/infrastructure.sh.
+# lib/wordpress.sh.
 #
 # Phase 6 grants the service user write access to the site with a recursive
 # `chmod -R g+w "$SITE_PATH"`, so it can edit themes and plugins. That grant
@@ -51,7 +51,9 @@ run_cmd() {
 }
 
 # shellcheck disable=SC1091
-eval "$(sed -n '/^harden_wp_config_permissions() {/,/^}/p' lib/infrastructure.sh)"
+# Lives in lib/wordpress.sh: upgrade.sh does not source infrastructure.sh, and
+# the service-identity migration needs this during an upgrade.
+eval "$(sed -n '/^harden_wp_config_permissions() {/,/^}/p' lib/wordpress.sh)"
 
 mode_of() {
   stat -c '%a' "$1"


### PR DESCRIPTION
Both bugs found by migrating h44lacrosse.com to non-root and inspecting the rendered unit **before** starting anything.

## 1. The environment did not follow the identity

The migration produced:

```
User=opencode
Environment=HOME=/root
Environment=KIMAKI_DATA_DIR=/root/.kimaki
```

Starting that runs the agent as a user that cannot read either path — `/root` is `0700`. It comes up with no session database and no runtime state.

`_merge_systemd_env_lines` keeps the **installed** unit's value for any key the template also sets. That's deliberate and correct — operator edits should survive an upgrade. But identity-derived values aren't operator edits; they describe an identity that no longer exists.

Same defect as #204 from the other direction: there the `User=` flipped silently while state stayed put; here the `User=` moved and the environment stayed put.

**The filter matches on value, not on a list of key names**, and that's what makes it hold:

```
PATH=/root/.kimaki/bin:/root/.cargo/bin:...
BUN_INSTALL=/root/.bun
```

Enumerating keys would have fixed `HOME` and `KIMAKI_DATA_DIR` and left the agent with a `PATH` full of directories it can no longer read. Prefer the property over a list of names (#318).

Operator additions that say nothing about the old home still survive — asserted both ways.

## 2. A guard around a required function is silent breakage

The site reclaim chmods the tree `g+w`, then hardens `wp-config.php` back to `640`. That harden lived in `lib/infrastructure.sh` — which `setup.sh` sources and **`upgrade.sh` does not** — and I called it behind `declare -F`.

So on an upgrade the function didn't exist, the guard silently skipped it, and h44lacrosse.com came out of the migration with its **database credentials group-writable** (`660`, not `640`).

I wrote that guard to be defensive. It converted a missing dependency into a silent, security-relevant regression — strictly worse than the crash it avoided.

Now defined in `lib/wordpress.sh`, which both entry points source, and called unconditionally. Tests assert it's defined in a lib `upgrade.sh` actually sources, and that it runs *after* the blanket `g+w`.

The existing `wp-config-permissions` test caught the move — it extracted the function from `infrastructure.sh` by path. Worth noting that test only began running in CI today, via #335.

## h44 status

Already corrected by hand and healthy: kimaki active as `opencode`, 0 restarts, site 200, WooCommerce/admin/REST/cron all verified. This makes sure no other install hits either bug.