### PR TITLE
fix: an hour is not a latency, it is a wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,19 @@ owned = installed  −  known to wp.org  −  installed by wp-coding-agents
 A plugin the agent creates is therefore editable and captured with no operator
 step and no self-declaration. `--owned-source` still overrides when supplied.
 
-Derivation is **continuous**, not upgrade-time. An mu-plugin listens to
-WordPress's own plugin and theme lifecycle hooks and reconciles the owned set,
-the capture manifest, and the runtime edit permissions as the installed set
-changes — plus an hourly sweep, because a plugin the agent *scaffolds* fires no
-lifecycle hook at all. An inventory fingerprint makes the usual call a single
-option read.
+Derivation is **continuous**, not upgrade-time. An mu-plugin reconciles the
+owned set, the capture manifest, and the runtime edit permissions as the
+installed set changes:
+
+- WordPress plugin and theme lifecycle hooks
+- WP-CLI `after_invoke`, which fires in the *same command* that scaffolded a
+  plugin — no race, no perceptible latency
+- every bootstrap, so a directory created by any means (a bare `mkdir` from the
+  agent's shell) is picked up by the next request
+- an hourly sweep as a backstop for a site nobody is touching
+
+An inventory fingerprint makes the usual call a single option read: measured at
+0.16 ms against a 191 ms page render.
 
 The derivation lives in PHP because that is the only place a WordPress hook can
 reach it; the installer delegates to the same code rather than keeping a second

--- a/templates/wp-coding-agents-source-reconcile.php
+++ b/templates/wp-coding-agents-source-reconcile.php
@@ -392,9 +392,48 @@ function wp_coding_agents_reconcile_on_change() {
 
 /**
  * A plugin the agent SCAFFOLDS fires none of the hooks above — no install, no
- * activation, just a directory appearing. That is the case this whole file
- * exists for, so the inventory is also checked on the site's regular heartbeat.
- * The hash comparison makes the usual outcome a single option read.
+ * activation, just a directory appearing. That is the case this file exists for,
+ * and the first version handled it with an hourly sweep.
+ *
+ * An hour is not a latency, it is a wall. An agent that writes a plugin and then
+ * cannot edit it until the next hour has to explain that to the person who asked
+ * for the plugin, which is the friction managed hosting exists to remove. Worse,
+ * it is unpredictable: sometimes instant, sometimes fifty-nine minutes, with no
+ * way for the agent to tell which.
+ *
+ * So the sweep is a backstop, not the mechanism. Two deterministic triggers do
+ * the real work.
+ *
+ * FIRST: WP-CLI, which is how a plugin actually gets scaffolded. `after_invoke`
+ * fires in the SAME command that created the directory, so the reconcile lands
+ * before the agent's next tool call — zero perceptible latency and no race.
+ */
+if ( class_exists( 'WP_CLI' ) && method_exists( 'WP_CLI', 'add_hook' ) ) {
+	foreach ( array( 'scaffold plugin', 'scaffold child-theme', 'plugin install', 'plugin delete', 'theme install', 'theme delete' ) as $wp_coding_agents_cli_cmd ) {
+		WP_CLI::add_hook(
+			'after_invoke:' . $wp_coding_agents_cli_cmd,
+			function () {
+				wp_coding_agents_reconcile_sources();
+			}
+		);
+	}
+	unset( $wp_coding_agents_cli_cmd );
+}
+
+/**
+ * SECOND: every WordPress bootstrap. The inventory hash makes the common case a
+ * single option read, so this is affordable on `init` — and it means a directory
+ * created by ANY means, including a bare mkdir from the agent's shell, is picked
+ * up by the very next WordPress request or wp-cli command. On an active agent
+ * that is seconds, not an hour, and it needs no cooperation from whatever
+ * created the directory.
+ */
+add_action( 'init', 'wp_coding_agents_reconcile_on_change', 5 );
+
+/**
+ * The sweep remains as a backstop for a site nobody is touching — where no
+ * request arrives to trigger the above — and is now the slow path rather than
+ * the only path.
  */
 add_action( 'wp_coding_agents_reconcile_cron', 'wp_coding_agents_reconcile_on_change' );
 add_action(

--- a/tests/source-reconcile.sh
+++ b/tests/source-reconcile.sh
@@ -156,12 +156,32 @@ echo ""
 echo "source-reconcile: wiring"
 
 # A scaffolded plugin fires none of the lifecycle hooks — no install, no
-# activation, just a directory appearing. That is the case this exists for, so
-# the scheduled sweep is not optional.
+# activation, just a directory appearing.
+#
+# The first version handled that with an hourly sweep, which is not a latency
+# but a wall: an agent that writes a plugin and cannot edit it for up to
+# fifty-nine minutes has to explain that to the person who asked for it, and
+# cannot tell them which of the two it will be. The sweep is now a backstop.
 tpl="$(cat "$TEMPLATE")"
 assert_contains "$tpl" "activated_plugin" "hooks plugin activation"
 assert_contains "$tpl" "upgrader_process_complete" "hooks installs and updates"
-assert_contains "$tpl" "wp_coding_agents_reconcile_cron" "schedules a sweep for scaffolded plugins"
+
+# WP-CLI is how a plugin actually gets scaffolded, and after_invoke fires in the
+# SAME command that created the directory — no race, no perceptible latency.
+assert_contains "$tpl" "after_invoke:" "hooks WP-CLI after_invoke"
+assert_contains "$tpl" "scaffold plugin" "covers the scaffold command specifically"
+
+# And every bootstrap, so a directory created by ANY means — including a bare
+# mkdir from the agent's shell — is picked up by the next request. Measured on
+# h44lacrosse.com: 0.16 ms against a 191 ms page render.
+assert_contains "$tpl" "add_action( 'init', 'wp_coding_agents_reconcile_on_change'" \
+  "reconciles on every bootstrap, not only on a timer"
+
+assert_contains "$tpl" "wp_coding_agents_reconcile_cron" "keeps the sweep as a backstop"
+
+# The hash check is what makes the init hook affordable; without it this would
+# be a filesystem scan in the hot path of every request.
+assert_contains "$tpl" "wp_coding_agents_inventory_hash" "the bootstrap path is hash-gated"
 
 # The shell must delegate, not re-derive: two implementations of the same safety
 # rule are free to drift, which is the failure this design removes.


### PR DESCRIPTION
The hourly sweep was the wrong instrument, and you were right that it's absurd on its face.

## The problem with what I shipped

A scaffolded plugin fires **no** WordPress lifecycle hook — no install, no activation, just a directory appearing. I covered that with an hourly sweep.

So the agent could write a plugin and be unable to edit it for up to 59 minutes, **with no way to tell the person who asked which it would be.** Sometimes instant, sometimes an hour. That's the friction managed hosting exists to remove, reintroduced by the mechanism meant to remove it.

## Two deterministic triggers

**WP-CLI `after_invoke`** — `wp scaffold plugin` is how a plugin actually gets created, and this fires in the *same command* that made the directory. The reconcile lands before the agent's next tool call: no race, no perceptible delay.

**Every WordPress bootstrap** (`init`, priority 5) — covers a directory created by *any* means, including a bare `mkdir` from the agent's shell, which no cooperative hook can catch. On an active agent the next request is seconds away.

The hourly sweep stays as a backstop for a site nobody is touching.

## The cost, measured not assumed

Putting a filesystem scan on `init` would be a worse bug than the one I'm fixing. So I measured it on h44:

```
inventory_hash:                    0.16 ms
full reconcile (unchanged path):   0.03 ms   (get_plugins() caches per-request)
homepage render:                 191    ms
```

**0.08% overhead.** The fingerprint short-circuit is what makes the bootstrap hook affordable — without it this wouldn't be defensible.

## Note

I did go looking for whether OpenCode re-reads `opencode.json` mid-session, since that would bound the latency regardless of how fast the reconcile is. Searching the bundled binary was a dead end and I stopped rather than burn time reverse-engineering it. It's worth confirming separately — if OpenCode snapshots config at session start, the remaining latency is a session boundary rather than anything this code controls.