### PR TITLE
fix: redact CLI transport diagnostics

### DIFF
--- a/templates/wp-coding-agents-cli-transport.php
+++ b/templates/wp-coding-agents-cli-transport.php
@@ -177,6 +177,93 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Registry', false ) ) {
 	}
 }
 
+if ( ! class_exists( 'WpCodingAgents_Cli_Output_Redactor', false ) ) {
+	/**
+	 * Redact secrets from untrusted child-process diagnostics.
+	 */
+	class WpCodingAgents_Cli_Output_Redactor {
+		private const REDACTED = '[redacted]';
+
+		/**
+		 * Redact generic credential patterns and known environment values.
+		 *
+		 * @param array<string, string> $configured_env Channel-configured environment.
+		 */
+		public static function redact( string $output, array $configured_env = array() ): string {
+			$redacted = $output;
+			foreach ( self::known_environment_values( $configured_env ) as $secret ) {
+				$redacted = str_replace( $secret, self::REDACTED, $redacted );
+			}
+
+			$candidate = preg_replace(
+				'/\b((?:(?:proxy-)?authorization|(?:set-)?cookie)\s*[:=]\s*)[^\r\n]+/i',
+				'$1' . self::REDACTED,
+				$redacted
+			);
+			$redacted  = is_string( $candidate ) ? $candidate : $redacted;
+
+			$candidate = preg_replace( '/\bbearer\s+[A-Za-z0-9._~+\/=\-]{8,}/i', 'Bearer ' . self::REDACTED, $redacted );
+			$redacted  = is_string( $candidate ) ? $candidate : $redacted;
+
+			$candidate = preg_replace( '#\b(https?://)[^/\s:@]+:[^@/\s]+@#i', '$1' . self::REDACTED . ':' . self::REDACTED . '@', $redacted );
+			$redacted  = is_string( $candidate ) ? $candidate : $redacted;
+
+			$sensitive_key = '(?:(?:[a-z][a-z0-9]*[_-])*(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth(?:orization)?|client[_-]?secret|cookie|credentials?|nonce|password|passwd|private[_-]?key|secret|signature|token))';
+			$candidate     = preg_replace( '/([?&]' . $sensitive_key . '=)[^&#\s]*/i', '$1' . self::REDACTED, $redacted );
+			$redacted      = is_string( $candidate ) ? $candidate : $redacted;
+
+			$assignment_pattern = '/(?P<prefix>(?:"|\')?\b' . $sensitive_key . '\b(?:"|\')?\s*[:=]\s*)(?P<value>"[^"\r\n]*"|\'[^\'\r\n]*\'|[^\s,;&#]+)/i';
+			$assigned           = preg_replace_callback(
+				$assignment_pattern,
+				static function ( array $matches ): string {
+					$value = $matches['value'];
+					$quote = in_array( $value[0] ?? '', array( '"', "'" ), true ) ? $value[0] : '';
+					return $matches['prefix'] . $quote . self::REDACTED . $quote;
+				},
+				$redacted
+			);
+			$redacted           = is_string( $assigned ) ? $assigned : $redacted;
+
+			return $redacted;
+		}
+
+		/**
+		 * Gather exact values that must not cross a diagnostic boundary.
+		 *
+		 * Every sufficiently distinctive configured value is treated as private;
+		 * inherited values are included only when their key is sensitive.
+		 *
+		 * @param array<string, string> $configured_env Channel-configured environment.
+		 * @return array<int, string>
+		 */
+		private static function known_environment_values( array $configured_env ): array {
+			$values = array();
+			foreach ( $configured_env as $value ) {
+				if ( strlen( $value ) >= 8 ) {
+					$values[] = $value;
+				}
+			}
+
+			$inherited = getenv();
+			if ( is_array( $inherited ) ) {
+				foreach ( $inherited as $key => $value ) {
+					if ( is_string( $key ) && is_string( $value ) && strlen( $value ) >= 8 && self::key_is_sensitive( $key ) ) {
+						$values[] = $value;
+					}
+				}
+			}
+
+			$values = array_values( array_unique( $values ) );
+			usort( $values, static fn( string $left, string $right ): int => strlen( $right ) <=> strlen( $left ) );
+			return $values;
+		}
+
+		private static function key_is_sensitive( string $key ): bool {
+			return 1 === preg_match( '/(?:api[_-]?key|auth|cookie|credential|nonce|password|passwd|private[_-]?key|secret|signature|token)/i', $key );
+		}
+	}
+}
+
 if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 	/**
 	 * Generic CLI transport for agents/dispatch-message.
@@ -243,13 +330,14 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 			$detach = (bool) ( $config['detach'] ?? true );
 			$timeout = isset( $config['timeout'] ) && is_int( $config['timeout'] ) ? $config['timeout'] : self::DEFAULT_TIMEOUT_SECONDS;
 			$cwd     = isset( $config['cwd'] ) && is_string( $config['cwd'] ) && '' !== $config['cwd'] ? $config['cwd'] : null;
-			$env     = self::build_env_map( isset( $config['env'] ) && is_array( $config['env'] ) ? $config['env'] : array() );
+			$configured_env = isset( $config['env'] ) && is_array( $config['env'] ) ? $config['env'] : array();
+			$env            = self::build_env_map( $configured_env );
 
 			if ( $detach ) {
-				return self::dispatch_detached( $channel, $recipient, $command_args, $cwd, $env );
+				return self::dispatch_detached( $channel, $recipient, $command_args, $cwd, $env, $configured_env );
 			}
 
-			return self::dispatch_sync( $channel, $recipient, $command_args, $cwd, $env, $timeout );
+			return self::dispatch_sync( $channel, $recipient, $command_args, $cwd, $env, $timeout, $configured_env );
 		}
 
 		/**
@@ -257,7 +345,7 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 		 * @param array<string, string>|null $env  Environment map.
 		 * @return array<string, mixed>|WP_Error
 		 */
