### PR TITLE
fix: bound CLI dispatch process trees

### DIFF
--- a/bridges/cc-connect.sh
+++ b/bridges/cc-connect.sh
@@ -76,7 +76,6 @@ _cc_connect_register_cli_channel() {
     "cc-connect" \
     "$cmd" \
     '["send","--project","{recipient}","{message}"]' \
-    "true" \
     "600"
 }
 

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -237,7 +237,6 @@ _kimaki_register_cli_channel() {
     "kimaki" \
     "$cmd" \
     '["send","--channel","{recipient}","--prompt","{message}"]' \
-    "true" \
     "600" \
     "$env_json"
 }

--- a/bridges/telegram.sh
+++ b/bridges/telegram.sh
@@ -145,7 +145,6 @@ _telegram_register_cli_channel() {
     "telegram" \
     "$curl_bin" \
     "[\"-sS\",\"-X\",\"POST\",\"https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage\",\"--data-urlencode\",\"chat_id={recipient}\",\"--data-urlencode\",\"text={message}\"]" \
-    "true" \
     "60"
 }
 

--- a/lib/cli-channel.sh
+++ b/lib/cli-channel.sh
@@ -40,7 +40,7 @@
 #   cli_channel_mu_plugin_path                 — echo resolved file path
 #   cli_channel_ensure_mu_plugin_file          — create stub if missing
 #   cli_channel_register <name> <command> \
-#       <args_json> [detach] [timeout] \
+#       <args_json> [timeout] \
 #       [env_json]                             — upsert a bridge's block
 #   cli_channel_unregister <name>              — remove a bridge's block
 #
