### PR TITLE
feat: assert the cross-layer invariants with verify.sh

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -222,6 +222,7 @@ jobs:
           - opencode-claude-auth-refresh-hardening
           - owned-source-discovery
           - source-reconcile
+          - verify
           - path-helpers
           - post-upgrade-restore
           - runtime-signature

--- a/README.md
+++ b/README.md
@@ -450,6 +450,29 @@ node tests/effective-prompt/run.mjs --verbose
 
 Use setup output and operator entrypoints for environment-specific verification commands. The generated summary is the source of truth for service names, paths, and bridge restart commands.
 
+## Verification
+
+```
+./verify.sh                 # exits non-zero on any disagreement
+./verify.sh --json          # machine-readable, for a scheduled check
+```
+
+Every defect that reached a live site during the managed-hosting rollout was a
+disagreement *between* layers, not a fault within one: a unit whose `User=` and
+`HOME=` described different identities, a manifest that had drifted from the
+recorded set, a declared source the permission surface did not allow, a function
+guarded by `declare -F` in a script that never sourced its library.
+
+Each component was internally correct and individually tested. Nothing owned the
+seam, so nothing failed until somebody looked — and the looking is what does not
+scale. An operator with two sites inspects a rendered systemd unit before
+starting services; an operator with two thousand does not.
+
+`verify.sh` owns the seams. It reports and never repairs: a check that fixes what
+it finds cannot be trusted to report honestly, and the failure it hides is the
+one worth seeing. An invariant it cannot evaluate is reported as skipped rather
+than passed.
+
 ## Upgrades
 
 Installed agents receive an `upgrade-wp-coding-agents` skill. The skill runs `upgrade.sh`, preserves user state, syncs managed bridge/runtime files, and prints verification and restart commands for the detected environment.

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# tests/verify.sh — the cross-layer invariant checker.
+#
+# The only property worth testing here is that it CATCHES things. A checker that
+# passes on a healthy install and also passes on a broken one is worse than no
+# checker, because it converts "nobody looked" into "something looked and said
+# it was fine".
+#
+# So every assertion below breaks one seam and demands a specific complaint.
+# The seams are the real ones: each corresponds to a defect that reached a live
+# site during the managed-hosting rollout, where every individual component was
+# correct and tested and nothing owned the space between them.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+FAILED=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_contains() {
+  case "$1" in *"$2"*) echo "  ok   $3" ;; *) echo "  FAIL $3 (missing: $2)"; FAILED=$((FAILED + 1)) ;; esac
+}
+refute_contains() {
+  case "$1" in *"$2"*) echo "  FAIL $3 (unexpectedly present: $2)"; FAILED=$((FAILED + 1)) ;; *) echo "  ok   $3" ;; esac
+}
+
+# A fake install. wp is stubbed so this needs no database.
+SITE="$TMP/site"
+mkdir -p "$SITE/wp-content/mu-plugins" "$TMP/units" "$TMP/manifest/site"
+# When running as root the manifest-writability check is live, so the fixture
+# has to model a correctly-provisioned directory.
+if [ "$(id -u)" -eq 0 ] && id -u www-data >/dev/null 2>&1; then
+  chown root:www-data "$TMP/manifest/site" 2>/dev/null || true
+  chmod 2775 "$TMP/manifest/site" 2>/dev/null || true
+  chmod o+rx "$TMP" "$TMP/manifest" 2>/dev/null || true
+fi
+: > "$SITE/wp-config.php"
+touch "$SITE/wp-content/mu-plugins/wp-coding-agents-source-reconcile.php" \
+      "$SITE/wp-content/mu-plugins/wp-coding-agents-runtime-guard.php"
+
+cat > "$TMP/wp" <<'WP'
+#!/bin/bash
+# Stub: `wp option get <name>`
+for a in "$@"; do case "$a" in --path=*) ;; esac; done
+case "$3" in
+  wp_coding_agents_source_mode)   echo owned ;;
+  wp_coding_agents_owned_sources) printf 'wp-content/plugins/acme-core\nwp-content/themes/acme\n' ;;
+  *) : ;;
+esac
+WP
+chmod +x "$TMP/wp"
+
+write_manifest() { printf '%s\n' "$@" > "$TMP/manifest/site/owned-sources"; chmod 644 "$TMP/manifest/site/owned-sources"; }
+write_opencode() {
+  python3 - "$SITE/opencode.json" "$@" <<'PY'
+import json, sys
+out = sys.argv[1]
+allows = sys.argv[2:]
+rules = {}
+for d in ("wp-admin/**","wp-includes/**","wp-content/plugins/**","wp-content/themes/**","wp-config.php"):
+    rules[d] = "deny"
+for a in allows:
+    rules[a + "/**"] = "allow"
+json.dump({"permission": {"edit": rules}}, open(out, "w"), indent=2)
+PY
+}
+write_unit() {
+  # $1 name, $2 User, $3 HOME, [$4 extra Environment line]
+  { printf '[Service]\nUser=%s\nEnvironment=HOME=%s\n' "$2" "$3"
+    [ -n "${4:-}" ] && printf '%s\n' "$4"
+    printf 'ExecStart=/bin/true\n'
+  } > "$TMP/units/$1"
+}
+
+run_verify() {
+  PATH="$TMP:$PATH" \
+  SYSTEMD_UNIT_DIR="$TMP/units" \
+  SOURCE_POLICY_MANIFEST_ROOT="$TMP/manifest" \
+    bash verify.sh --site-path "$SITE" 2>&1 || true
+}
+
+# Baseline: everything agrees.
+write_manifest wp-content/plugins/acme-core wp-content/themes/acme
+write_opencode wp-content/plugins/acme-core wp-content/themes/acme
+write_unit kimaki.service opencode /home/opencode
+
+echo "verify: a healthy install passes"
+OUT="$(run_verify)"
+refute_contains "$OUT" "FAIL" "no complaints when every seam agrees"
+assert_contains "$OUT" "permission.edit allows exactly the declared set" "checks the permission seam"
+assert_contains "$OUT" "manifest agrees with the recorded set" "checks the manifest seam"
+
+if PATH="$TMP:$PATH" SYSTEMD_UNIT_DIR="$TMP/units" SOURCE_POLICY_MANIFEST_ROOT="$TMP/manifest" bash verify.sh --site-path "$SITE" --quiet; then
+  echo "  ok   exits 0 when healthy"
+else
+  echo "  FAIL healthy install exited non-zero"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+echo "verify: it catches the defects that reached a live site"
+
+# 1. The identity bug. The migration rendered User=opencode with HOME=/root, and
+#    the agent would have started with a home it cannot read. Nothing owned the
+#    relationship between those two lines.
+write_unit kimaki.service opencode /root
+OUT="$(run_verify)"
+assert_contains "$OUT" "User=opencode but HOME=/root" "catches a User/HOME mismatch"
+
+# 2. A value left pointing into the home the install migrated away from. PATH and
+#    KIMAKI_DATA_DIR both did this; enumerating key names would have missed it.
+write_unit kimaki.service opencode /home/opencode "Environment=KIMAKI_DATA_DIR=/root/.kimaki"
+OUT="$(run_verify)"
+assert_contains "$OUT" "points outside opencode's home" "catches a stale value from the old identity"
+
+write_unit kimaki.service opencode /home/opencode
+
+# 3. Manifest drift. Capture reads the manifest; permissions come from the
+#    option. Disagreement means the agent edits what nothing records.
+write_manifest wp-content/plugins/acme-core wp-content/plugins/GONE
+OUT="$(run_verify)"
+assert_contains "$OUT" "manifest disagrees with the recorded set" "catches manifest drift"
+assert_contains "$OUT" "acme-core" "names both sides of the disagreement"
+
+# 4. Manifest missing entirely — the state h44lacrosse.com was in after the
+#    first release that was supposed to create it.
+rm -f "$TMP/manifest/site/owned-sources"
+OUT="$(run_verify)"
+assert_contains "$OUT" "manifest missing" "catches a missing manifest"
+write_manifest wp-content/plugins/acme-core wp-content/themes/acme
+
+# 5. A deny removed. This is the one that matters most: it is the difference
+#    between an agent that cannot touch a payment gateway and one that can.
+python3 - "$SITE/opencode.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["permission"]["edit"].pop("wp-content/plugins/**", None)
+json.dump(d, open(sys.argv[1], "w"), indent=2)
+PY
+OUT="$(run_verify)"
+assert_contains "$OUT" "NOT denied: wp-content/plugins/**" "catches a removed deny"
+write_opencode wp-content/plugins/acme-core wp-content/themes/acme
+
+# 6. Permissions that do not match the declaration.
+write_opencode wp-content/plugins/acme-core
+OUT="$(run_verify)"
+assert_contains "$OUT" "permission.edit disagrees with the declared set" "catches declared-but-not-allowed"
+write_opencode wp-content/plugins/acme-core wp-content/themes/acme
+
+# 7. A missing owned-mode component.
+mv "$SITE/wp-content/mu-plugins/wp-coding-agents-source-reconcile.php" "$TMP/held"
+OUT="$(run_verify)"
+assert_contains "$OUT" "wp-coding-agents-source-reconcile is missing" "catches a half-applied owned mode"
+mv "$TMP/held" "$SITE/wp-content/mu-plugins/wp-coding-agents-source-reconcile.php"
+
+echo ""
+echo "verify: failure is reported, not repaired"
+
+# A checker that fixes what it finds cannot be trusted to report honestly, and
+# the failure it hides is the one worth seeing.
+write_manifest wp-content/plugins/acme-core wp-content/plugins/GONE
+run_verify >/dev/null
+if grep -q 'GONE' "$TMP/manifest/site/owned-sources"; then
+  echo "  ok   a broken manifest is left broken"
+else
+  echo "  FAIL verify repaired the manifest instead of reporting it"
+  FAILED=$((FAILED + 1))
+fi
+
+if PATH="$TMP:$PATH" SYSTEMD_UNIT_DIR="$TMP/units" SOURCE_POLICY_MANIFEST_ROOT="$TMP/manifest" bash verify.sh --site-path "$SITE" --quiet; then
+  echo "  FAIL exited 0 despite a disagreement"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   exits non-zero on disagreement"
+fi
+
+# An invariant that could not be checked must not report as healthy.
+OUT="$(run_verify)"
+assert_contains "$OUT" "skip" "unverifiable invariants are skipped, not passed"
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "verify: all assertions passed"
+else
+  echo "verify: $FAILED assertion(s) failed"
+  exit 1
+fi

--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+# verify.sh — assert the cross-layer invariants on an installed agent.
+#
+# WHY THIS EXISTS
+#
+# Every defect that reached a live site during the managed-hosting rollout was a
+# disagreement BETWEEN layers, not a fault within one:
+#
+#   unit User= vs unit HOME            the agent ran with a home it cannot read
+#   recorded option vs manifest file   capture read a set the site had moved on from
+#   manifest vs harvest components     a hardcoded list drifted from the declaration
+#   owned set vs permission.edit       declared editable, actually denied
+#   function vs the lib its caller sources
+#                                      a guard silently skipped, leaving database
+#                                      credentials group-writable
+#
+# Each component was internally correct and individually tested. Nothing owned
+# the seam, so nothing failed until someone looked — and the looking is what
+# does not scale. An operator with two sites inspects a rendered systemd unit
+# before starting services. An operator with two thousand does not.
+#
+# So the seams get an owner. This asserts them, exits non-zero on disagreement,
+# and is cheap enough to run on a schedule.
+#
+# WHAT IT DELIBERATELY DOES NOT DO
+#
+# It never repairs. A check that fixes what it finds cannot be trusted to report
+# honestly, and the failure it hides is exactly the one worth seeing: silent
+# convergence is how "it works on my box" survives. `./upgrade.sh` is the
+# repair; this is the measurement.
+#
+# Usage:
+#   ./verify.sh [--site-path PATH] [--quiet] [--json]
+#
+# Exit: 0 all invariants hold, 1 at least one disagreement, 2 cannot check.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+QUIET=false
+JSON=false
+SITE_PATH="${SITE_PATH:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --site-path) SITE_PATH="$2"; shift 2 ;;
+    --quiet)     QUIET=true; shift ;;
+    --json)      JSON=true; QUIET=true; shift ;;
+    --help|-h)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) shift ;;
+  esac
+done
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+FINDINGS=""
+
+_say() { [ "$QUIET" = true ] || printf '%s\n' "$1"; }
+
+pass() {
+  PASSED=$((PASSED + 1))
+  _say "  ok    $1"
+}
+
+# A disagreement. The message must name BOTH sides — "permissions are wrong" is
+# not actionable; "declared X, permission.edit allows Y" is.
+fail() {
+  FAILED=$((FAILED + 1))
+  FINDINGS="${FINDINGS}${1}"$'\n'
+  _say "  FAIL  $1"
+}
+
+# Something this cannot see from here. Distinct from a pass on purpose: an
+# invariant that could not be checked has not been shown to hold, and reporting
+# it as fine is how a check becomes decoration.
+skip() {
+  SKIPPED=$((SKIPPED + 1))
+  _say "  skip  $1"
+}
+
+section() { _say ""; _say "$1"; }
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+if [ -z "$SITE_PATH" ]; then
+  for candidate in /var/www/*/; do
+    [ -f "${candidate}wp-config.php" ] || continue
+    SITE_PATH="${candidate%/}"
+    break
+  done
+fi
+
+if [ -z "$SITE_PATH" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
+  echo "verify: no WordPress install found (pass --site-path)" >&2
+  exit 2
+fi
+
+WP_CMD="${WP_CMD:-wp}"
+command -v "$WP_CMD" >/dev/null 2>&1 || { echo "verify: $WP_CMD not on PATH" >&2; exit 2; }
+WP_ROOT_FLAG=""
+[ "$(id -u)" -eq 0 ] && WP_ROOT_FLAG="--allow-root"
+
+wp_opt() {
+  # shellcheck disable=SC2086
+  "$WP_CMD" option get "$1" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
+}
+
+SOURCE_MODE="$(wp_opt wp_coding_agents_source_mode | tr -d '[:space:]')"
+[ -n "$SOURCE_MODE" ] || SOURCE_MODE="$(wp_opt wp_coding_agents_posture | tr -d '[:space:]')"
+case "$SOURCE_MODE" in
+  managed) SOURCE_MODE=owned ;;
+  engineering) SOURCE_MODE=workspace ;;
+esac
+
+_say "wp-coding-agents verify"
+_say "  site:        $SITE_PATH"
+_say "  source mode: ${SOURCE_MODE:-<unset>}"
+
+# ---------------------------------------------------------------------------
+# Seam 1: the recorded set, the manifest, and the permissions must agree
+# ---------------------------------------------------------------------------
+
+section "owned set agreement"
+
+if [ "$SOURCE_MODE" != "owned" ]; then
+  skip "not an owned-mode install — no owned set to agree about"
+else
+  RECORDED="$(wp_opt wp_coding_agents_owned_sources | sed '/^[[:space:]]*$/d' | sort)"
+  [ -n "$RECORDED" ] || RECORDED="$(wp_opt wp_coding_agents_managed_sources | sed '/^[[:space:]]*$/d' | sort)"
+
+  SITE_KEY="$(basename "$SITE_PATH")"
+  MANIFEST="${SOURCE_POLICY_MANIFEST_ROOT:-/var/lib/wp-coding-agents}/$SITE_KEY/owned-sources"
+
+  if [ -z "$RECORDED" ]; then
+    fail "owned mode records no sources — the agent has no editable source at all"
+  else
+    pass "recorded owned sources: $(printf '%s' "$RECORDED" | tr '\n' ' ')"
+  fi
+
+  if [ ! -f "$MANIFEST" ]; then
+    fail "manifest missing at $MANIFEST — out-of-band capture cannot learn the editable set"
+  else
+    MANIFEST_SET="$(sed '/^[[:space:]]*$/d' "$MANIFEST" | sort)"
+    if [ "$MANIFEST_SET" = "$RECORDED" ]; then
+      pass "manifest agrees with the recorded set"
+    else
+      fail "manifest disagrees with the recorded set — capture and permissions would diverge
+          recorded: $(printf '%s' "$RECORDED" | tr '\n' ' ')
+          manifest: $(printf '%s' "$MANIFEST_SET" | tr '\n' ' ')"
+    fi
+
+    # The reader is a deliberately unprivileged identity that cannot reach the
+    # database. A manifest it cannot read is the same as no manifest.
+    MODE="$(stat -c '%a' "$MANIFEST" 2>/dev/null)"
+    case "$MODE" in
+      *4|*5|*6|*7) pass "manifest is world-readable ($MODE) — the capture identity can read it" ;;
+      *) fail "manifest mode $MODE is not world-readable — the capture identity cannot read it" ;;
+    esac
+
+    case "$MANIFEST" in
+      "$SITE_PATH"/*) fail "manifest lives inside the web root — it is fetchable over HTTP" ;;
+      *) pass "manifest lives outside the web root" ;;
+    esac
+  fi
+
+  # The permission surface has to grant exactly what was declared. Declared but
+  # denied is an agent that cannot do its job; denied but allowed is an agent
+  # editing something nothing captures.
+  OPENCODE_JSON="$SITE_PATH/opencode.json"
+  if [ ! -f "$OPENCODE_JSON" ]; then
+    skip "no opencode.json — cannot compare permissions"
+  else
+    ALLOWED="$(python3 - "$OPENCODE_JSON" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+rules = d.get("permission", {}).get("edit", {})
+if not isinstance(rules, dict):
+    sys.exit(0)
+for pattern, action in rules.items():
+    if action == "allow" and pattern.endswith("/**"):
+        print(pattern[:-3])
+PY
+)"
+    ALLOWED="$(printf '%s' "$ALLOWED" | sed '/^[[:space:]]*$/d' | sort)"
+    if [ "$ALLOWED" = "$RECORDED" ]; then
+      pass "permission.edit allows exactly the declared set"
+    else
+      fail "permission.edit disagrees with the declared set
+          declared: $(printf '%s' "$RECORDED" | tr '\n' ' ')
+          allowed:  $(printf '%s' "$ALLOWED" | tr '\n' ' ')"
+    fi
+
+    # These denies are what keep the agent off a payment gateway. Their absence
+    # is the failure worth waking up for.
+    for root in "wp-content/plugins/**" "wp-content/themes/**" "wp-admin/**" "wp-includes/**" "wp-config.php"; do
+      if python3 - "$OPENCODE_JSON" "$root" <<'PY' 2>/dev/null
+import json, sys
+d = json.load(open(sys.argv[1]))
+sys.exit(0 if d.get("permission", {}).get("edit", {}).get(sys.argv[2]) == "deny" else 1)
+PY
+      then
+        pass "denied: $root"
+      else
+        fail "NOT denied: $root — third-party code and core are writable by the edit tool"
+      fi
+    done
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Seam 2: the service identity must be internally coherent
+# ---------------------------------------------------------------------------
+
+section "service identity coherence"
+
+UNIT_DIR="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+UNITS_CHECKED=0
+for unit in "$UNIT_DIR"/kimaki*.service "$UNIT_DIR"/datamachine-worker.service; do
+  [ -f "$unit" ] || continue
+  UNITS_CHECKED=$((UNITS_CHECKED + 1))
+  name="$(basename "$unit")"
+  u_user="$(awk -F= '/^User=/ {print $2; exit}' "$unit")"
+  [ -n "$u_user" ] || continue
+  u_home="$(getent passwd "$u_user" 2>/dev/null | cut -d: -f6)"
+  [ -n "$u_home" ] || u_home="/home/$u_user"
+  [ "$u_user" = "root" ] && u_home="/root"
+
+  env_home="$(awk -F= '/^Environment=HOME=/ {print $3; exit}' "$unit")"
+  if [ -z "$env_home" ]; then
+    skip "$name declares no HOME"
+  elif [ "$env_home" = "$u_home" ]; then
+    pass "$name: User=$u_user and HOME=$env_home agree"
+  else
+    fail "$name: User=$u_user but HOME=$env_home — the service cannot read its own home"
+  fi
+
+  # Any value pointing into a home that is not this user's is left over from an
+  # identity that no longer exists.
+  while IFS= read -r line; do
+    value="${line#Environment=*=}"
+    case "$value" in
+      /root/*|/home/*)
+        case "$value" in
+          "$u_home"/*|"$u_home") ;;
+          *) fail "$name: '${line%%=*}=${line#Environment=}' points outside ${u_user}'s home" ;;
+        esac
+        ;;
+    esac
+  done < <(grep '^Environment=' "$unit" 2>/dev/null | grep -vE '^Environment=(PATH|HOME)=')
+done
+
+[ "$UNITS_CHECKED" -eq 0 ] && skip "no agent systemd units on this host"
+
+# ---------------------------------------------------------------------------
+# Seam 3: the pieces owned mode requires must actually be installed
+# ---------------------------------------------------------------------------
+
+section "owned-mode components"
+
+if [ "$SOURCE_MODE" != "owned" ]; then
+  skip "not an owned-mode install"
+else
+  for mu in wp-coding-agents-source-reconcile wp-coding-agents-runtime-guard; do
+    if [ -f "$SITE_PATH/wp-content/mu-plugins/$mu.php" ]; then
+      pass "$mu is installed"
+    else
+      fail "$mu is missing — owned mode is not fully applied"
+    fi
+  done
+
+  # A reconcile that cannot write is a reconcile that reports success and
+  # changes nothing.
+  MANIFEST_DIR="${SOURCE_POLICY_MANIFEST_ROOT:-/var/lib/wp-coding-agents}/$(basename "$SITE_PATH")"
+  if [ -d "$MANIFEST_DIR" ]; then
+    # Answering this requires becoming another user, which requires root. When
+    # that is impossible the invariant has not been shown to hold and must be
+    # reported as unchecked — not as a failure, which would cry wolf on every
+    # unprivileged run, and not as a pass, which is how a checker becomes
+    # decoration.
+    if [ "$(id -u)" -ne 0 ] || ! id -u www-data >/dev/null 2>&1; then
+      skip "cannot test manifest writability without root and a www-data account"
+    elif su -s /bin/bash www-data -c "test -w '$MANIFEST_DIR'" 2>/dev/null; then
+      pass "the web user can write the manifest directory"
+    else
+      fail "www-data cannot write $MANIFEST_DIR — the reactive reconcile updates the option and leaves capture reading a stale file"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+
+section "result"
+_say "  $PASSED passed, $FAILED failed, $SKIPPED skipped"
+
+if [ "$JSON" = true ]; then
+  printf '{"passed":%d,"failed":%d,"skipped":%d,"findings":' "$PASSED" "$FAILED" "$SKIPPED"
+  printf '%s' "$FINDINGS" | python3 -c 'import json,sys; print(json.dumps([l for l in sys.stdin.read().split("\n") if l.strip()]))'
+  printf '}\n'
+fi
+
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## The pattern

Every defect that reached a live site during this rollout was a disagreement **between** layers, not a fault within one:

| seam | what it cost |
|---|---|
| unit `User=` vs unit `HOME=` | the agent would have started with a home it cannot read |
| recorded option vs manifest | capture read a set the site had moved on from |
| manifest vs harvest components | a hardcoded list drifted from the declaration |
| owned set vs `permission.edit` | declared editable, actually denied |
| function vs the lib its caller sources | a `declare -F` guard silently skipped, leaving database credentials group-writable |

Each component was internally correct and individually tested. **Nothing owned the space between them**, so nothing failed until someone looked.

The looking is what doesn't scale. An operator with two sites inspects a rendered systemd unit before starting services. An operator with two thousand does not.

## What it does

```
./verify.sh          # exits non-zero on any disagreement
./verify.sh --json   # machine-readable, for a scheduled check
```

Three seams: owned-set agreement (option ↔ manifest ↔ permissions, plus the denies that keep the agent off a payment gateway), service-identity coherence (`User=` ↔ `HOME=`, and any value still pointing into a home the install migrated away from), and owned-mode completeness.

## Two design choices

**It reports and never repairs.** A check that fixes what it finds can't be trusted to report honestly, and the failure it hides is the one worth seeing. `upgrade.sh` is the repair; this is the measurement.

**An invariant it cannot evaluate is `skip`, not `pass`.** My own test caught me violating this: the manifest-writability check needs root to become `www-data`, and unprivileged it reported a *failure* rather than declining to answer — which would have cried wolf on every CI run and taught everyone to ignore it. That's how a checker becomes decoration.

## Validated against live installs

**h44lacrosse.com: 15 passed, 0 failed, 0 skipped.** **chubes.net** (workspace mode): owned-set checks correctly skip.

Then deliberately re-broken, one seam at a time — it named every one:

```
FAIL  kimaki.service: User=opencode but HOME=/root — the service cannot read its own home
FAIL  kimaki.service: 'KIMAKI_DATA_DIR=/root/.kimaki' points outside opencode's home
FAIL  manifest disagrees with the recorded set — capture and permissions would diverge
FAIL  manifest missing — out-of-band capture cannot learn the editable set
FAIL  NOT denied: wp-content/plugins/** — third-party code and core are writable
```

The first two are the exact bug hand-fixed on h44 this morning. Live config was restored and re-verified clean afterwards.

Tests assert it **catches** each of those, not merely that it passes when healthy — a checker green on both a healthy and a broken install is worse than none, because it converts "nobody looked" into "something looked and said it was fine".