### PR TITLE
feat: reconcile the owned source set continuously, not at upgrade time

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -221,6 +221,7 @@ jobs:
           - kimaki-system-message-patch
           - opencode-claude-auth-refresh-hardening
           - owned-source-discovery
+          - source-reconcile
           - path-helpers
           - post-upgrade-restore
           - runtime-signature

--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ owned = installed  −  known to wp.org  −  installed by wp-coding-agents
 A plugin the agent creates is therefore editable and captured with no operator
 step and no self-declaration. `--owned-source` still overrides when supplied.
 
+Derivation is **continuous**, not upgrade-time. An mu-plugin listens to
+WordPress's own plugin and theme lifecycle hooks and reconciles the owned set,
+the capture manifest, and the runtime edit permissions as the installed set
+changes — plus an hourly sweep, because a plugin the agent *scaffolds* fires no
+lifecycle hook at all. An inventory fingerprint makes the usual call a single
+option read.
+
+The derivation lives in PHP because that is the only place a WordPress hook can
+reach it; the installer delegates to the same code rather than keeping a second
+copy that could drift.
+
 **It cannot widen on missing evidence.** The wp.org signal is a transient; on a
 fresh install, after a cache flush, or when wp.org is unreachable it is absent,
 and treating absence as "nothing belongs to wp.org" would classify every plugin

--- a/lib/source-reconcile.sh
+++ b/lib/source-reconcile.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# lib/source-reconcile.sh — install the continuous owned-source reconciler.
+#
+# Derivation used to run only during upgrade.sh, which is enough for a plugin
+# that already exists and useless for one the agent is about to write: it creates
+# the directory and nothing recomputes anything until somebody SSHes in. "Build
+# me a booking plugin" then ends in a support ticket, which is what managed
+# hosting exists to remove.
+#
+# The mu-plugin this installs listens to WordPress's own plugin and theme
+# lifecycle hooks and reconciles the owned set, the capture manifest, and the
+# runtime edit permissions as the installed set changes.
+#
+# WHY THE DERIVATION MOVED INTO PHP
+#
+# It began in lib/owned-source-discovery.sh. Keeping it there and adding a PHP
+# copy for the reactive path would be two implementations of the same safety
+# rule, free to drift — the exact failure #336 and #337 removed from the capture
+# path. PHP wins the tie because it is the only one of the two that can run from
+# a WordPress hook, so the shell now DELEGATES to it and there is one answer.
+#
+# Public surface:
+#   source_reconcile_mu_plugin_path
+#   source_reconcile_sync              # install / remove the mu-plugin
+#   source_reconcile_prepare_manifest_dir
+#   source_reconcile_run               # invoke a reconcile now, via WP-CLI
+
+source_reconcile_mu_plugin_path() {
+  [ -n "${SITE_PATH:-}" ] || return 1
+  printf '%s' "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-source-reconcile.php"
+}
+
+# The manifest lives outside the web root and is written by PHP, which runs as
+# www-data. Setup creates it root-owned, so the reactive path silently could not
+# write it — the reconcile would update the option and leave capture reading a
+# stale file, which is precisely the drift the manifest exists to prevent.
+source_reconcile_prepare_manifest_dir() {
+  local key dir
+  key="${SITE_DOMAIN:-}"
+  [ -n "$key" ] || key="$(basename "${SITE_PATH:-}" 2>/dev/null)"
+  [ -n "$key" ] || return 0
+  dir="${SOURCE_POLICY_MANIFEST_ROOT:-/var/lib/wp-coding-agents}/$key"
+
+  [ "${LOCAL_MODE:-false}" = true ] && return 0
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would make $dir writable by www-data"
+    return 0
+  fi
+
+  mkdir -p "$dir" 2>/dev/null || return 0
+  # Group-owned by www-data with group write: PHP writes the manifest, and the
+  # read-only capture identity still reads it. Not world-writable, and outside
+  # the docroot so it is not web-servable either.
+  chown root:www-data "$dir" 2>/dev/null || true
+  chmod 2775 "$dir" 2>/dev/null || true
+}
+
+source_reconcile_sync() {
+  local file
+  file="$(source_reconcile_mu_plugin_path)" || {
+    warn "  source_reconcile_sync: SITE_PATH not set — skipping"
+    return 1
+  }
+
+  # Workspace installs derive nothing: their editable set is empty by design and
+  # their changes reach git through a workspace, not a harvest. Remove anything
+  # a source-mode switch left behind.
+  if ! source_policy_is_owned; then
+    if [ -f "$file" ]; then
+      if [ "${DRY_RUN:-false}" = true ]; then
+        echo -e "${BLUE}[dry-run]${NC} Would remove source reconcile mu-plugin $file"
+        return 0
+      fi
+      rm -f "$file"
+      log "  Removed source reconcile mu-plugin (source mode is ${SOURCE_MODE:-workspace})"
+    fi
+    return 0
+  fi
+
+  local template="$SCRIPT_DIR/templates/wp-coding-agents-source-reconcile.php"
+  if [ ! -f "$template" ]; then
+    warn "  source_reconcile_sync: missing template $template"
+    return 1
+  fi
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would install source reconcile mu-plugin at $file"
+    return 0
+  fi
+
+  source_reconcile_prepare_manifest_dir
+
+  mkdir -p "${file%/*}"
+  if [ -f "$file" ] && cmp -s "$template" "$file"; then
+    service_file_normalize_perms "$file"
+    return 0
+  fi
+
+  cp "$template" "$file"
+  service_file_normalize_perms "$file"
+  log "  Installed source reconcile mu-plugin: $file"
+  if [ -n "${UPDATED_ITEMS+x}" ]; then
+    UPDATED_ITEMS+=("continuous source reconcile")
+  fi
+}
+
+# Run a reconcile now, so an upgrade converges the same way a live change does.
+#
+# Delegates rather than deriving: the mu-plugin is the single implementation, and
+# a second one here is the drift this design exists to avoid.
+source_reconcile_run() {
+  source_policy_is_owned || return 0
+  [ -n "${SITE_PATH:-}" ] || return 0
+  [ -f "$SITE_PATH/wp-config.php" ] || return 0
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would run an owned-source reconcile via WP-CLI"
+    return 0
+  fi
+
+  local out
+  # shellcheck disable=SC2086
+  out="$($WP_CMD eval 'if ( function_exists( "wp_coding_agents_reconcile_sources" ) ) { $r = wp_coding_agents_reconcile_sources( true ); echo $r["status"] . ( isset( $r["reason"] ) ? ": " . $r["reason"] : "" ); } else { echo "unavailable"; }' \
+    $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true)"
+
+  case "$out" in
+    reconciled*) log "  Owned sources reconciled from site state" ;;
+    unchanged*)  : ;;
+    deferred*)   warn "  Owned-source reconcile deferred (${out#deferred: }) — the recorded set stands" ;;
+    skipped*)    : ;;
+    *)           warn "  Owned-source reconcile did not run: ${out:-no response}" ;;
+  esac
+}

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect source-policy owned-source-discovery wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance; do
+for lib in common detect source-policy owned-source-discovery wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -530,6 +530,10 @@ runtime_merge_mcp_servers
 install_skills
 cli_transport_install
 runtime_guard_sync
