### PR TITLE
fix: a crashed prompt test is not a leaking prompt filter

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -998,6 +998,34 @@ bridge_sync_config() {
   # outside Kimaki's npm package so `npm update -g kimaki` cannot wipe them.
   _kimaki_sync_bin_helpers
 
+# Resolve a runtime that can import the harness AND the TypeScript filter it
+# loads. node cannot: dm-context-filter.ts is TypeScript, and node exits with
+# ERR_UNKNOWN_FILE_EXTENSION on import. Echoes nothing when none is available,
+# which the caller must treat as "unverified" rather than "failing".
+#
+# Checks PATH first, then the service home, then root's — a service-identity
+# migration moves the toolchain, and bun installed for one identity is not on
+# the PATH of a shell running as another.
+_kimaki_effective_prompt_runner() {
+  if command -v bun >/dev/null 2>&1; then
+    command -v bun
+    return 0
+  fi
+  # /root is checked because a service-identity migration leaves the toolchain
+  # behind while the upgrade itself still runs as root — h44lacrosse.com's exact
+  # shape. Overridable so a test can model a host with no bun anywhere.
+  local home
+  for home in "${SERVICE_HOME:-}" "$HOME" "${KIMAKI_BUN_FALLBACK_HOME:-/root}"; do
+    [ -n "$home" ] || continue
+    if [ -x "$home/.bun/bin/bun" ]; then
+      printf '%s' "$home/.bun/bin/bun"
+      return 0
+    fi
+  done
+  return 0
+}
+
+
   # On local, execute post-upgrade.sh inline to restore the upgrade skill.
   # On VPS, kimaki.service ExecStartPre runs it on next service restart.
   if [ "$LOCAL_MODE" = true ] && [ -x "$KIMAKI_CONFIG_DIR/post-upgrade.sh" ]; then
@@ -1026,13 +1054,25 @@ bridge_sync_config() {
   # underlying sync was successful. The signal is in UPDATED_ITEMS so the
   # final summary surfaces it.
   local TEST_SCRIPT="$SCRIPT_DIR/tests/effective-prompt/run.mjs"
-  if [ -f "$TEST_SCRIPT" ] && command -v node &>/dev/null; then
+  local TEST_RUNNER
+  TEST_RUNNER="$(_kimaki_effective_prompt_runner)"
+  if [ -f "$TEST_SCRIPT" ] && [ -z "$TEST_RUNNER" ]; then
+    # NOT a leak. The harness imports dm-context-filter.ts directly, and node
+    # cannot load TypeScript — it exits with ERR_UNKNOWN_FILE_EXTENSION before
+    # rendering a single prompt. Reporting that as a possible leak is how this
+    # warned on every upgrade of h44lacrosse.com while the filter was in fact
+    # clean, which is worse than silence: an alarm that is always wrong teaches
+    # everyone to scroll past the one time it is right.
+    warn "  effective-prompt test SKIPPED — needs a TypeScript-capable runtime (bun)"
+    warn "    the filter is UNVERIFIED on this host, not known to be leaking"
+    UPDATED_ITEMS+=("effective-prompt test skipped — install bun to verify the prompt filter")
+  elif [ -f "$TEST_SCRIPT" ]; then
     if [ "$DRY_RUN" = true ]; then
-      echo -e "${BLUE}[dry-run]${NC} Would run: node $TEST_SCRIPT"
+      echo -e "${BLUE}[dry-run]${NC} Would run: $TEST_RUNNER $TEST_SCRIPT"
     else
-      log "  Running effective-prompt regression test..."
+      log "  Running effective-prompt regression test ($TEST_RUNNER)..."
       local TEST_OUT
-      if TEST_OUT=$(node "$TEST_SCRIPT" 2>&1); then
+      if TEST_OUT=$("$TEST_RUNNER" "$TEST_SCRIPT" 2>&1); then
         # Pull the scenario count from the harness's "OK — N scenario(s)" line.
         local SCENARIO_LINE
         SCENARIO_LINE=$(echo "$TEST_OUT" | grep -E "^OK — [0-9]+ scenario" | head -1)
@@ -1040,8 +1080,8 @@ bridge_sync_config() {
         UPDATED_ITEMS+=("ran effective-prompt test (no filter leaks)")
       else
         warn "  effective-prompt test FAILED — dm-context-filter may be leaking banned phrases"
-        warn "    rerun with: node $TEST_SCRIPT --verbose"
-        warn "    if drift is intentional: node $TEST_SCRIPT --update"
+        warn "    rerun with: $TEST_RUNNER $TEST_SCRIPT --verbose"
+        warn "    if drift is intentional: $TEST_RUNNER $TEST_SCRIPT --update"
         # Surface the failure section of the test output (last ~12 lines).
         echo "$TEST_OUT" | tail -12 | sed 's/^/    /' >&2
         UPDATED_ITEMS+=("effective-prompt test FAILED — review filter or refresh snapshots")

--- a/tests/bridge-render.sh
+++ b/tests/bridge-render.sh
@@ -226,3 +226,65 @@ fi
 
 echo
 echo "OK: all snapshots match"
+
+# ---------------------------------------------------------------------------
+echo "==> effective-prompt runner resolution"
+# ---------------------------------------------------------------------------
+#
+# The harness imports dm-context-filter.ts directly. node cannot load
+# TypeScript — it exits ERR_UNKNOWN_FILE_EXTENSION before rendering a single
+# prompt — and the upgrade reported that crash as
+# "dm-context-filter may be leaking banned phrases".
+#
+# It warned on every h44lacrosse.com upgrade while the filter was in fact clean
+# (verified: OK — 2 scenarios, 0 leaks, under bun). An alarm that is always
+# wrong is worse than silence, because it teaches everyone to scroll past the
+# one time it is right.
+
+_ep_probe() {
+  # Args: PATH_DIR SERVICE_HOME HOME
+  ( PATH="$1:/usr/bin:/bin"; SERVICE_HOME="$2"; HOME="$3"
+    # Model a host with no bun anywhere; this box really does have /root/.bun.
+    KIMAKI_BUN_FALLBACK_HOME="${4:-$3}"
+    # shellcheck disable=SC1090
+    eval "$(sed -n '/^_kimaki_effective_prompt_runner()/,/^}/p' "$SCRIPT_DIR/bridges/kimaki.sh")"
+    _kimaki_effective_prompt_runner )
+}
+
+EPT="$(mktemp -d)"
+trap 'rm -rf "$EPT"' EXIT
+mkdir -p "$EPT/onpath" "$EPT/svc/.bun/bin" "$EPT/root/.bun/bin" "$EPT/empty"
+printf '#!/bin/sh\n' > "$EPT/onpath/bun"; chmod +x "$EPT/onpath/bun"
+printf '#!/bin/sh\n' > "$EPT/svc/.bun/bin/bun"; chmod +x "$EPT/svc/.bun/bin/bun"
+
+got="$(_ep_probe "$EPT/onpath" "" "$EPT/empty" "$EPT/empty")"
+[ -n "$got" ] && echo "  ok   prefers bun on PATH" || { echo "  FAIL bun on PATH not found"; FAILED=$((FAILED+1)); }
+
+# A service-identity migration moves the toolchain: bun installed for one
+# identity is not on the PATH of a shell running as another.
+got="$(_ep_probe "$EPT/empty" "$EPT/svc" "$EPT/empty" "$EPT/empty")"
+case "$got" in
+  */svc/.bun/bin/bun) echo "  ok   falls back to the service home" ;;
+  *) echo "  FAIL did not find bun under SERVICE_HOME (got: ${got:-none})"; FAILED=$((FAILED+1)) ;;
+esac
+
+# No TypeScript-capable runtime: must report nothing, so the caller can say
+# "unverified" instead of alleging a leak.
+got="$(_ep_probe "$EPT/empty" "$EPT/empty" "$EPT/empty" "$EPT/empty")"
+[ -z "$got" ] && echo "  ok   reports nothing when no TS runtime exists" || { echo "  FAIL returned '$got'"; FAILED=$((FAILED+1)); }
+
+# And the caller must distinguish the two.
+kimaki_src="$(cat "$SCRIPT_DIR/bridges/kimaki.sh")"
+case "$kimaki_src" in
+  *"effective-prompt test SKIPPED"*) echo "  ok   a missing runtime is reported as skipped" ;;
+  *) echo "  FAIL no skipped path — a crash would still be called a leak"; FAILED=$((FAILED+1)) ;;
+esac
+case "$kimaki_src" in
+  *"not known to be leaking"*) echo "  ok   the skip message denies alleging a leak" ;;
+  *) echo "  FAIL the skip message does not disclaim a leak"; FAILED=$((FAILED+1)) ;;
+esac
+# node must not be invoked against the TypeScript import at all.
+case "$kimaki_src" in
+  *'TEST_OUT=$(node "$TEST_SCRIPT"'*) echo "  FAIL still runs the harness under node"; FAILED=$((FAILED+1)) ;;
+  *) echo "  ok   no longer runs the harness under node" ;;
+esac