-		private static function dispatch_detached( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env ) {
+		private static function dispatch_detached( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env, array $configured_env ) {
 			// Capture stderr so an early-exiting child can report WHY it died.
 			// proc_close() below waits for the child either way (it always has —
 			// "detached" here means new session, not fire-and-forget), so the
@@ -312,21 +400,20 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 			$duration_ms = (int) round( ( microtime( true ) - $started_at ) * 1000 );
 
 			if ( null !== $exit_code && 0 !== $exit_code ) {
+				$stderr = self::sanitize_output( $stderr, $configured_env );
 				return new WP_Error(
 					'wp_coding_agents_cli_dispatch_exit_nonzero',
 					sprintf(
-						'CLI dispatch process "%s" exited with code %d after %dms.%s',
-						$argv[0] ?? '',
+						'CLI dispatch process exited with code %d after %dms.',
 						$exit_code,
-						$duration_ms,
-						'' !== $stderr ? ' stderr: ' . self::truncate_output( $stderr ) : ''
+						$duration_ms
 					),
 					array(
 						'channel'     => $channel,
 						'recipient'   => $recipient,
 						'exit_code'   => $exit_code,
 						'duration_ms' => $duration_ms,
-						'stderr'      => self::truncate_output( $stderr ),
+						'stderr'      => $stderr,
 					)
 				);
 			}
@@ -350,7 +437,7 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 		 * @param array<string, string>|null $env  Environment map.
 		 * @return array<string, mixed>|WP_Error
 		 */
-		private static function dispatch_sync( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env, int $timeout ) {
+		private static function dispatch_sync( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env, int $timeout, array $configured_env ) {
 			$descriptors = array(
 				0 => array( 'pipe', 'r' ),
 				1 => array( 'pipe', 'w' ),
@@ -429,13 +516,15 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 
 			$exit_code   = proc_close( $process );
 			$duration_ms = (int) round( ( microtime( true ) - $started_at ) * 1000 );
+			$stdout      = self::sanitize_output( $stdout, $configured_env );
+			$stderr      = self::sanitize_output( $stderr, $configured_env );
 
 			if ( $timed_out ) {
-				return new WP_Error( 'wp_coding_agents_cli_dispatch_timeout', sprintf( 'CLI channel "%s" exceeded the %d second timeout.', $channel, $timeout ), array( 'channel' => $channel, 'recipient' => $recipient, 'stdout' => self::truncate_output( $stdout ), 'stderr' => self::truncate_output( $stderr ), 'duration_ms' => $duration_ms ) );
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_timeout', sprintf( 'CLI channel "%s" exceeded the %d second timeout.', $channel, $timeout ), array( 'channel' => $channel, 'recipient' => $recipient, 'stdout' => $stdout, 'stderr' => $stderr, 'duration_ms' => $duration_ms ) );
 			}
 
 			if ( 0 !== $exit_code ) {
-				return new WP_Error( 'wp_coding_agents_cli_dispatch_nonzero_exit', sprintf( 'CLI channel "%s" exited with code %d.', $channel, $exit_code ), array( 'channel' => $channel, 'recipient' => $recipient, 'exit_code' => $exit_code, 'stdout' => self::truncate_output( $stdout ), 'stderr' => self::truncate_output( $stderr ), 'duration_ms' => $duration_ms ) );
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_nonzero_exit', sprintf( 'CLI channel "%s" exited with code %d.', $channel, $exit_code ), array( 'channel' => $channel, 'recipient' => $recipient, 'exit_code' => $exit_code, 'stdout' => $stdout, 'stderr' => $stderr, 'duration_ms' => $duration_ms ) );
 			}
 
 			return array(
@@ -447,8 +536,6 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 					'mode'        => 'sync',
 					'exit_code'   => $exit_code,
 					'duration_ms' => $duration_ms,
-					'stdout'      => self::truncate_output( $stdout ),
-					'stderr'      => self::truncate_output( $stderr ),
 				),
 			);
 		}
@@ -472,7 +559,7 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 
 			$process = @proc_open( $argv, $descriptors, $pipes, $cwd, $env, $options );
 			if ( ! is_resource( $process ) ) {
-				return new WP_Error( 'wp_coding_agents_cli_dispatch_spawn_failed', sprintf( 'Failed to spawn CLI process "%s".', $argv[0] ?? '' ) );
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_spawn_failed', 'Failed to spawn CLI process.' );
 			}
 
 			return $process;
@@ -567,6 +654,11 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 			}
 
 			return substr( $output, 0, $limit ) . "\n[...truncated]";
+		}
+
+		/** @param array<string, string> $configured_env Channel-configured environment. */
+		private static function sanitize_output( string $output, array $configured_env ): string {
+			return self::truncate_output( WpCodingAgents_Cli_Output_Redactor::redact( $output, $configured_env ) );
 		}
 	}
 }