@@ -134,7 +134,6 @@ cli_channel_ensure_mu_plugin_file() {
  *   $channels['<name>'] = [
  *       'command' => '/absolute/path/to/cli',
  *       'args'    => [ 'send', '--channel', '{recipient}', '--prompt', '{message}' ],
- *       'detach'  => true,
  *       'timeout' => 600,
  *       'env'     => [ 'HOME' => '/home/<service-user>' ], // optional
  *   ];
@@ -185,7 +184,7 @@ PHP
 # Block render
 # ---------------------------------------------------------------------------
 
-# _cli_channel_render_block <name> <command> <args_json> <detach> <timeout> [env_json]
+# _cli_channel_render_block <name> <command> <args_json> <timeout> [env_json]
 #
 # Print the marker-delimited PHP block for a single bridge, including
 # surrounding BEGIN/END markers, indented to match the scaffold's filter
@@ -194,10 +193,9 @@ PHP
 # the caller has already constructed.
 #
 # When env_json is a non-empty JSON object, an 'env' => [ ... ] line is added
-# after 'timeout'. Omitting it (empty arg) keeps the block byte-identical to
-# the historical four-key form, so existing channels without env are unchanged.
+# after 'timeout'.
 _cli_channel_render_block() {
-  local name="$1" command="$2" args_json="$3" detach="$4" timeout="$5" env_json="${6:-}"
+  local name="$1" command="$2" args_json="$3" timeout="$4" env_json="${5:-}"
   local esc_name esc_command esc_args env_line=""
   esc_name=$(_cli_channel_php_escape "$name")
   esc_command=$(_cli_channel_php_escape "$command")
@@ -219,7 +217,6 @@ _cli_channel_render_block() {
     \$channels['${esc_name}'] = [
         'command' => '${esc_command}',
         'args'    => ${esc_args},
-        'detach'  => ${detach},
         'timeout' => ${timeout},${env_line}
     ];
     // END bridge:${esc_name}
@@ -302,21 +299,19 @@ PY
 # Register / unregister
 # ---------------------------------------------------------------------------
 
-# cli_channel_register <name> <command> <args_json> [detach] [timeout] [env_json]
+# cli_channel_register <name> <command> <args_json> [timeout] [env_json]
 #
 # Upsert <name>'s block in the mu-plugin file. Idempotent: re-running with the
 # same arguments leaves the file unchanged; re-running with different
 # arguments replaces just <name>'s block. Other bridges' blocks are preserved.
 #
 # Defaults:
-#   detach   — "true"  (CLI bridges dispatch fire-and-forget by default)
 #   timeout  — "600"   (10 minutes; matches DMC's default per #412)
-#   env_json — ""      (no 'env' key emitted; the four-key block is unchanged)
+#   env_json — ""      (no 'env' key emitted)
 cli_channel_register() {
   local name="$1" command="$2" args_json="$3"
-  local detach="${4:-true}"
-  local timeout="${5:-600}"
-  local env_json="${6:-}"
+  local timeout="${4:-600}"
+  local env_json="${5:-}"
 
   if [ -z "$name" ] || [ -z "$command" ] || [ -z "$args_json" ]; then
     warn "  cli_channel_register: missing required args (name=$name command=$command args=$args_json)"
@@ -332,7 +327,7 @@ cli_channel_register() {
   cli_channel_ensure_mu_plugin_file || return 1
 
   local new_block
-  new_block=$(_cli_channel_render_block "$name" "$command" "$args_json" "$detach" "$timeout" "$env_json")
+  new_block=$(_cli_channel_render_block "$name" "$command" "$args_json" "$timeout" "$env_json")
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would register CLI channel '$name' in $file"

--- a/templates/wp-coding-agents-cli-transport.php
+++ b/templates/wp-coding-agents-cli-transport.php
@@ -102,13 +102,8 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Registry', false ) ) {
 				$normalized_args[] = $arg;
 			}
 
-			$detach = $config['detach'] ?? true;
-			if ( ! is_bool( $detach ) ) {
-				$detach = (bool) $detach;
-			}
-
 			$timeout = $config['timeout'] ?? 30;
-			if ( ! is_int( $timeout ) || $timeout < 0 ) {
+			if ( ! is_int( $timeout ) || $timeout < 1 ) {
 				$timeout = 30;
 			}
 
@@ -132,7 +127,6 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Registry', false ) ) {
 			return array(
 				'command' => $command,
 				'args'    => $normalized_args,
-				'detach'  => $detach,
 				'timeout' => $timeout,
 				'env'     => $normalized_env,
 				'cwd'     => $cwd,
@@ -270,6 +264,8 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 	 */
 	class WpCodingAgents_Cli_Channel_Transport {
 		private const DEFAULT_TIMEOUT_SECONDS = 30;
+		private const POLL_INTERVAL_MICROSECONDS = 20000;
+		private const TERMINATION_GRACE_MICROSECONDS = 200000;
 
 		/** Register the transport handler filter. */
 		public static function register(): void {
@@ -327,109 +323,12 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 			$command_args = WpCodingAgents_Cli_Channel_Registry::substitute_tokens( $config['args'], $input );
 			array_unshift( $command_args, $config['command'] );
 
-			$detach = (bool) ( $config['detach'] ?? true );
 			$timeout = isset( $config['timeout'] ) && is_int( $config['timeout'] ) ? $config['timeout'] : self::DEFAULT_TIMEOUT_SECONDS;
 			$cwd     = isset( $config['cwd'] ) && is_string( $config['cwd'] ) && '' !== $config['cwd'] ? $config['cwd'] : null;
 			$configured_env = isset( $config['env'] ) && is_array( $config['env'] ) ? $config['env'] : array();
 			$env            = self::build_env_map( $configured_env );
 
-			if ( $detach ) {
-				return self::dispatch_detached( $channel, $recipient, $command_args, $cwd, $env, $configured_env );
-			}
-
 			return self::dispatch_sync( $channel, $recipient, $command_args, $cwd, $env, $timeout, $configured_env );
-		}
-
-		/**
-		 * @param array<int, string>         $argv Command argv.
-		 * @param array<string, string>|null $env  Environment map.
-		 * @return array<string, mixed>|WP_Error
-		 */
-		private static function dispatch_detached( string $channel, string $recipient, array $argv, ?string $cwd, ?array $env, array $configured_env ) {
-			// Capture stderr so an early-exiting child can report WHY it died.
-			// proc_close() below waits for the child either way (it always has —
-			// "detached" here means new session, not fire-and-forget), so the
-			// exit code is available for free. Discarding it caused scheduled
-			// dispatches to be marked delivered when the CLI crashed at startup
-			// (ENOSPC, bad binary path, auth failure). See data-machine-code#643.
-			$stderr_file = tempnam( sys_get_temp_dir(), 'wpca-dispatch-' );
-			$stderr_spec = false !== $stderr_file
-				? array( 'file', $stderr_file, 'w' )
-				: array( 'file', '/dev/null', 'w' );
-
-			$descriptors = array(
-				0 => array( 'file', '/dev/null', 'r' ),
-				1 => array( 'file', '/dev/null', 'w' ),
-				2 => $stderr_spec,
-			);
-
-			$started_at = microtime( true );
-			$process    = self::open_process( $argv, $descriptors, $cwd, $env, true );
-			if ( $process instanceof WP_Error ) {
-				if ( false !== $stderr_file ) {
-					@unlink( $stderr_file );
-				}
-				return $process;
-			}
-
-			$pid       = null;
-			$exit_code = null;
-			$status    = proc_get_status( $process );
-			if ( is_array( $status ) && isset( $status['pid'] ) ) {
-				$pid = (int) $status['pid'];
-			}
-			// exitcode is only valid the first time running flips false.
-			if ( is_array( $status ) && false === ( $status['running'] ?? true ) ) {
-				$exit_code = isset( $status['exitcode'] ) ? (int) $status['exitcode'] : null;
-			}
-
-			$close_code = proc_close( $process );
-			if ( null === $exit_code && is_int( $close_code ) && -1 !== $close_code ) {
-				$exit_code = $close_code;
-			}
-
-			$stderr = '';
-			if ( false !== $stderr_file ) {
-				$raw = @file_get_contents( $stderr_file );
-				if ( is_string( $raw ) ) {
-					$stderr = trim( $raw );
-				}
-				@unlink( $stderr_file );
-			}
-
-			$duration_ms = (int) round( ( microtime( true ) - $started_at ) * 1000 );
-
-			if ( null !== $exit_code && 0 !== $exit_code ) {
-				$stderr = self::sanitize_output( $stderr, $configured_env );
-				return new WP_Error(
-					'wp_coding_agents_cli_dispatch_exit_nonzero',
-					sprintf(
-						'CLI dispatch process exited with code %d after %dms.',
-						$exit_code,
-						$duration_ms
-					),
-					array(
-						'channel'     => $channel,
-						'recipient'   => $recipient,
-						'exit_code'   => $exit_code,
-						'duration_ms' => $duration_ms,
-						'stderr'      => $stderr,
-					)
-				);
-			}
-
-			return array(
-				'sent'       => true,
-				'channel'    => $channel,
-				'recipient'  => $recipient,
-				'message_id' => null !== $pid ? (string) $pid : null,
-				'metadata'   => array(
-					'mode'        => 'detached',
-					'pid'         => $pid,
-					'exit_code'   => $exit_code,
-					'duration_ms' => $duration_ms,
-				),
-			);
 		}
 
 		/**
@@ -446,7 +345,7 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 
 			$pipes      = array();
 			$started_at = microtime( true );
-			$process    = self::open_process( $argv, $descriptors, $cwd, $env, false, $pipes );
+			$process    = self::open_process( $argv, $descriptors, $cwd, $env, $pipes );
 			if ( $process instanceof WP_Error ) {
 				return $process;
 			}
@@ -461,60 +360,44 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 				stream_set_blocking( $pipes[2], false );
 			}
 
-			$stdout    = '';
-			$stderr    = '';
-			$timed_out = false;
-			$deadline  = $started_at + max( 1, $timeout );
+			$stdout       = '';
+			$stderr       = '';
+			$timed_out    = false;
+			$exit_code    = null;
+			$deadline     = $started_at + $timeout;
+			$pid          = null;
+			$first_status = proc_get_status( $process );
+			if ( is_array( $first_status ) && isset( $first_status['pid'] ) ) {
+				$pid = (int) $first_status['pid'];
+			}
+			$status = $first_status;
 
 			while ( true ) {
-				$status = proc_get_status( $process );
-
-				if ( isset( $pipes[1] ) && is_resource( $pipes[1] ) ) {
-					$chunk = stream_get_contents( $pipes[1] );
-					if ( is_string( $chunk ) && '' !== $chunk ) {
-						$stdout .= $chunk;
-					}
-				}
-				if ( isset( $pipes[2] ) && is_resource( $pipes[2] ) ) {
-					$chunk = stream_get_contents( $pipes[2] );
-					if ( is_string( $chunk ) && '' !== $chunk ) {
-						$stderr .= $chunk;
-					}
-				}
+				self::drain_output( $pipes, $stdout, $stderr );
 
 				if ( ! is_array( $status ) || false === $status['running'] ) {
+					if ( is_array( $status ) && isset( $status['exitcode'] ) && -1 !== (int) $status['exitcode'] ) {
+						$exit_code = (int) $status['exitcode'];
+					}
 					break;
 				}
 				if ( microtime( true ) >= $deadline ) {
 					$timed_out = true;
-					proc_terminate( $process, 15 );
-					usleep( 100000 );
-					$status = proc_get_status( $process );
-					if ( is_array( $status ) && true === $status['running'] ) {
-						proc_terminate( $process, 9 );
-					}
+					self::terminate_process_tree( $process, $pid, $pipes, $stdout, $stderr );
 					break;
 				}
 
-				usleep( 20000 );
+				usleep( self::POLL_INTERVAL_MICROSECONDS );
+				$status = proc_get_status( $process );
 			}
 
-			foreach ( array( 1, 2 ) as $fd ) {
-				if ( ! isset( $pipes[ $fd ] ) || ! is_resource( $pipes[ $fd ] ) ) {
-					continue;
-				}
-				$chunk = stream_get_contents( $pipes[ $fd ] );
-				if ( is_string( $chunk ) && '' !== $chunk ) {
-					if ( 1 === $fd ) {
-						$stdout .= $chunk;
-					} else {
-						$stderr .= $chunk;
-					}
-				}
-				fclose( $pipes[ $fd ] );
-			}
+			self::drain_output( $pipes, $stdout, $stderr );
+			self::close_output_pipes( $pipes );
 
-			$exit_code   = proc_close( $process );
+			$close_code = proc_close( $process );
+			if ( null === $exit_code && is_int( $close_code ) && -1 !== $close_code ) {
+				$exit_code = $close_code;
+			}
 			$duration_ms = (int) round( ( microtime( true ) - $started_at ) * 1000 );
 			$stdout      = self::sanitize_output( $stdout, $configured_env );
 			$stderr      = self::sanitize_output( $stderr, $configured_env );
@@ -523,8 +406,9 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 				return new WP_Error( 'wp_coding_agents_cli_dispatch_timeout', sprintf( 'CLI channel "%s" exceeded the %d second timeout.', $channel, $timeout ), array( 'channel' => $channel, 'recipient' => $recipient, 'stdout' => $stdout, 'stderr' => $stderr, 'duration_ms' => $duration_ms ) );
 			}
 
-			if ( 0 !== $exit_code ) {
-				return new WP_Error( 'wp_coding_agents_cli_dispatch_nonzero_exit', sprintf( 'CLI channel "%s" exited with code %d.', $channel, $exit_code ), array( 'channel' => $channel, 'recipient' => $recipient, 'exit_code' => $exit_code, 'stdout' => $stdout, 'stderr' => $stderr, 'duration_ms' => $duration_ms ) );
+			if ( null === $exit_code || 0 !== $exit_code ) {
+				$exit_description = null === $exit_code ? 'without a readable exit code' : sprintf( 'with code %d', $exit_code );
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_nonzero_exit', sprintf( 'CLI channel "%s" exited %s.', $channel, $exit_description ), array( 'channel' => $channel, 'recipient' => $recipient, 'exit_code' => $exit_code, 'stdout' => $stdout, 'stderr' => $stderr, 'duration_ms' => $duration_ms ) );
 			}
 
 			return array(
@@ -533,7 +417,8 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 				'recipient'  => $recipient,
 				'message_id' => null,
 				'metadata'   => array(
-					'mode'        => 'sync',
+					'mode'        => 'synchronous-session-isolated',
+					'pid'         => $pid,
 					'exit_code'   => $exit_code,
 					'duration_ms' => $duration_ms,
 				),
@@ -547,22 +432,123 @@ if ( ! class_exists( 'WpCodingAgents_Cli_Channel_Transport', false ) ) {
 		 * @param array<int, resource>       $pipes       Output pipes.
 		 * @return resource|WP_Error
 		 */
-		private static function open_process( array $argv, array $descriptors, ?string $cwd, ?array $env, bool $detached, array &$pipes = array() ) {
+		private static function open_process( array $argv, array $descriptors, ?string $cwd, ?array $env, array &$pipes = array() ) {
 			if ( ! function_exists( 'proc_open' ) ) {
 				return new WP_Error( 'wp_coding_agents_cli_dispatch_no_proc_open', 'proc_open is not available on this host.' );
 			}
-
-			$options = array();
-			if ( $detached ) {
-				$options['start_new_session'] = true;
+			if ( ! function_exists( 'posix_kill' ) ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_no_posix_kill', 'The POSIX process extension is required for bounded CLI process-tree cleanup.' );
 			}
 
-			$process = @proc_open( $argv, $descriptors, $pipes, $cwd, $env, $options );
+			$session_launcher = self::find_session_launcher();
+			if ( null === $session_launcher ) {
+				return new WP_Error( 'wp_coding_agents_cli_dispatch_no_session_launcher', 'A POSIX setsid executable is required for bounded CLI process-tree cleanup.' );
+			}
+
+			array_unshift( $argv, $session_launcher, '--' );
+			$process = @proc_open( $argv, $descriptors, $pipes, $cwd, $env );
 			if ( ! is_resource( $process ) ) {
 				return new WP_Error( 'wp_coding_agents_cli_dispatch_spawn_failed', 'Failed to spawn CLI process.' );
 			}
 
 			return $process;
+		}
+
+		/** Locate the POSIX session launcher without invoking a shell. */
+		private static function find_session_launcher(): ?string {
+			$candidates = array( '/usr/bin/setsid', '/bin/setsid' );
+			$path       = getenv( 'PATH' );
+			if ( is_string( $path ) ) {
+				foreach ( explode( PATH_SEPARATOR, $path ) as $directory ) {
+					if ( '' !== $directory ) {
+						$candidates[] = rtrim( $directory, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . 'setsid';
+					}
+				}
+			}
+
+			foreach ( array_unique( $candidates ) as $candidate ) {
+				if ( is_file( $candidate ) && is_executable( $candidate ) ) {
+					return $candidate;
+				}
+			}
+
+			return null;
+		}
+
+		/**
+		 * Drain currently available child output without blocking.
+		 *
+		 * @param array<int, resource> $pipes  Process pipes.
+		 * @param string               $stdout Collected standard output.
+		 * @param string               $stderr Collected standard error.
+		 */
+		private static function drain_output( array $pipes, string &$stdout, string &$stderr ): void {
+			foreach ( array( 1, 2 ) as $fd ) {
+				if ( ! isset( $pipes[ $fd ] ) || ! is_resource( $pipes[ $fd ] ) ) {
+					continue;
+				}
+				$chunk = stream_get_contents( $pipes[ $fd ] );
+				if ( is_string( $chunk ) && '' !== $chunk ) {
+					if ( 1 === $fd ) {
+						$stdout .= $chunk;
+					} else {
+						$stderr .= $chunk;
+					}
+				}
+			}
+		}
+
+		/** @param array<int, resource> $pipes Process pipes. */
+		private static function close_output_pipes( array $pipes ): void {
+			foreach ( array( 1, 2 ) as $fd ) {
+				if ( isset( $pipes[ $fd ] ) && is_resource( $pipes[ $fd ] ) ) {
+					fclose( $pipes[ $fd ] );
+				}
+			}
+		}
+
+		/**
+		 * Terminate the isolated process group, escalating after a short grace.
+		 *
+		 * @param resource             $process Child process resource.
+		 * @param array<int, resource> $pipes   Process pipes.
+		 */
+		private static function terminate_process_tree( $process, ?int $pid, array $pipes, string &$stdout, string &$stderr ): void {
+			self::signal_process_tree( $process, $pid, 15 );
+			$grace_deadline = microtime( true ) + ( self::TERMINATION_GRACE_MICROSECONDS / 1000000 );
+			while ( microtime( true ) < $grace_deadline ) {
+				self::drain_output( $pipes, $stdout, $stderr );
+				if ( ! self::process_tree_is_running( $process, $pid ) ) {
+					return;
+				}
+				usleep( self::POLL_INTERVAL_MICROSECONDS );
+			}
+
+			self::signal_process_tree( $process, $pid, 9 );
+			$kill_deadline = microtime( true ) + ( self::TERMINATION_GRACE_MICROSECONDS / 1000000 );
+			while ( microtime( true ) < $kill_deadline && self::process_tree_is_running( $process, $pid ) ) {
+				self::drain_output( $pipes, $stdout, $stderr );
+				usleep( self::POLL_INTERVAL_MICROSECONDS );
+			}
+		}
+
+		/** @param resource $process Child process resource. */
+		private static function signal_process_tree( $process, ?int $pid, int $signal ): void {
+			if ( null !== $pid && $pid > 0 && @posix_kill( -$pid, $signal ) ) {
+				return;
+			}
+
+			proc_terminate( $process, $signal );
+		}
+
+		/** @param resource $process Child process resource. */
+		private static function process_tree_is_running( $process, ?int $pid ): bool {
+			if ( null !== $pid && $pid > 0 ) {
+				return @posix_kill( -$pid, 0 );
+			}
+
+			$status = proc_get_status( $process );
+			return is_array( $status ) && true === ( $status['running'] ?? false );
 		}
 
 		/**

--- a/tests/cli-channel-binary-path.sh
+++ b/tests/cli-channel-binary-path.sh
@@ -74,7 +74,7 @@ registered_command() {
 import sys
 with open(sys.argv[1], 'rb') as handle:
     parts = [p.decode() for p in handle.read().split(b'\0') if p]
-# cli_channel_register "kimaki" "<command>" "<args_json>" "<detach>" "<timeout>"
+# cli_channel_register "kimaki" "<command>" "<args_json>" "<timeout>"
 print(parts[1] if len(parts) > 1 else '')
 PY
 }

--- a/tests/cli-channel-perms.sh
+++ b/tests/cli-channel-perms.sh
@@ -97,6 +97,12 @@ echo "==> register kimaki (fresh scaffold, umask 077)"
 )
 assert_mode_0664 "$MU_FILE" "fresh scaffold lands as 0664 under umask 077"
 assert_group "$MU_FILE" "fresh scaffold inherits parent dir group"
+if grep -q "'detach'" "$MU_FILE"; then
+  echo "  FAIL generated channel block preserves misleading detach mode"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   generated channel block declares only bounded synchronous execution"
+fi
 
 # --- 2. Sibling register exercises mktemp + mv path; self-heal from 0600 ---
 echo "==> simulate legacy 0600 file and verify self-heal on next register"

--- a/tests/kimaki-agent-fallback.sh
+++ b/tests/kimaki-agent-fallback.sh
@@ -54,7 +54,6 @@ expected = [
     'kimaki',
     kimaki_bin,
     '["send","--channel","{recipient}","--prompt","{message}"]',
-    'true',
     '600',
 ]
 if actual != expected:

--- a/tests/kimaki-multi-instance.sh
+++ b/tests/kimaki-multi-instance.sh
@@ -172,7 +172,7 @@ KIMAKI_LOCK_PORT=6543
 AGENT_SLUG=site-b
 
 [ "$(_kimaki_instance_suffix)" = -site-b ]
-cli_channel_register() { printf '%s\n%s\n' "$2" "$6"; }
+cli_channel_register() { printf '%s\n%s\n' "$2" "$5"; }
 channel_registration=$(LOCAL_MODE=false SERVICE_USER=opencode SERVICE_HOME=/home/opencode KIMAKI_DATA_DIR=/home/opencode/.kimaki-site-b KIMAKI_BIN=/usr/bin/kimaki _kimaki_register_cli_channel)
 echo "$channel_registration" | grep -q '^/usr/local/bin/wp-coding-agents-kimaki-site-b-dispatch$'
 echo "$channel_registration" | grep -q '"HOME":"/home/opencode","KIMAKI_DATA_DIR":"/home/opencode/.kimaki-site-b"'

--- a/tests/smoke-cli-transport.php
+++ b/tests/smoke-cli-transport.php
@@ -111,6 +111,8 @@ $valid_entry = array(
 );
 $normalized  = WpCodingAgents_Cli_Channel_Registry::normalize_entry( $valid_entry );
 $assert( 'valid entry normalizes', is_array( $normalized ) && $echo_bin === $normalized['command'] );
+$assert( 'legacy detach key is not part of normalized contract', is_array( $normalized ) && ! array_key_exists( 'detach', $normalized ) );
+$assert( 'non-positive timeout resets to bounded default', 30 === WpCodingAgents_Cli_Channel_Registry::normalize_entry( array( 'command' => $echo_bin, 'timeout' => 0 ) )['timeout'] );
 $assert( 'missing command is rejected', null === WpCodingAgents_Cli_Channel_Registry::normalize_entry( array( 'args' => array() ) ) );
 $assert( 'non-string arg is rejected', null === WpCodingAgents_Cli_Channel_Registry::normalize_entry( array( 'command' => $echo_bin, 'args' => array( 123 ) ) ) );
 
@@ -205,6 +207,17 @@ $safe_fixture  = 'token count: 5; secret sauce; Basic skills; https://example.co
 $safe_redacted = WpCodingAgents_Cli_Output_Redactor::redact( $safe_fixture );
 $assert( 'non-secret prose resists false positives', $safe_fixture === $safe_redacted );
 
+$tree_pid_file = tempnam( sys_get_temp_dir(), 'wpca-tree-pid-' );
+if ( false !== $tree_pid_file ) {
+	@unlink( $tree_pid_file );
+}
+$tree_parent_code = false !== $tree_pid_file
+	? '$descriptors = array( 0 => array( "file", "/dev/null", "r" ), 1 => array( "file", "/dev/null", "w" ), 2 => array( "file", "/dev/null", "w" ) );'
+		. '$child = proc_open( array( PHP_BINARY, "-r", "while ( true ) { usleep( 100000 ); }" ), $descriptors, $pipes );'
+		. '$status = proc_get_status( $child ); file_put_contents( ' . var_export( $tree_pid_file, true ) . ', (string) $status["pid"] );'
+		. 'while ( true ) { usleep( 100000 ); }'
+	: '';
+
 $wp_coding_agents_test_options = array(
 	'wp_coding_agents_cli_channels' => array(
 		'sync-echo'     => array(
@@ -225,6 +238,11 @@ $wp_coding_agents_test_options = array(
 			'detach'  => false,
 			'timeout' => 5,
 		),
+		'startup-fail'  => array(
+			'command' => '/definitely/missing/wpca-cli',
+			'args'    => array(),
+			'timeout' => 5,
+		),
 		'sync-sleep'    => array(
 			'command' => $sleep_bin,
 			'args'    => array( '5' ),
@@ -235,6 +253,16 @@ $wp_coding_agents_test_options = array(
 			'command' => $php_bin,
 			'args'    => array( '-r', 'fwrite(STDERR, "refresh_token=timeout-secret\\n"); sleep(5);' ),
 			'detach'  => false,
+			'timeout' => 1,
+		),
+		'long-running-success' => array(
+			'command' => $php_bin,
+			'args'    => array( '-r', 'usleep( 1100000 ); fwrite( STDOUT, "completed" );' ),
+			'timeout' => 3,
+		),
+		'tree-timeout' => array(
+			'command' => $php_bin,
+			'args'    => array( '-r', $tree_parent_code ),
 			'timeout' => 1,
 		),
 		'detached-true' => array(
@@ -328,10 +356,19 @@ if ( is_array( $ok ) ) {
 }
 
 $assert( 'sync true succeeds', is_array( WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-true', 'recipient' => 'r', 'message' => 'm' ) ) ) );
+$assert( 'successful completion is idempotent', is_array( WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-true', 'recipient' => 'r', 'message' => 'm' ) ) ) );
 $fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-false', 'recipient' => 'r', 'message' => 'm' ) );
 $assert( 'nonzero exit returns WP_Error', $fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_nonzero_exit' === $fail->get_error_code() );
+$startup_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'startup-fail', 'recipient' => 'r', 'message' => 'm' ) );
+$startup_data = $startup_fail instanceof WP_Error ? (array) $startup_fail->get_error_data() : array();
+$assert( 'startup failure returns WP_Error', $startup_fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_nonzero_exit' === $startup_fail->get_error_code() );
+$assert( 'startup failure preserves stderr diagnostics', isset( $startup_data['stderr'] ) && '' !== $startup_data['stderr'] );
+$long_running = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'long-running-success', 'recipient' => 'r', 'message' => 'm' ) );
+$assert( 'long-running child succeeds within timeout', is_array( $long_running ) && 'synchronous-session-isolated' === ( $long_running['metadata']['mode'] ?? null ) );
+$timeout_started = microtime( true );
 $timed = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'sync-sleep', 'recipient' => 'r', 'message' => 'm' ) );
 $assert( 'timeout returns WP_Error', $timed instanceof WP_Error && 'wp_coding_agents_cli_dispatch_timeout' === $timed->get_error_code() );
+$assert( 'timeout return is bounded', microtime( true ) - $timeout_started < 3 );
 $timed_secret = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'timeout-secret', 'recipient' => 'r', 'message' => 'm' ) );
 $timed_data   = $timed_secret instanceof WP_Error ? (array) $timed_secret->get_error_data() : array();
 $assert( 'timeout structured stderr is redacted', isset( $timed_data['stderr'] ) && ! str_contains( (string) $timed_data['stderr'], 'timeout-secret' ) && str_contains( (string) $timed_data['stderr'], '[redacted]' ) );
@@ -339,17 +376,35 @@ $unknown = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'u
 $assert( 'execute unknown returns WP_Error', $unknown instanceof WP_Error );
 
 $detached = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-true', 'recipient' => 'r', 'message' => 'm' ) );
-$assert( 'detached returns array', is_array( $detached ) && true === ( $detached['sent'] ?? false ) );
+$assert( 'legacy detach config runs synchronously', is_array( $detached ) && 'synchronous-session-isolated' === ( $detached['metadata']['mode'] ?? null ) );
 
-// Regression: a detached child that exits non-zero must fail the dispatch
-// instead of being reported as delivered (data-machine-code#643).
+// Regression: a legacy detach key must not bypass exit acknowledgement.
 $detached_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-false', 'recipient' => 'r', 'message' => 'm' ) );
-$assert( 'detached early exit returns WP_Error', $detached_fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_exit_nonzero' === $detached_fail->get_error_code() );
+$assert( 'legacy detach early exit returns WP_Error', $detached_fail instanceof WP_Error && 'wp_coding_agents_cli_dispatch_nonzero_exit' === $detached_fail->get_error_code() );
 
 $detached_secret = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'detached-secret', 'recipient' => 'r', 'message' => 'm' ) );
 $detached_data   = $detached_secret instanceof WP_Error ? (array) $detached_secret->get_error_data() : array();
-$assert( 'detached error message omits child output', $detached_secret instanceof WP_Error && ! str_contains( $detached_secret->get_error_message(), 'detached-secret-token' ) );
-$assert( 'detached structured stderr is redacted', isset( $detached_data['stderr'] ) && ! str_contains( (string) $detached_data['stderr'], 'detached-secret-token' ) && str_contains( (string) $detached_data['stderr'], '[redacted]' ) );
+$assert( 'legacy detach error message omits child output', $detached_secret instanceof WP_Error && ! str_contains( $detached_secret->get_error_message(), 'detached-secret-token' ) );
+$assert( 'legacy detach structured stderr is redacted', isset( $detached_data['stderr'] ) && ! str_contains( (string) $detached_data['stderr'], 'detached-secret-token' ) && str_contains( (string) $detached_data['stderr'], '[redacted]' ) );
+
+if ( false === $tree_pid_file || ! function_exists( 'posix_kill' ) ) {
+	$assert( 'process-tree cleanup prerequisites available', false );
+} else {
+	$tree_timeout = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'tree-timeout', 'recipient' => 'r', 'message' => 'm' ) );
+	$assert( 'process-tree fixture times out', $tree_timeout instanceof WP_Error && 'wp_coding_agents_cli_dispatch_timeout' === $tree_timeout->get_error_code() );
+	$tree_pid = is_file( $tree_pid_file ) ? (int) file_get_contents( $tree_pid_file ) : 0;
+	$tree_running = $tree_pid > 0;
+	for ( $attempt = 0; $tree_running && $attempt < 50; $attempt++ ) {
+		$stat = @file_get_contents( '/proc/' . $tree_pid . '/stat' );
+		$fields = is_string( $stat ) ? explode( ' ', $stat ) : array();
+		$tree_running = @posix_kill( $tree_pid, 0 ) && 'Z' !== ( $fields[2] ?? null );
+		if ( $tree_running ) {
+			usleep( 20000 );
+		}
+	}
+	$assert( 'timeout terminates descendant process', $tree_pid > 0 && ! $tree_running );
+	@unlink( $tree_pid_file );
+}
 
 $diagnostic_fail = WpCodingAgents_Cli_Channel_Transport::execute( array( 'channel' => 'diagnostics-fail', 'recipient' => 'r', 'message' => 'm' ) );
 $diagnostic_data = $diagnostic_fail instanceof WP_Error ? (array) $diagnostic_fail->get_error_data() : array();


### PR DESCRIPTION
## Summary

- model every CLI dispatch as acknowledged synchronous, session-isolated execution instead of preserving a misleading detach path
- enforce positive timeouts and terminate the complete isolated process group with SIGTERM followed by bounded SIGKILL escalation
- update the owning channel generator and deterministic fixtures so new registrations no longer emit `detach`

## Execution model

The transport now has one execution path. It starts the configured argv without a shell under `setsid`, waits for acknowledged completion, and reports `metadata.mode` as `synchronous-session-isolated`. This matches the transport's actual delivery contract: success is returned only after a zero exit, while startup and runtime failures remain observable.

Existing installed registry entries that contain `detach` remain compatible: normalization ignores the legacy key and executes them through the same bounded synchronous path. Upgrade/setup rewrites integration-owned generated channel blocks without `detach`.

## Timeout and process-tree semantics

- non-positive or invalid timeout values normalize to the 30-second default
- installer-generated channels retain their explicit 60/600-second bounds
- each command is launched as its own POSIX session/process group using an argv-safe `setsid` executable
- timeout sends SIGTERM to the process group, waits a bounded 200ms grace period, then sends SIGKILL and performs one final bounded cleanup wait
- hosts without `posix_kill` or `setsid` fail before dispatch with a specific startup diagnostic rather than running without enforceable tree cleanup

## Diagnostics and compatibility

Stdout and stderr are drained non-blockingly while the process runs. Startup failures, non-zero exits, timeouts, exit codes, duration, channel, and recipient remain available through structured results. Child output is redacted before truncation so configured environment values, credential assignments, authorization headers, cookies, bearer tokens, and URL credentials do not cross the diagnostic boundary.

The generic transport remains vendor-neutral. Vendor-specific values stay in integration-owned bridge configuration, and no production plugin files are changed.

## Tests

- full `tests/*.sh` integration/install/upgrade suite exercised; #342-affected fixture regressions pass after updating the generated channel signature
- `php tests/smoke-cli-transport.php`
- all `tests/*.mjs` suites with Bun
- all tracked PHP files pass `php -l`
- all tracked shell files pass `bash -n` and ShellCheck
- `homeboy review audit --profile architecture --changed-since origin/main`: no introduced findings
- generated transport byte-equivalence, ownership, permissions, bridge registration, install, upgrade, and multi-instance fixtures pass
- lifecycle coverage includes success, repeated/idempotent completion, long-running success, hung timeout, bounded return, startup failure, early non-zero exit, redacted diagnostics, legacy detach compatibility, and descendant process-tree cleanup

PHPUnit, PHPCS, and PHPStan have no repository configuration or installed binary in this shell-based project. Homeboy likewise reports no linked lint/test/build extension for this component. The full shell suite still prints the pre-existing late `source-mode.sh` assertions tracked by #344; that harness currently exits zero and is unrelated to this change.

Closes #342