+# Install the reconciler, then run it once so a fresh install converges the same
+# way a live change will.
+source_reconcile_sync
+source_reconcile_run
 install_chat_bridge
 datamachine_worker_install
 print_summary

--- a/templates/wp-coding-agents-source-reconcile.php
+++ b/templates/wp-coding-agents-source-reconcile.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * Plugin Name: wp-coding-agents — continuous owned-source reconcile
+ * Description: Keeps the agent's editable source set and the operator's capture
+ *              manifest in agreement with what is actually installed, as it
+ *              changes. Managed by wp-coding-agents setup/upgrade — do not edit
+ *              by hand.
+ *
+ * WHY THIS EXISTS
+ *
+ * Owned mode derives what the site owns rather than asking an operator to
+ * declare it (#336). That derivation ran only during `upgrade.sh`, which is
+ * enough for a plugin that already exists and useless for one the agent is
+ * about to write: it creates the directory, and nothing recomputes anything
+ * until somebody SSHes in and runs an upgrade. "Build me a booking plugin" then
+ * ends in a support ticket, which is the thing managed hosting exists to remove.
+ *
+ * So the derivation is reactive. WordPress already knows when the installed set
+ * changes — it fires hooks for it — and this listens.
+ *
+ * WHY THE DERIVATION LIVES HERE AND NOT IN THE INSTALLER
+ *
+ * It used to live in lib/owned-source-discovery.sh. Keeping it there and adding
+ * a PHP copy for the reactive path would be two implementations of the same
+ * safety rule, free to drift — the exact failure this project spent #336 and
+ * #337 removing from the capture path. PHP wins the tie because it is the only
+ * one of the two that can run from a WordPress hook. The installer calls this
+ * through WP-CLI, so there is one implementation and one answer.
+ *
+ * WHAT IT WILL NOT DO
+ *
+ * It never widens on missing evidence. The wp.org signal is a transient; on a
+ * fresh install, after a cache flush, or when wp.org is unreachable it is
+ * absent, and treating absence as "nothing belongs to wp.org" would classify
+ * every plugin as the site's — handing the agent write access to WooCommerce
+ * and any payment gateway. Ownership is inferred only from the PRESENCE of
+ * evidence. A signal that cannot be trusted produces no reconcile at all and
+ * the last recorded set stands.
+ *
+ * That asymmetry is the whole safety argument, and it is why this file does not
+ * simply invert the permission model. Allowing wp-content/plugins/** and
+ * denying each known third-party would make creation frictionless in one step,
+ * and would turn "can the agent edit the payment gateway" from a question about
+ * the allow list into a question about the deny list — where a stale or
+ * incomplete entry means yes.
+ *
+ * @package wp-coding-agents
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'WP_CODING_AGENTS_SOURCE_MODE_OPTION' ) ) {
+	define( 'WP_CODING_AGENTS_SOURCE_MODE_OPTION', 'wp_coding_agents_source_mode' );
+}
+if ( ! defined( 'WP_CODING_AGENTS_OWNED_OPTION' ) ) {
+	define( 'WP_CODING_AGENTS_OWNED_OPTION', 'wp_coding_agents_owned_sources' );
+}
+if ( ! defined( 'WP_CODING_AGENTS_NOT_OWNED_OPTION' ) ) {
+	define( 'WP_CODING_AGENTS_NOT_OWNED_OPTION', 'wp_coding_agents_not_owned' );
+}
+if ( ! defined( 'WP_CODING_AGENTS_INVENTORY_OPTION' ) ) {
+	define( 'WP_CODING_AGENTS_INVENTORY_OPTION', 'wp_coding_agents_inventory_hash' );
+}
+
+/**
+ * Plugin slugs wp-coding-agents installs and updates itself.
+ *
+ * Not the site's: the agent's own runtime, replaced wholesale by the next
+ * upgrade. Editing them in place loses the edit; capturing them would commit
+ * the installer's source into the site's repository.
+ *
+ * @return string[]
+ */
+function wp_coding_agents_carried_slugs() {
+	return apply_filters(
+		'wp_coding_agents_carried_slugs',
+		array( 'data-machine', 'data-machine-code', 'wp-codebox' )
+	);
+}
+
+/**
+ * How stale the wp.org signal may be before it stops counting as evidence.
+ *
+ * WordPress refreshes update transients roughly twice daily. Two days tolerates
+ * a quiet site or a brief wp.org outage without tolerating a cleared cache.
+ *
+ * @return int Seconds.
+ */
+function wp_coding_agents_max_signal_age() {
+	return (int) apply_filters( 'wp_coding_agents_max_signal_age', 2 * DAY_IN_SECONDS );
+}
+
+/**
+ * Slugs wp.org knows about, across plugins and themes.
+ *
+ * Returns null when the signal is missing, empty, or stale — deliberately
+ * distinct from an empty array, which would mean "wp.org genuinely knows of
+ * nothing installed here" and is never a conclusion this should reach.
+ *
+ * @return string[]|null
+ */
+function wp_coding_agents_wporg_slugs() {
+	$plugins = get_site_transient( 'update_plugins' );
+	if ( ! $plugins || empty( $plugins->last_checked ) ) {
+		return null;
+	}
+
+	$files = array_merge(
+		array_keys( (array) ( $plugins->response ?? array() ) ),
+		array_keys( (array) ( $plugins->no_update ?? array() ) )
+	);
+	// A transient listing no plugins is not evidence that none are known to
+	// wp.org; it is evidence the check has not really run.
+	if ( ! $files ) {
+		return null;
+	}
+	if ( ( time() - (int) $plugins->last_checked ) > wp_coding_agents_max_signal_age() ) {
+		return null;
+	}
+
+	$slugs = array();
+	foreach ( $files as $file ) {
+		$slugs[] = false !== strpos( $file, '/' )
+			? substr( $file, 0, strpos( $file, '/' ) )
+			: basename( $file, '.php' );
+	}
+
+	// Themes are a SEPARATE transient with its own freshness, and it has to be
+	// gated independently. A fresh plugin signal alongside a missing theme
+	// signal would leave every bundled theme unrecognised — so twentytwentyfive
+	// would derive as the site's, become editable, and get captured. Same
+	// fail-open danger as the plugin case, reached by a different door, and the
+	// only reason it is not shipped is that a test asserted the bundled theme
+	// was excluded rather than assuming it.
+	$themes = get_site_transient( 'update_themes' );
+	if ( ! $themes || empty( $themes->last_checked ) ) {
+		return null;
+	}
+	$theme_slugs = array_merge(
+		array_keys( (array) ( $themes->response ?? array() ) ),
+		array_keys( (array) ( $themes->no_update ?? array() ) )
+	);
+	if ( ! $theme_slugs ) {
+		return null;
+	}
+	if ( ( time() - (int) $themes->last_checked ) > wp_coding_agents_max_signal_age() ) {
+		return null;
+	}
+	foreach ( $theme_slugs as $slug ) {
+		$slugs[] = $slug;
+	}
+
+	return array_values( array_unique( $slugs ) );
+}
+
+/**
+ * Derive the owned set as wp-content-relative paths.
+ *
+ * @return string[]|null Null when the wp.org signal cannot be trusted.
+ */
+function wp_coding_agents_derive_owned_sources() {
+	$wporg = wp_coding_agents_wporg_slugs();
+	if ( null === $wporg ) {
+		return null;
+	}
+
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$excluded = wp_coding_agents_not_owned_slugs();
+	$skip     = array_merge( $wporg, wp_coding_agents_carried_slugs(), $excluded );
+
+	$owned = array();
+
+	foreach ( array_keys( get_plugins() ) as $file ) {
+		$slug = false !== strpos( $file, '/' )
+			? substr( $file, 0, strpos( $file, '/' ) )
+			: basename( $file, '.php' );
+		// A single-file plugin has no directory of its own to own; capturing it
+		// would mean capturing all of wp-content/plugins.
+		if ( false === strpos( $file, '/' ) ) {
+			continue;
+		}
+		if ( in_array( $slug, $skip, true ) ) {
+			continue;
+		}
+		$owned[] = 'wp-content/plugins/' . $slug;
+	}
+
+	foreach ( array_keys( wp_get_themes() ) as $slug ) {
+		if ( in_array( $slug, $skip, true ) ) {
+			continue;
+		}
+		$owned[] = 'wp-content/themes/' . $slug;
+	}
+
+	sort( $owned );
+	return $owned;
+}
+
+/**
+ * Operator-declared slugs that are NOT the site's despite deriving as owned.
+ *
+ * @return string[]
+ */
+function wp_coding_agents_not_owned_slugs() {
+	$raw = (string) get_option( WP_CODING_AGENTS_NOT_OWNED_OPTION, '' );
+	$out = array();
+	foreach ( preg_split( '/\s+/', $raw ) as $slug ) {
+		$slug = trim( $slug );
+		if ( '' !== $slug ) {
+			$out[] = $slug;
+		}
+	}
+	return $out;
+}
+
+/**
+ * A cheap fingerprint of the installed set.
+ *
+ * Lets a reconcile be skipped when nothing relevant changed, so this can be
+ * called from a frequently-firing hook without doing real work each time.
+ *
+ * @return string
+ */
+function wp_coding_agents_inventory_hash() {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	$parts = array_merge( array_keys( get_plugins() ), array_keys( wp_get_themes() ) );
+	sort( $parts );
+	return md5( implode( '|', $parts ) . '|' . implode( '|', wp_coding_agents_not_owned_slugs() ) );
+}
+
+/**
+ * Reconcile the owned set, the capture manifest, and the runtime permissions.
+ *
+ * @param bool $force Reconcile even when the installed set looks unchanged.
+ * @return array{status:string,owned?:string[],reason?:string}
+ */
+function wp_coding_agents_reconcile_sources( $force = false ) {
+	if ( 'owned' !== get_option( WP_CODING_AGENTS_SOURCE_MODE_OPTION, '' ) ) {
+		return array( 'status' => 'skipped', 'reason' => 'not owned mode' );
+	}
+
+	$hash = wp_coding_agents_inventory_hash();
+	if ( ! $force && $hash === get_option( WP_CODING_AGENTS_INVENTORY_OPTION, '' ) ) {
+		return array( 'status' => 'unchanged' );
+	}
+
+	$owned = wp_coding_agents_derive_owned_sources();
+	if ( null === $owned ) {
+		// Never widen on missing evidence. The recorded set stands.
+		return array( 'status' => 'deferred', 'reason' => 'wp.org signal missing or stale' );
+	}
+	if ( ! $owned ) {
+		// Fail closed: a site that owns nothing gets no editable source, rather
+		// than falling back to opening wp-content wholesale.
+		return array( 'status' => 'deferred', 'reason' => 'derived an empty owned set' );
+	}
+
+	update_option( WP_CODING_AGENTS_OWNED_OPTION, implode( "\n", $owned ), false );
+	update_option( WP_CODING_AGENTS_INVENTORY_OPTION, $hash, false );
+
+	wp_coding_agents_write_manifest( $owned );
+	wp_coding_agents_write_edit_permissions( $owned );
+
+	/**
+	 * Fires after the owned set has been reconciled.
+	 *
+	 * @param string[] $owned wp-content-relative paths.
+	 */
+	do_action( 'wp_coding_agents_sources_reconciled', $owned );
+
+	return array( 'status' => 'reconciled', 'owned' => $owned );
+}
+
+/**
+ * Project the owned set to the file out-of-band capture reads.
+ *
+ * Capture runs as a deliberately read-only identity that cannot read
+ * wp-config.php, so it can never run WP-CLI and never reach this database.
+ * Deliberately outside the site root: SITE_PATH is the web root, and a file
+ * written there is fetchable over HTTP.
+ *
+ * @param string[] $owned
+ * @return bool
+ */
+function wp_coding_agents_write_manifest( array $owned ) {
+	$dir = '/var/lib/wp-coding-agents/' . wp_coding_agents_site_key();
+	if ( ! is_dir( $dir ) || ! is_writable( $dir ) ) {
+		return false;
+	}
+	$path = $dir . '/owned-sources';
+	$tmp  = $path . '.tmp';
+	if ( false === file_put_contents( $tmp, implode( "\n", $owned ) . "\n" ) ) {
+		return false;
+	}
+	@chmod( $tmp, 0644 );
+	return rename( $tmp, $path );
+}
+
+/**
+ * The manifest is keyed by site so one host can serve several.
+ *
+ * @return string
+ */
+function wp_coding_agents_site_key() {
+	$host = wp_parse_url( home_url(), PHP_URL_HOST );
+	return $host ? $host : 'default';
+}
+
+/**
+ * Rewrite permission.edit so the agent may edit exactly what it owns.
+ *
+ * KEY ORDER IS THE PRECEDENCE MECHANISM. OpenCode evaluates with findLast over
+ * a ruleset built in JSON key order, so the broad denies have to be written
+ * before the allows that carve exceptions out of them. Emitting the allows
+ * first silently inverts the policy.
+ *
+ * @param string[] $owned
+ * @return bool
+ */
+function wp_coding_agents_write_edit_permissions( array $owned ) {
+	$file = trailingslashit( ABSPATH ) . 'opencode.json';
+	if ( ! is_readable( $file ) || ! is_writable( $file ) ) {
+		return false;
+	}
+	$data = json_decode( (string) file_get_contents( $file ), true );
+	if ( ! is_array( $data ) || ! isset( $data['permission']['edit'] ) || ! is_array( $data['permission']['edit'] ) ) {
+		return false;
+	}
+
+	$managed = array();
+	foreach ( $data['permission']['edit'] as $pattern => $action ) {
+		// Drop stale owned-source allows this install no longer declares, so a
+		// component that stops being owned stops being editable.
+		$is_stale_allow = 'allow' === $action
+			&& ( 0 === strpos( $pattern, 'wp-content/plugins/' ) || 0 === strpos( $pattern, 'wp-content/themes/' ) )
+			&& '/**' === substr( $pattern, -3 );
+		if ( $is_stale_allow ) {
+			continue;
+		}
+		$managed[ $pattern ] = $action;
+	}
+
+	foreach ( $owned as $path ) {
+		$managed[ $path . '/**' ] = 'allow';
+	}
+
+	if ( $managed === $data['permission']['edit'] ) {
+		return true;
+	}
+
+	$data['permission']['edit'] = $managed;
+	$encoded                    = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	if ( false === $encoded ) {
+		return false;
+	}
+	$tmp = $file . '.tmp';
+	if ( false === file_put_contents( $tmp, $encoded . "\n" ) ) {
+		return false;
+	}
+	return rename( $tmp, $file );
+}
+
+// ---------------------------------------------------------------------------
+// Triggers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconcile after anything that can change the installed set.
+ *
+ * The inventory hash makes a no-op call cheap, so these can be broad.
+ */
+foreach ( array( 'activated_plugin', 'deactivated_plugin', 'deleted_plugin', 'switch_theme', 'deleted_theme', 'upgrader_process_complete' ) as $wp_coding_agents_hook ) {
+	add_action( $wp_coding_agents_hook, 'wp_coding_agents_reconcile_on_change', 20 );
+}
+unset( $wp_coding_agents_hook );
+
+/**
+ * Hook target that ignores its arguments.
+ *
+ * @return void
+ */
+function wp_coding_agents_reconcile_on_change() {
+	wp_coding_agents_reconcile_sources();
+}
+
+/**
+ * A plugin the agent SCAFFOLDS fires none of the hooks above — no install, no
+ * activation, just a directory appearing. That is the case this whole file
+ * exists for, so the inventory is also checked on the site's regular heartbeat.
+ * The hash comparison makes the usual outcome a single option read.
+ */
+add_action( 'wp_coding_agents_reconcile_cron', 'wp_coding_agents_reconcile_on_change' );
+add_action(
+	'init',
+	function () {
+		if ( ! wp_next_scheduled( 'wp_coding_agents_reconcile_cron' ) ) {
+			wp_schedule_event( time() + 60, 'hourly', 'wp_coding_agents_reconcile_cron' );
+		}
+	}
+);

--- a/tests/source-reconcile.sh
+++ b/tests/source-reconcile.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# tests/source-reconcile.sh — continuous owned-source reconcile (#336).
+#
+# Derivation used to run only during upgrade.sh. That is enough for a plugin
+# that already exists and useless for one the agent is about to write: it creates
+# the directory, and nothing recomputes anything until somebody SSHes in. This
+# makes the derivation reactive, which means it now runs UNATTENDED on a live
+# site — so the properties that matter are the ones that hold when nobody is
+# looking.
+#
+# The safety argument is unchanged and load-bearing: ownership is inferred only
+# from the PRESENCE of evidence. The wp.org signal is a transient, and treating
+# its absence as "nothing belongs to wp.org" would classify every plugin as the
+# site's — granting the agent write access to WooCommerce and any payment
+# gateway. Running that logic on a schedule rather than at an operator's
+# keyboard raises the stakes rather than lowering them.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+FAILED=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [ "$got" = "$want" ]; then echo "  ok   $name"; else
+    echo "  FAIL $name"; echo "         got:  $got"; echo "         want: $want"
+    FAILED=$((FAILED + 1))
+  fi
+}
+assert_contains() {
+  case "$1" in *"$2"*) echo "  ok   $3" ;; *) echo "  FAIL $3 (missing: $2)"; FAILED=$((FAILED + 1)) ;; esac
+}
+refute_contains() {
+  case "$1" in *"$2"*) echo "  FAIL $3 (unexpectedly present: $2)"; FAILED=$((FAILED + 1)) ;; *) echo "  ok   $3" ;; esac
+}
+
+TEMPLATE="templates/wp-coding-agents-source-reconcile.php"
+
+echo "source-reconcile: the mu-plugin is valid PHP"
+if php -l "$TEMPLATE" >/dev/null 2>&1; then
+  echo "  ok   template parses"
+else
+  echo "  FAIL template does not parse"
+  php -l "$TEMPLATE" 2>&1 | sed 's/^/         /'
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+echo "source-reconcile: never widens on missing evidence"
+
+# A harness that loads the template's functions against stubbed WordPress state,
+# so the derivation can be exercised without a site.
+run_php() {
+  php -r "
+    define('ABSPATH', '$TMP/');
+    define('DAY_IN_SECONDS', 86400);
+    \$GLOBALS['opts'] = ${2:-array()};
+    \$GLOBALS['transient'] = ${3:-null};
+    \$GLOBALS['theme_transient'] = ${6:-\$GLOBALS['transient']};
+    \$GLOBALS['themes'] = ${4:-array()};
+    \$GLOBALS['plugins'] = ${5:-array()};
+    function add_action(...\$a) {}
+    function add_filter(...\$a) {}
+    function apply_filters(\$h, \$v) { return \$v; }
+    function do_action(...\$a) {}
+    function wp_next_scheduled(...\$a) { return true; }
+    function wp_schedule_event(...\$a) {}
+    function get_option(\$k, \$d = '') { return \$GLOBALS['opts'][\$k] ?? \$d; }
+    function update_option(\$k, \$v, \$a = null) { \$GLOBALS['opts'][\$k] = \$v; return true; }
+    function get_site_transient(\$k) { return \$k === 'update_plugins' ? \$GLOBALS['transient'] : (\$GLOBALS['theme_transient'] ?? null); }
+    function get_plugins() { return \$GLOBALS['plugins']; }
+    function wp_get_themes() { return \$GLOBALS['themes']; }
+    function wp_parse_url(\$u, \$c = -1) { return 'example.com'; }
+    function home_url() { return 'https://example.com'; }
+    function trailingslashit(\$s) { return rtrim(\$s, '/') . '/'; }
+    function wp_json_encode(\$d, \$f = 0) { return json_encode(\$d, \$f); }
+    require '$TEMPLATE';
+    $1
+  " 2>&1
+}
+
+FRESH="(object) array('last_checked' => time(), 'response' => array(), 'no_update' => array('woocommerce/woocommerce.php' => 1, 'akismet/akismet.php' => 1))"
+PLUGINS="array('woocommerce/woocommerce.php' => array(), 'akismet/akismet.php' => array(), 'data-machine/data-machine.php' => array(), 'h44-core/h44-core.php' => array(), 'hello.php' => array())"
+THEMES="array('h44-lacrosse-theme' => 1, 'twentytwentyfive' => 1)"
+# wp.org's THEME transient is separate from the plugin one and needs its own
+# fixture: reusing the plugin transient would leave every theme unrecognised.
+FRESH_THEMES="(object) array('last_checked' => time(), 'response' => array(), 'no_update' => array('twentytwentyfive' => 1))"
+
+OUT="$(run_php 'print_r(wp_coding_agents_derive_owned_sources());' "array()" "$FRESH" "$THEMES" "$PLUGINS" "$FRESH_THEMES")"
+assert_contains "$OUT" "wp-content/plugins/h44-core" "derives the site's own plugin"
+assert_contains "$OUT" "wp-content/themes/h44-lacrosse-theme" "derives the site's own theme"
+refute_contains "$OUT" "plugins/woocommerce" "excludes a wp.org plugin"
+refute_contains "$OUT" "plugins/akismet" "excludes another"
+refute_contains "$OUT" "plugins/data-machine" "excludes the agent's own runtime"
+refute_contains "$OUT" "themes/twentytwentyfive" "excludes a bundled theme"
+# A single-file plugin has no directory to own; capturing it would mean
+# capturing all of wp-content/plugins.
+refute_contains "$OUT" "hello" "ignores a single-file plugin"
+
+# Each of these is the same danger wearing a different costume.
+# A fresh plugin signal with a broken THEME signal must also defer: otherwise
+# every bundled theme looks unrecognised and derives as the site's.
+OUT="$(run_php 'var_dump(null === wp_coding_agents_derive_owned_sources());' "array()" "$FRESH" "$THEMES" "$PLUGINS" "null")"
+assert_contains "$OUT" "bool(true)" "refuses when only the THEME signal is broken"
+
+for label in missing stale empty; do
+  case "$label" in
+    missing) T="null" ;;
+    stale)   T="(object) array('last_checked' => time() - 999999, 'no_update' => array('woocommerce/woocommerce.php' => 1))" ;;
+    empty)   T="(object) array('last_checked' => time(), 'response' => array(), 'no_update' => array())" ;;
+  esac
+  OUT="$(run_php 'var_dump(null === wp_coding_agents_derive_owned_sources());' "array()" "$T" "$THEMES" "$PLUGINS")"
+  assert_contains "$OUT" "bool(true)" "refuses to derive from a $label signal"
+done
+
+# The catastrophe asserted directly rather than implied.
+OUT="$(run_php 'print_r(wp_coding_agents_derive_owned_sources());' "array()" "null" "$THEMES" "$PLUGINS")"
+refute_contains "$OUT" "woocommerce" "a missing signal cannot open WooCommerce"
+
+echo ""
+echo "source-reconcile: reconcile is gated and fails closed"
+
+# Workspace installs derive nothing.
+OUT="$(run_php 'print_r(wp_coding_agents_reconcile_sources(true));' "array('wp_coding_agents_source_mode' => 'workspace')" "$FRESH" "$THEMES" "$PLUGINS" "$FRESH_THEMES")"
+assert_contains "$OUT" "skipped" "does nothing outside owned mode"
+
+# An untrustworthy signal defers instead of writing a widened set.
+OUT="$(run_php 'print_r(wp_coding_agents_reconcile_sources(true));' "array('wp_coding_agents_source_mode' => 'owned')" "null" "$THEMES" "$PLUGINS")"
+assert_contains "$OUT" "deferred" "defers when the signal is untrustworthy"
+refute_contains "$OUT" "reconciled" "and does not report success"
+
+# A site that owns nothing gets no editable source, rather than a fallback that
+# opens wp-content wholesale.
+EMPTY_PLUGINS="array('woocommerce/woocommerce.php' => array())"
+OUT="$(run_php 'print_r(wp_coding_agents_reconcile_sources(true));' "array('wp_coding_agents_source_mode' => 'owned')" "$FRESH" "array()" "$EMPTY_PLUGINS" "$FRESH_THEMES")"
+assert_contains "$OUT" "deferred" "an empty derived set defers rather than writing one"
+
+# The operator exclusion still applies on the reactive path.
+OUT="$(run_php 'print_r(wp_coding_agents_derive_owned_sources());' "array('wp_coding_agents_not_owned' => 'h44-core')" "$FRESH" "$THEMES" "$PLUGINS" "$FRESH_THEMES")"
+refute_contains "$OUT" "plugins/h44-core" "--not-owned is honoured by the reactive path"
+
+echo ""
+echo "source-reconcile: the inventory hash makes hot hooks cheap"
+
+OUT="$(run_php 'echo wp_coding_agents_inventory_hash();' "array()" "$FRESH" "$THEMES" "$PLUGINS" "$FRESH_THEMES")"
+OUT2="$(run_php 'echo wp_coding_agents_inventory_hash();' "array()" "$FRESH" "$THEMES" "$PLUGINS" "$FRESH_THEMES")"
+assert_eq "$OUT" "$OUT2" "the hash is stable for an unchanged inventory"
+OUT3="$(run_php 'echo wp_coding_agents_inventory_hash();' "array()" "$FRESH" "$THEMES" "array('h44-core/h44-core.php' => array())" "$FRESH_THEMES")"
+if [ "$OUT" != "$OUT3" ]; then echo "  ok   the hash changes when a plugin appears"; else
+  echo "  FAIL the hash did not change for a different inventory"; FAILED=$((FAILED + 1)); fi
+
+echo ""
+echo "source-reconcile: wiring"
+
+# A scaffolded plugin fires none of the lifecycle hooks — no install, no
+# activation, just a directory appearing. That is the case this exists for, so
+# the scheduled sweep is not optional.
+tpl="$(cat "$TEMPLATE")"
+assert_contains "$tpl" "activated_plugin" "hooks plugin activation"
+assert_contains "$tpl" "upgrader_process_complete" "hooks installs and updates"
+assert_contains "$tpl" "wp_coding_agents_reconcile_cron" "schedules a sweep for scaffolded plugins"
+
+# The shell must delegate, not re-derive: two implementations of the same safety
+# rule are free to drift, which is the failure this design removes.
+recon="$(cat lib/source-reconcile.sh)"
+assert_contains "$recon" "wp_coding_agents_reconcile_sources" "the installer delegates to the mu-plugin"
+refute_contains "$recon" "update_plugins" "the installer does not re-derive from the transient"
+
+# PHP runs as www-data and writes the manifest. Setup created that directory
+# root-owned, so the reactive path could not write it and capture would read a
+# stale file — the drift the manifest exists to prevent.
+assert_contains "$recon" "source_reconcile_prepare_manifest_dir" "the manifest dir is prepared for PHP"
+assert_contains "$recon" "chown root:www-data" "and made group-writable by the web user"
+
+for f in setup.sh upgrade.sh; do
+  assert_contains "$(cat $f)" "source_reconcile_sync" "$f installs the reconciler"
+  assert_contains "$(cat $f)" "source_reconcile_run" "$f converges once on run"
+done
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "source-reconcile: all assertions passed"
+else
+  echo "source-reconcile: $FAILED assertion(s) failed"
+  exit 1
+fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard agents-md-guidance agents-md-backups; do
+for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -563,6 +563,8 @@ sync_cli_transport_runtime() {
   log "Phase 2b: Syncing CLI dispatch transport..."
   cli_transport_install
   runtime_guard_sync
+  source_reconcile_sync
+  source_reconcile_run
 }
 
 update_ai_gateway() {


### PR DESCRIPTION
Closes the last friction in #336: an agent can now create a plugin and have it become editable and captured with no operator step.

## The gap

Derivation ran only during `upgrade.sh` — fine for a plugin that already exists, useless for one the agent is about to write. It creates the directory, and nothing recomputes until somebody SSHes in. *"Build me a booking plugin"* ended in a support ticket.

## The design fork, stated

There were two shapes. **Invert the permissions** — allow `wp-content/plugins/**`, deny each known third-party — so a new directory is writable instantly and no reconcile is needed. Or **keep deny-by-default and reconcile reactively**.

I took the second. Inverting turns *"can the agent edit the payment gateway"* from a question about the **allow** list into a question about the **deny** list, where a stale or incomplete entry means yes. Every safety property in this project rests on deny-by-default; one saved step isn't worth trading it on a site taking card payments.

Creation goes through WP-CLI, which the agent already has. The reconcile grants edit rights immediately after.

## How it stays current

An mu-plugin hooks `activated_plugin`, `deactivated_plugin`, `deleted_plugin`, `switch_theme`, `deleted_theme`, `upgrader_process_complete` — **plus an hourly sweep**, because a plugin the agent *scaffolds* fires none of those. An inventory fingerprint makes the usual call a single option read, which is what lets the hooks be broad.

## One implementation, not two

Derivation began in `lib/owned-source-discovery.sh`. Keeping it there and adding a PHP copy would be two implementations of the same safety rule, free to drift — the exact failure #336 and #337 removed from the capture path.

PHP wins the tie because it's the only one that can run from a WordPress hook. The shell now delegates, and a test asserts the installer doesn't re-derive.

## A bug the tests caught

`update_themes` is a **separate transient** from `update_plugins`, with its own freshness. A fresh plugin signal alongside a missing theme signal left every bundled theme unrecognised — so `twentytwentyfive` derived as the site's, became editable, and would have been captured.

Same fail-open danger as the plugin case, reached through a different door. Gated independently now. The only reason it didn't ship is that the test asserted the bundled theme was *excluded* rather than assuming it.

## Also

The manifest directory is handed to `www-data`. PHP writes it; setup created it root-owned, so the reactive path would have updated the option while capture kept reading a stale file — precisely the drift the manifest exists to prevent.

Since this now runs **unattended on a live site**, every fail-closed property is asserted directly: missing, empty, and stale signals each defer; an empty derived set defers rather than opening `wp-content`; and *a missing signal cannot open WooCommerce* is its own assertion rather than an implication.