--- a/tests/smoke-cli-transport.php
+++ b/tests/smoke-cli-transport.php
@@ -89,11 +89,11 @@ $find_stub = static function ( array $candidates ): ?string {
 };
 
 $echo_bin  = $find_stub( array( '/bin/echo', '/usr/bin/echo' ) );
-$env_bin   = $find_stub( array( '/usr/bin/env', '/bin/env' ) );
 $true_bin  = $find_stub( array( '/bin/true', '/usr/bin/true' ) );
 $false_bin = $find_stub( array( '/bin/false', '/usr/bin/false' ) );
 $sleep_bin = $find_stub( array( '/bin/sleep', '/usr/bin/sleep' ) );
-foreach ( array( 'echo' => $echo_bin, 'env' => $env_bin, 'true' => $true_bin, 'false' => $false_bin, 'sleep' => $sleep_bin ) as $name => $path ) {
+$php_bin   = is_executable( PHP_BINARY ) ? PHP_BINARY : null;
+foreach ( array( 'echo' => $echo_bin, 'true' => $true_bin, 'false' => $false_bin, 'sleep' => $sleep_bin, 'php' => $php_bin ) as $name => $path ) {
 	if ( null === $path ) {
 		echo "  [SKIP] stub binary {$name} not present\n";
 		exit( 0 );
@@ -175,6 +175,36 @@ $substituted = WpCodingAgents_Cli_Channel_Registry::substitute_tokens(
 $assert( 'message token substituted verbatim', 'hello $(rm -rf /)' === $substituted[3] );
 $assert( 'conversation token substituted', 'conv-abc' === $substituted[5] );
 
+$redaction_fixture = implode(
+	"\n",
+	array(
+		'Authorization: Bearer bearer-secret-123456',
+		'Proxy-Authorization: Basic dXNlcjpwYXNzd29yZA==',
+		'Cookie: session=cookie-secret',
+		'OPENAI_API_KEY=assignment-secret',
+		'"refresh_token": "json-secret"',
+		'Authorization=Bearer assignment-bearer-secret',
+		'https://user:password@example.com/callback?access_token=query-secret&state=public',
+		'safe multiline detail',
+	)
+);
+$redacted_fixture = WpCodingAgents_Cli_Output_Redactor::redact( $redaction_fixture );
+$assert( 'bearer authorization is redacted', ! str_contains( $redacted_fixture, 'bearer-secret-123456' ) && ! str_contains( $redacted_fixture, 'assignment-bearer-secret' ) );
+$assert( 'basic authorization is redacted', ! str_contains( $redacted_fixture, 'dXNlcjpwYXNzd29yZA==' ) );
+$assert( 'cookie header is redacted', ! str_contains( $redacted_fixture, 'cookie-secret' ) );
+$assert( 'secret assignments are redacted', ! str_contains( $redacted_fixture, 'assignment-secret' ) && ! str_contains( $redacted_fixture, 'json-secret' ) );
+$assert( 'URL credentials are redacted', ! str_contains( $redacted_fixture, 'user:password' ) );
+$assert( 'URL query secrets are redacted', ! str_contains( $redacted_fixture, 'query-secret' ) );
+$assert( 'multiline safe detail is preserved', str_contains( $redacted_fixture, "\nsafe multiline detail" ) );
+
+$known_env_secret = '/private/configured/path/known-secret';
+$known_redacted   = WpCodingAgents_Cli_Output_Redactor::redact( 'diagnostic: ' . $known_env_secret, array( 'OPAQUE_VALUE' => $known_env_secret ) );
+$assert( 'configured environment values are redacted', ! str_contains( $known_redacted, $known_env_secret ) && str_contains( $known_redacted, '[redacted]' ) );
+
+$safe_fixture  = 'token count: 5; secret sauce; Basic skills; https://example.com/?page=1&state=public';
+$safe_redacted = WpCodingAgents_Cli_Output_Redactor::redact( $safe_fixture );
+$assert( 'non-secret prose resists false positives', $safe_fixture === $safe_redacted );
+
 $wp_coding_agents_test_options = array(
 	'wp_coding_agents_cli_channels' => array(
 		'sync-echo'     => array(
@@ -201,6 +231,12 @@ $wp_coding_agents_test_options = array(
 			'detach'  => false,
 			'timeout' => 1,
 		),
+		'timeout-secret' => array(
+			'command' => $php_bin,
+			'args'    => array( '-r', 'fwrite(STDERR, "refresh_token=timeout-secret\\n"); sleep(5);' ),
+			'detach'  => false,
+			'timeout' => 1,
+		),
 		'detached-true' => array(
 			'command' => $true_bin,
 			'args'    => array(),
@@ -211,15 +247,41 @@ $wp_coding_agents_test_options = array(
 			'args'    => array(),
 			'detach'  => true,
 		),
+		'detached-secret' => array(
+			'command' => $php_bin,
+			'args'    => array( '-r', 'fwrite(STDERR, "Authorization: Bearer detached-secret-token\\n"); exit(7);' ),
+			'detach'  => true,
+		),
+		'diagnostics-fail' => array(
+			'command' => $php_bin,
+			'args'    => array( '-r', 'fwrite(STDOUT, "token=stdout-secret\\nsafe stdout\\n"); fwrite(STDERR, "Authorization: Basic stderr-secret\\nsafe stderr\\n"); exit(9);' ),
+			'detach'  => false,
+			'timeout' => 5,
+		),
+		'configured-secret-fail' => array(
+			'command' => $php_bin,
+			'args'    => array( '-r', 'fwrite(STDERR, "opaque=" . getenv("OPAQUE_VALUE")); exit(9);' ),
+			'detach'  => false,
+			'timeout' => 5,
+			'env'     => array(
+				'OPAQUE_VALUE' => $known_env_secret,
+			),
+		),
+		'truncation-order-fail' => array(
+			'command' => $php_bin,
+			'args'    => array( '-r', 'fwrite(STDERR, str_repeat("x", 8170) . " token=" . str_repeat("z", 100)); exit(9);' ),
+			'detach'  => false,
+			'timeout' => 5,
+		),
 		'inherit-env'   => array(
-			'command' => $env_bin,
-			'args'    => array(),
+			'command' => $php_bin,
+			'args'    => array( '-r', 'exit("parent-ok" === getenv("WP_CODING_AGENTS_PARENT_ENV") ? 0 : 11);' ),
 			'detach'  => false,
 			'timeout' => 5,
 		),
 		'configured-env' => array(
-			'command' => $env_bin,
-			'args'    => array(),
+			'command' => $php_bin,
+			'args'    => array( '-r', 'exit("parent-ok" === getenv("WP_CODING_AGENTS_PARENT_ENV") && "configured-ok" === getenv("WP_CODING_AGENTS_CONFIGURED_ENV") ? 0 : 11);' ),
 			'detach'  => false,
 			'timeout' => 5,
 			'env'     => array(
@@ -229,15 +291,15 @@ $wp_coding_agents_test_options = array(
 		// #228: a channel with no configured HOME must not have a poisoned
 		// (unwritable) inherited HOME leak through to the child.
 		'guard-home'    => array(
-			'command' => $env_bin,
-			'args'    => array(),
+			'command' => $php_bin,
+			'args'    => array( '-r', 'exit(false === getenv("HOME") && "parent-ok" === getenv("WP_CODING_AGENTS_PARENT_ENV") ? 0 : 11);' ),
 			'detach'  => false,
 			'timeout' => 5,
 		),
 		// #228: a channel that pins a writable HOME keeps it verbatim.
 		'pinned-home'   => array(
-			'command' => $env_bin,
-			'args'    => array(),
+			'command' => $php_bin,
+			'args'    => array( '-r', 'exit(getenv("HOME") === sys_get_temp_dir() ? 0 : 11);' ),
 			'detach'  => false,
 			'timeout' => 5,
 			'env'     => array(
@@ -262,7 +324,7 @@ $ok = WpCodingAgents_Cli_Channel_Transport::execute(
 );
 $assert( 'sync success returns array', is_array( $ok ) && ! ( $ok instanceof WP_Error ) );
 if ( is_array( $ok ) ) {
-	$assert( 'sync success captures stdout', isset( $ok['metadata']['stdout'] ) && 'user-1:hi-there' === trim( (string) $ok['metadata']['stdout'] ) );
+	$assert( 'sync success omits child output', ! isset( $ok['metadata']['stdout'] ) && ! isset( $ok['metadata']['stderr'] ) );
 }
 
 $assert( 'sync true succeeds', is_array( WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-true', 'recipient' => 'r', 'message' => 'm' ) ) ) );
@@ -270,6 +332,9 @@ $fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync
 $assert( 'nonzero exit returns WP_Error', $fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_nonzero_exit' === $fail->get_error_code() );
 $timed = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-sleep', 'recipient' => 'r', 'message' => 'm' ) );
 $assert( 'timeout returns WP_Error', $timed instanceof WP_Error && 'wp_coding_agents_cli_dispatch_timeout' === $timed->get_error_code() );
+$timed_secret = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'timeout-secret', 'recipient' => 'r', 'message' => 'm' ) );
+$timed_data   = $timed_secret instanceof WP_Error ? (array) $timed_secret->get_error_data() : array();
+$assert( 'timeout structured stderr is redacted', isset( $timed_data['stderr'] ) && ! str_contains( (string) $timed_data['stderr'], 'timeout-secret' ) && str_contains( (string) $timed_data['stderr'], '[redacted]' ) );
 $unknown = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'unknown', 'recipient' => 'r', 'message' => 'm' ) );
 $assert( 'execute unknown returns WP_Error', $unknown instanceof WP_Error );
 
@@ -281,14 +346,30 @@ $assert( 'detached returns array', is_array( $detached ) && true === ( $detached
 $detached_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-false', 'recipient' => 'r', 'message' => 'm' ) );
 $assert( 'detached early exit returns WP_Error', $detached_fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_exit_nonzero' === $detached_fail->get_error_code() );
 
+$detached_secret = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-secret', 'recipient' => 'r', 'message' => 'm' ) );
+$detached_data   = $detached_secret instanceof WP_Error ? (array) $detached_secret->get_error_data() : array();
+$assert( 'detached error message omits child output', $detached_secret instanceof WP_Error && ! str_contains( $detached_secret->get_error_message(), 'detached-secret-token' ) );
+$assert( 'detached structured stderr is redacted', isset( $detached_data['stderr'] ) && ! str_contains( (string) $detached_data['stderr'], 'detached-secret-token' ) && str_contains( (string) $detached_data['stderr'], '[redacted]' ) );
+
+$diagnostic_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'diagnostics-fail', 'recipient' => 'r', 'message' => 'm' ) );
+$diagnostic_data = $diagnostic_fail instanceof WP_Error ? (array) $diagnostic_fail->get_error_data() : array();
+$assert( 'sync structured stdout is redacted', isset( $diagnostic_data['stdout'] ) && ! str_contains( (string) $diagnostic_data['stdout'], 'stdout-secret' ) && str_contains( (string) $diagnostic_data['stdout'], 'safe stdout' ) );
+$assert( 'sync structured stderr is redacted', isset( $diagnostic_data['stderr'] ) && ! str_contains( (string) $diagnostic_data['stderr'], 'stderr-secret' ) && str_contains( (string) $diagnostic_data['stderr'], 'safe stderr' ) );
+
+$configured_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'configured-secret-fail', 'recipient' => 'r', 'message' => 'm' ) );
+$configured_data = $configured_fail instanceof WP_Error ? (array) $configured_fail->get_error_data() : array();
+$assert( 'configured value is redacted at error boundary', isset( $configured_data['stderr'] ) && ! str_contains( (string) $configured_data['stderr'], $known_env_secret ) );
+
+$truncation_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'truncation-order-fail', 'recipient' => 'r', 'message' => 'm' ) );
+$truncation_data = $truncation_fail instanceof WP_Error ? (array) $truncation_fail->get_error_data() : array();
+$assert( 'redaction occurs before truncation', isset( $truncation_data['stderr'] ) && ! str_contains( (string) $truncation_data['stderr'], str_repeat( 'z', 20 ) ) && ! str_contains( (string) $truncation_data['stderr'], '[...truncated]' ) );
+
 putenv( 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' );
 $inherited = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'inherit-env', 'recipient' => 'r', 'message' => 'm' ) );
-$assert( 'empty channel env inherits parent env', is_array( $inherited ) && str_contains( (string) ( $inherited['metadata']['stdout'] ?? '' ), 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' ) );
+$assert( 'empty channel env inherits parent env', is_array( $inherited ) );
 
 $configured = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'configured-env', 'recipient' => 'r', 'message' => 'm' ) );
-$configured_stdout = is_array( $configured ) ? (string) ( $configured['metadata']['stdout'] ?? '' ) : '';
-$assert( 'configured channel env keeps parent env', str_contains( $configured_stdout, 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' ) );
-$assert( 'configured channel env adds configured env', str_contains( $configured_stdout, 'WP_CODING_AGENTS_CONFIGURED_ENV=configured-ok' ) );
+$assert( 'configured channel env keeps parent and adds configured env', is_array( $configured ) );
 
 // #228 regression: when the caller's HOME is unwritable (PHP-FPM/WP-cron as
 // www-data with HOME=/var/www) and the channel does not pin HOME, the
@@ -299,15 +380,12 @@ $prev_home     = getenv( 'HOME' );
 // A non-existent directory is, by definition, not a writable HOME.
 putenv( 'HOME=' . $poisoned_home );
 $guarded = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'guard-home', 'recipient' => 'r', 'message' => 'm' ) );
-$guarded_stdout = is_array( $guarded ) ? (string) ( $guarded['metadata']['stdout'] ?? '' ) : '';
-$assert( 'unwritable inherited HOME is not leaked', ! str_contains( $guarded_stdout, 'HOME=' . $poisoned_home ) );
-$assert( 'guarded channel still inherits other parent env', str_contains( $guarded_stdout, 'WP_CODING_AGENTS_PARENT_ENV=parent-ok' ) );
+$assert( 'unwritable HOME is dropped while other parent env is inherited', is_array( $guarded ) );
 
 // #228: a channel that pins a writable HOME keeps it even when the inherited
 // HOME is poisoned — this is the kimaki installer's fix path.
 $pinned = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'pinned-home', 'recipient' => 'r', 'message' => 'm' ) );
-$pinned_stdout = is_array( $pinned ) ? (string) ( $pinned['metadata']['stdout'] ?? '' ) : '';
-$assert( 'pinned writable HOME wins over poisoned inherited HOME', str_contains( $pinned_stdout, 'HOME=' . sys_get_temp_dir() ) );
+$assert( 'pinned writable HOME wins over poisoned inherited HOME', is_array( $pinned ) );
 // Restore HOME so any later code/tests see the original value.
 if ( false === $prev_home ) {
 	putenv( 'HOME' );


### PR DESCRIPTION
## Summary
- redact generic credentials, authorization/cookie headers, credentialed URLs, secret query parameters, and known environment values before bounding child-process diagnostics
- remove stdout/stderr from successful synchronous metadata and keep failure details in bounded, redacted `WP_Error` data instead of error messages
- cover sync, timeout, and detached boundaries plus multiline output, truncation order, configured values, and false-positive resistance

## Validation
- `php tests/smoke-cli-transport.php`
- `bash tests/cli-transport-install.sh`
- PHP syntax checks for the transport template and smoke test
- `bash -n` across all repository shell scripts
- `git diff --check`
- full `tests/*.sh` suite run; it exposed an unrelated existing late-assertion failure-gate defect tracked in #344

Closes #341