### PR DESCRIPTION
## The alarm was always wrong

h44lacrosse.com has warned this on **every upgrade**:

```
effective-prompt test FAILED — dm-context-filter may be leaking banned phrases
```

It isn't. The filter is clean — verified on that host under `bun`:

```
baseline leaks: 0
filtered leaks: 0
OK — 2 scenario(s) passed
```

The harness imports `dm-context-filter.ts` directly, and node **cannot load TypeScript**:

```
ERR_UNKNOWN_FILE_EXTENSION: Unknown file extension ".ts"
```

It exits before rendering a single prompt. The runner is `if node run.mjs; then ... else "may be leaking banned phrases"`, so a crash, a missing dependency, or a syntax error all get reported as a possible security leak.

## Why this matters more than the bug

An alarm that is always wrong is worse than silence, because it teaches everyone to scroll past the one time it's right. **I scrolled past this a dozen times today** before actually reading it — on a live payments site, in a warning about the agent's prompt filter.

It's the same shape as the `declare -F` guard fixed in #343: a caller assuming it knows why the thing below it failed. There the error was silent; here it's loud and inaccurate. Both are worse than an honest "I could not tell."

## The fix

Resolve a runtime that can actually import TypeScript — `bun` on PATH, then `SERVICE_HOME`, then root's. That last one matters: a service-identity migration leaves the toolchain behind while the upgrade still runs as root, which is exactly h44's shape (`bun` at `/root/.bun`, not on the upgrade's PATH).

When none exists:

```
effective-prompt test SKIPPED — needs a TypeScript-capable runtime (bun)
  the filter is UNVERIFIED on this host, not known to be leaking
```

Unverified, explicitly disclaiming a leak. Same principle as `verify.sh`: an invariant that could not be checked has not been shown to hold, and must not be reported as either passing or failing.

A genuine failure with a working runtime still reports as a possible leak — that's the case the message was written for.

## Coverage

Added to `tests/bridge-render.sh`: prefers `bun` on PATH, falls back to the service home, returns nothing when no TS runtime exists, the skip path exists and disclaims a leak, and the harness is no longer invoked under node. The `/root` fallback got a test seam so a host with no bun anywhere can be modelled — this dev box really does have `/root/.bun`, which made the first version of that assertion pass for the wrong reason.