### PR TITLE
Project Agents API subagents for OpenCode

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Run tests/opencode-wrapper-removal.sh
         run: ./tests/opencode-wrapper-removal.sh
 
+  opencode-subagents:
+    name: Data Machine graph OpenCode subagents (#355)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/opencode-subagents.sh
+        run: bash tests/opencode-subagents.sh
+
   managed-skill-targets:
     name: managed skill target deduplication (#306)
     runs-on: ubuntu-latest

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -588,6 +588,7 @@ recompose_agents_md_for_homeboy() {
   # correct file the main compose phase just wrote.
   if (cd "$SITE_PATH" && wp_run_as_service_user datamachine memory compose AGENTS.md >/dev/null 2>&1); then
     log "AGENTS.md recomposed after Homeboy availability sync."
+    opencode_project_subagents
   else
     homeboy_handle_failure "Could not recompose AGENTS.md after Homeboy availability sync."
   fi

--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Project Data Machine's persisted portable agent graph for OpenCode.
+
+opencode_project_subagents() {
+  [ "${DRY_RUN:-false}" = true ] && return 0
+  local runtime has_opencode=false
+  for runtime in "${DETECTED_RUNTIMES[@]:-}"; do
+    [ "$runtime" = opencode ] && has_opencode=true
+  done
+  [ "$has_opencode" = true ] || [ "${RUNTIME:-}" = opencode ] || return 0
+  [ -n "${AGENT_SLUG:-}" ] || return 0
+  [ -f "$SITE_PATH/wp-config.php" ] || return 0
+  [ -f "$SITE_PATH/opencode.json" ] || return 0
+
+  local graph_helper projector agent_json
+  graph_helper="$SCRIPT_DIR/lib/read-opencode-subagent-graph.php"
+  projector="$SCRIPT_DIR/lib/project-opencode-subagents.py"
+  [ -f "$graph_helper" ] || { warn "OpenCode subagent graph reader not found: $graph_helper"; return 1; }
+  [ -f "$projector" ] || { warn "OpenCode subagent projector not found: $projector"; return 1; }
+
+  # The Agents API registry owns child topology. Data Machine owns the
+  # registered identity files and declared skill artifacts used by the reader.
+  agent_json="$(wp_cmd eval-file "$graph_helper" -- "$AGENT_SLUG" 2>/dev/null)" || {
+    warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
+    return 1
+  }
+  local source
+  source="$(mktemp)"
+  printf '%s' "$agent_json" > "$source"
+  local before after
+  before="$(tar -cf - -C "$SITE_PATH" opencode.json .opencode 2>/dev/null | shasum || true)"
+  if ! python3 "$projector" "$source" "$SITE_PATH"; then
+    rm -f "$source"
+    return 1
+  fi
+  rm -f "$source"
+  after="$(tar -cf - -C "$SITE_PATH" opencode.json .opencode 2>/dev/null | shasum || true)"
+  if [ "$before" != "$after" ]; then
+    if [ -n "${UPDATED_ITEMS+x}" ]; then
+      UPDATED_ITEMS+=("OpenCode subagent graph (restart OpenCode to load changes)")
+    fi
+    warn "OpenCode subagent graph changed. Restart OpenCode; it does not hot-reload agent files or task permissions."
+  fi
+}

--- a/lib/project-opencode-subagents.py
+++ b/lib/project-opencode-subagents.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Safely project a Data Machine coordinator graph into OpenCode files."""
+
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+SENTINEL = "wp-coding-agents-opencode-subagents-v2"
+MANIFEST_NAME = ".wp-coding-agents-subagents.json"
+SLUG = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+ACTIONS = {"allow", "deny", "ask"}
+OPENCODE_ACTIONS = {"read", "edit", "glob", "grep", "bash", "task", "skill", "lsp", "question", "webfetch", "websearch", "external_directory", "doom_loop"}
+
+
+def fail(message): raise ValueError(message)
+
+
+def text(value, name, optional=False):
+    if value is None and optional: return None
+    if not isinstance(value, str) or (not optional and not value): fail(f"{name} must be a non-empty string")
+    return value
+
+
+def rel(value, name):
+    if isinstance(value, Path): value = str(value)
+    path = Path(text(value, name))
+    if path.is_absolute() or ".." in path.parts or str(path) in {"", "."}: fail(f"{name} must be a normalized relative path")
+    return path
+
+
+def regular(path, name, root=None):
+    path = Path(path)
+    if root is not None:
+        try: path.relative_to(root)
+        except ValueError: fail(f"{name} is outside its Data Machine agent root")
+    for parent in (path, *path.parents):
+        if parent.exists() and parent.is_symlink(): fail(f"{name} has a symlink target or parent")
+        if root is not None and parent == root: break
+    try: mode = path.lstat().st_mode
+    except OSError: fail(f"{name} does not exist")
+    if not stat.S_ISREG(mode): fail(f"{name} must be a regular non-symlink file")
+    return path
+
+
+def permission(value, name):
+    if not isinstance(value, dict): fail(f"{name} must be an OpenCode permission object")
+    for key, rule in value.items():
+        if not isinstance(key, str) or not key: fail(f"{name} has an invalid key")
+        if isinstance(rule, str) and rule in ACTIONS: continue
+        if isinstance(rule, dict): permission(rule, f"{name}.{key}"); continue
+        fail(f"{name}.{key} must use allow, deny, or ask")
+    return value
+
+
+def translated_policy(value, name):
+    if not isinstance(value, dict): fail(f"{name}.tool_policy must be an object")
+    # `opencode` is the explicit runtime-policy namespace. Generic capability
+    # policy remains Data Machine's authority; only capability IDs that are
+    # exact OpenCode permission actions can tighten this deny-default adapter.
+    native = value.get("opencode")
+    if native is not None:
+        if not isinstance(native, dict): fail(f"{name}.tool_policy.opencode must be an object")
+        return permission(native.get("permission", native), f"{name}.tool_policy.opencode")
+    if value.get("default") == "deny" and isinstance(value.get("allow"), list):
+        return {capability: "allow" for capability in value["allow"] if isinstance(capability, str) and capability in OPENCODE_ACTIONS}
+    return {}
+
+
+def map_sources(value, name, root, kind=None):
+    if not isinstance(value, dict): fail(f"{name} must be a source map")
+    result = {}
+    for target, source in value.items():
+        target = rel(target, f"{name} key")
+        source = regular(text(source, f"{name}.{target}"), f"{name}.{target}", root)
+        if kind is not None and source != root / kind / target: fail(f"{name}.{target} is outside the expected {kind}/ root")
+        result[target] = source
+    return result
+
+
+def skill_name(skill_file):
+    raw = skill_file.read_bytes()
+    if not raw.startswith(b"---\n"): fail(f"{skill_file} must have SKILL.md frontmatter")
+    try: frontmatter = raw.split(b"\n---\n", 1)[0].decode("utf-8")
+    except UnicodeDecodeError: fail(f"{skill_file} frontmatter must be UTF-8")
+    names = [line[5:].strip() for line in frontmatter.splitlines()[1:] if line.startswith("name:")]
+    if len(names) != 1 or not SLUG.fullmatch(names[0]): fail(f"{skill_file} frontmatter requires a slug name")
+    return names[0]
+
+
+def graph(data):
+    if not isinstance(data, dict) or data.get("success") is not True: fail("agent graph must be successful")
+    coordinator, nodes = text(data.get("coordinator"), "graph.coordinator"), data.get("nodes")
+    if not SLUG.fullmatch(coordinator) or not isinstance(nodes, list): fail("graph coordinator or nodes is invalid")
+    result, edges_by_node = {}, {}
+    for index, node in enumerate(nodes):
+        name = f"graph.nodes[{index}]"
+        if not isinstance(node, dict): fail(f"{name} must be an object")
+        slug = text(node.get("slug"), f"{name}.slug")
+        if not SLUG.fullmatch(slug) or slug in result or slug in edges_by_node: fail(f"{name}.slug is invalid or duplicated")
+        edges = node.get("subagents")
+        if not isinstance(edges, list) or len(edges) != len(set(edges)) or any(not isinstance(edge, str) or not SLUG.fullmatch(edge) for edge in edges): fail(f"{name}.subagents is invalid")
+        edges_by_node[slug] = sorted(edges)
+        sources = node.get("sources")
+        if not isinstance(sources, dict): fail(f"{name}.sources must be an object")
+        raw_instructions = sources.get("instructions")
+        if not isinstance(raw_instructions, dict): fail(f"{name}.sources.instructions must be a source map")
+        raw_skills, raw_references = sources.get("skills"), sources.get("references")
+        if not isinstance(raw_skills, dict) or not isinstance(raw_references, dict): fail(f"{name}.sources skills and references must be source maps")
+        candidates = []
+        for kind, raw in (("instructions", raw_instructions), ("skills", raw_skills), ("references", raw_references)):
+            for target, source in raw.items():
+                target = rel(target, f"{name}.sources.{kind} key")
+                source = Path(text(source, f"{name}.sources.{kind}.{target}"))
+                candidates.append(source.parent if kind == "instructions" else source.parents[len(target.parts)])
+        if not candidates: fail(f"{name}.sources must contain an artifact")
+        root = candidates[0]
+        if any(candidate != root for candidate in candidates): fail(f"{name}.sources do not share one agent root")
+        instructions = map_sources(raw_instructions, f"{name}.sources.instructions", root)
+        skills = map_sources(raw_skills, f"{name}.sources.skills", root, "skills")
+        references = map_sources(raw_references, f"{name}.sources.references", root, "references")
+        policy = translated_policy(node.get("tool_policy"), name)
+        declared = node.get("skill_policy", {}).get("paths") if isinstance(node.get("skill_policy"), dict) else None
+        if not isinstance(declared, list) or {rel(path, f"{name}.skill_policy.paths") for path in declared} != set(skills): fail(f"{name}.skill_policy.paths must exactly match sources.skills")
+        skill_files = {path: source for path, source in skills.items() if path.name == "SKILL.md"}
+        if skills and not skill_files: fail(f"{name}.sources.skills must contain SKILL.md")
+        names = {path: skill_name(source) for path, source in skill_files.items()}
+        if len(set(names.values())) != len(names): fail(f"{name} has duplicate SKILL.md names")
+        result[slug] = {"description": text(node.get("description"), f"{name}.description"), "model": text(node.get("model"), f"{name}.model", True) or None, "instructions": instructions, "skills": skills, "references": references, "skill_names": names, "permission": policy}
+    if coordinator not in edges_by_node: fail("graph does not contain its coordinator")
+    if any(edge not in result for edges in edges_by_node.values() for edge in edges): fail("graph contains an unresolved child edge")
+    return result, edges_by_node, coordinator
+
+
+def wrapper(instructions):
+    ordered = sorted(instructions.items())
+    if len(ordered) == 1: return ordered[0][1].read_bytes()
+    # Source copies remain byte-identical beside the agent; this wrapper only
+    # defines their deterministic composition order for OpenCode's prompt.
+    return b"\n\n".join(b"# " + str(path).encode() + b"\n\n" + source.read_bytes() for path, source in ordered)
+
+
+def agent_bytes(child, task_edges):
+    body = wrapper(child["instructions"])
+    permission_map = {"*": "deny", **child["permission"], "task": {"*": "deny", **{edge: "allow" for edge in task_edges}}, "skill": {name: "allow" for name in sorted(child["skill_names"].values())}}
+    front = ["---", f"description: {json.dumps(child['description'])}", "mode: subagent"]
+    if child["model"]: front.append(f"model: {json.dumps(child['model'])}")
+    front.append(f"permission: {json.dumps(permission_map, separators=(',', ':'))}")
+    return "\n".join(front).encode() + b"\n---\n\n" + body + b"\n\n<!-- " + SENTINEL.encode() + b" -->\n"
+
+
+def safe_target(root, relative, namespace):
+    relative = rel(relative, "managed manifest entry")
+    if not relative.parts or relative.parts[0] != namespace: fail(f"managed manifest entry is outside {namespace}/")
+    path = root / relative
+    for parent in (root, *path.parents):
+        if parent.exists() and parent.is_symlink(): fail(f"managed target has a symlink parent: {path}")
+        if parent == root: break
+    return path
+
+
+def atomic_write(path, contents, root):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for parent in path.parents:
+        if parent.is_symlink(): fail(f"managed target has a symlink parent: {path}")
+        if parent == root: break
+    if path.exists() and path.is_symlink(): fail(f"managed target is a symlink: {path}")
+    fd, temporary = tempfile.mkstemp(prefix=".wp-coding-agents-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as handle: handle.write(contents); handle.flush(); os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary): os.unlink(temporary)
+
+
+def manifest(path, root):
+    if not path.exists(): return {"agents": [], "artifacts": [], "task_permission": None, "skill_permission": {}}
+    regular(path, "managed manifest", root)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("sentinel") != SENTINEL: fail("managed manifest is unrecognized")
+    for key in ("agents", "artifacts"):
+        if not isinstance(data.get(key), list): fail(f"managed manifest {key} is invalid")
+    for value in data["agents"]: safe_target(root, value, "agents")
+    for value in data["artifacts"]:
+        value = rel(value, "managed manifest entry")
+        if value.parts[0] not in {"agents", "skills"}: fail("managed artifact is outside agents/ or skills/")
+        safe_target(root, value, value.parts[0])
+    if data.get("task_permission") is not None: permission({"task": data["task_permission"]}, "managed manifest task permission")
+    if not isinstance(data.get("skill_permission", {}), dict): fail("managed manifest skill permission is invalid")
+    permission({"skill": data.get("skill_permission", {})}, "managed manifest skill permission")
+    return data
+
+
+def main():
+    if len(sys.argv) != 3: raise SystemExit("usage: project-opencode-subagents.py GRAPH_JSON PROJECT_ROOT")
+    try:
+        nodes, edges, coordinator = graph(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")))
+        project, root = Path(sys.argv[2]), Path(sys.argv[2]) / ".opencode"
+        config_path, manifest_path = project / "opencode.json", root / MANIFEST_NAME
+        if not config_path.is_file() or config_path.is_symlink(): fail("opencode.json must be a regular file")
+        previous = manifest(manifest_path, root)
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(config, dict) or not isinstance(config.get("permission", {}), dict): fail("OpenCode config permission must be an object")
+        config.setdefault("permission", {})
+        children = {slug: node for slug, node in nodes.items() if slug != coordinator}
+        all_skill_names = [name for node in nodes.values() for name in node["skill_names"].values()]
+        if len(set(all_skill_names)) != len(all_skill_names): fail("graph has duplicate SKILL.md frontmatter names")
+        desired, agents, artifacts = {}, [], []
+        for slug, child in nodes.items():
+            if slug == coordinator:
+                continue
+            agent = Path("agents") / f"{slug}.md"
+            desired[root / agent] = agent_bytes(child, edges[slug])
+            agents.append(str(agent))
+            for relative, source in child["instructions"].items():
+                target = Path("agents") / f"{slug}.instructions" / relative
+                desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+            skill_roots = {path.parent: name for path, name in child["skill_names"].items()}
+            for relative, source in child["skills"].items():
+                matching = [base for base in skill_roots if relative.is_relative_to(base)]
+                if not matching: fail(f"skill support file is not below a SKILL.md: {relative}")
+                base = max(matching, key=lambda value: len(value.parts))
+                target = Path("skills") / skill_roots[base] / relative.relative_to(base)
+                desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+            for relative, source in child["references"].items():
+                matching = [base for base in skill_roots if relative.is_relative_to(base)]
+                if len(matching) != 1: fail(f"reference must belong to exactly one skill: {relative}")
+                base = matching[0]
+                target = Path("skills") / skill_roots[base] / "references" / relative.relative_to(base)
+                desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+        coordinator_skill_names = sorted(nodes[coordinator]["skill_names"].values())
+        coordinator_artifacts = nodes[coordinator]
+        skill_roots = {path.parent: name for path, name in coordinator_artifacts["skill_names"].items()}
+        for relative, source in coordinator_artifacts["skills"].items():
+            matching = [base for base in skill_roots if relative.is_relative_to(base)]
+            if not matching: fail(f"skill support file is not below a SKILL.md: {relative}")
+            base = max(matching, key=lambda value: len(value.parts))
+            target = Path("skills") / skill_roots[base] / relative.relative_to(base)
+            desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+        for relative, source in coordinator_artifacts["references"].items():
+            matching = [base for base in skill_roots if relative.is_relative_to(base)]
+            if len(matching) != 1: fail(f"reference must belong to exactly one skill: {relative}")
+            base = matching[0]
+            target = Path("skills") / skill_roots[base] / "references" / relative.relative_to(base)
+            desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+        # Only the coordinator's own task configuration belongs in opencode.json.
+        task = {"*": "deny", **{edge: "allow" for edge in edges[coordinator]}}
+        current = config["permission"].get("task")
+        if current not in (None, previous["task_permission"]): fail("refusing to overwrite user-owned OpenCode permission.task")
+        current_skill = config["permission"].get("skill", {})
+        if not isinstance(current_skill, dict): fail("refusing to overwrite non-map OpenCode permission.skill")
+        previous_skill = previous["skill_permission"]
+        if any(current_skill.get(name) != action for name, action in previous_skill.items()): fail("refusing to overwrite user-owned OpenCode permission.skill")
+        coordinator_skill_permission = {name: "allow" for name in coordinator_skill_names}
+        old = {safe_target(root, item, "agents") for item in previous["agents"]}
+        old |= {safe_target(root, item, rel(item, "managed manifest entry").parts[0]) for item in previous["artifacts"]}
+        old_agents = {safe_target(root, item, "agents") for item in previous["agents"]}
+        for path in desired:
+            if path.exists() and path not in old: fail(f"refusing to overwrite user-owned OpenCode file: {path}")
+            if path.exists() and path.is_symlink(): fail(f"managed target is a symlink: {path}")
+            if path in old_agents and path.exists() and SENTINEL.encode() not in path.read_bytes(): fail(f"refusing to overwrite user-modified OpenCode agent: {path}")
+        for path, contents in desired.items():
+            if not path.is_file() or path.read_bytes() != contents: atomic_write(path, contents, root)
+        for path in old - set(desired):
+            if path.exists():
+                if path.is_symlink() or not path.is_file(): fail(f"managed stale target is unsafe: {path}")
+                path.unlink()
+        if current != task:
+            config["permission"]["task"] = task
+        if coordinator_skill_permission:
+            config["permission"]["skill"] = {**current_skill, **coordinator_skill_permission}
+        elif previous_skill:
+            config["permission"]["skill"] = {key: value for key, value in current_skill.items() if key not in previous_skill}
+        if config["permission"].get("task") != current or config["permission"].get("skill", {}) != current_skill:
+            atomic_write(config_path, (json.dumps(config, indent=2) + "\n").encode(), project)
+        data = {"sentinel": SENTINEL, "agents": sorted(agents), "artifacts": sorted(artifacts), "task_permission": task, "skill_permission": coordinator_skill_permission}
+        serialized = (json.dumps(data, indent=2, sort_keys=True) + "\n").encode()
+        if not manifest_path.is_file() or manifest_path.read_bytes() != serialized: atomic_write(manifest_path, serialized, root)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"OpenCode subagent projection failed: {error}", file=sys.stderr); return 1
+    return 0
+
+
+if __name__ == "__main__": raise SystemExit(main())

--- a/lib/read-opencode-subagent-graph.php
+++ b/lib/read-opencode-subagent-graph.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Read a Data Machine agent relationship as a runtime-neutral projection graph.
+ *
+ * Invoked through `wp eval-file ... -- <coordinator-slug>` so the Agents API
+ * registry is fully initialized before this code reads its `subagents` edges.
+ */
+
+if ( ! function_exists( 'wp_get_agent' ) || ! function_exists( 'wp_get_ability' ) ) {
+	throw new RuntimeException( 'The Agents API and Data Machine abilities must be loaded.' );
+}
+
+$coordinator_slug = isset( $args[0] ) ? sanitize_title( (string) $args[0] ) : '';
+$coordinator      = '' === $coordinator_slug ? null : wp_get_agent( $coordinator_slug );
+if ( ! $coordinator instanceof WP_Agent ) {
+	throw new RuntimeException( 'The coordinator is not a registered Agents API agent.' );
+}
+
+$agents   = wp_get_agents();
+$pending  = array( $coordinator_slug );
+$visited  = array();
+$nodes    = array();
+$ability  = wp_get_ability( 'datamachine/list-injectable-memory-files' );
+
+while ( ! empty( $pending ) ) {
+	$slug = array_shift( $pending );
+	if ( isset( $visited[ $slug ] ) ) {
+		continue;
+	}
+	$visited[ $slug ] = true;
+	$agent            = $agents[ $slug ] ?? null;
+	if ( ! $agent instanceof WP_Agent ) {
+		throw new RuntimeException( sprintf( 'Registered agent "%s" declares an unresolved subagent.', $slug ) );
+	}
+
+	$config = $agent->get_default_config();
+	$meta   = $agent->get_meta();
+	$agent_id = (int) ( $meta['datamachine_agent_id'] ?? 0 );
+	if ( $agent_id <= 0 || ! $ability ) {
+		throw new RuntimeException( sprintf( 'Agent "%s" is not a persisted Data Machine agent.', $slug ) );
+	}
+	$memory = $ability->execute( array( 'agent_id' => $agent_id ) );
+	if ( empty( $memory['success'] ) || ! is_array( $memory['files'] ?? null ) ) {
+		throw new RuntimeException( sprintf( 'Could not resolve Data Machine identity files for "%s".', $slug ) );
+	}
+
+	$instructions = array();
+	foreach ( $memory['files'] as $file ) {
+		if ( ! is_array( $file ) || ! is_string( $file['filename'] ?? null ) || ! is_string( $file['path'] ?? null ) ) {
+			continue;
+		}
+		$instructions[ $file['filename'] ] = $file['path'];
+	}
+
+	// Skills and references are explicit portable agent config declarations.
+	// Each map key is the relative path retained by the runtime projection.
+	$skills     = is_array( $config['skills'] ?? null ) ? $config['skills'] : array();
+	$references = is_array( $config['references'] ?? null ) ? $config['references'] : array();
+	$subagents  = $agent->get_subagents();
+	foreach ( $subagents as $child ) {
+		$pending[] = $child;
+	}
+
+	$nodes[] = array(
+		'slug'         => $slug,
+		'description'  => $agent->get_description(),
+		'model'        => is_string( $config['default_model'] ?? null ) ? $config['default_model'] : '',
+		'subagents'    => $subagents,
+		'sources'      => array(
+			'instructions' => $instructions,
+			'skills'       => $skills,
+			'references'   => $references,
+		),
+		'tool_policy'  => is_array( $config['tool_policy'] ?? null ) ? $config['tool_policy'] : array(),
+		'skill_policy' => array( 'paths' => array_keys( $skills ) ),
+	);
+}
+
+echo wp_json_encode(
+	array(
+		'success'     => true,
+		'coordinator' => $coordinator_slug,
+		'nodes'       => $nodes,
+	),
+	JSON_UNESCAPED_SLASHES
+);

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect source-policy owned-source-discovery wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance; do
+for lib in common detect source-policy owned-source-discovery wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance opencode-subagents; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -527,6 +527,7 @@ ai_gateway_configure_opencode
 runtime_install_hooks
 configure_homeboy_wordpress_extension
 runtime_generate_instructions
+opencode_project_subagents
 runtime_merge_mcp_servers
 install_skills
 cli_transport_install

--- a/tests/opencode-subagents-reader.php
+++ b/tests/opencode-subagents-reader.php
@@ -1,0 +1,57 @@
+<?php
+/** Contract coverage for the Agents API/Data Machine graph reader. */
+
+final class WP_Agent {
+	public function __construct(
+		private string $description,
+		private array $subagents,
+		private array $config,
+		private array $meta
+	) {}
+	public function get_description(): string { return $this->description; }
+	public function get_subagents(): array { return $this->subagents; }
+	public function get_default_config(): array { return $this->config; }
+	public function get_meta(): array { return $this->meta; }
+}
+
+$agents = array(
+	'coordinator' => new WP_Agent( 'Routes work', array( 'writer' ), array(), array( 'datamachine_agent_id' => 1 ) ),
+	'writer'      => new WP_Agent( 'Writes prose', array(), array(
+		'default_model' => 'openai/gpt-5',
+		'skills'        => array( 'writer/SKILL.md' => '/agents/writer/skills/writer/SKILL.md' ),
+		'references'    => array( 'writer/context.md' => '/agents/writer/references/writer/context.md' ),
+	), array( 'datamachine_agent_id' => 2 ) ),
+);
+
+function sanitize_title( string $value ): string { return $value; }
+function wp_get_agent( string $slug ): ?WP_Agent { global $agents; return $agents[ $slug ] ?? null; }
+function wp_get_agents(): array { global $agents; return $agents; }
+function wp_json_encode( $value, int $flags = 0 ): string { return json_encode( $value, $flags | JSON_THROW_ON_ERROR ); }
+function wp_get_ability( string $slug ): object {
+	if ( 'datamachine/list-injectable-memory-files' !== $slug ) {
+		throw new RuntimeException( 'Unexpected ability.' );
+	}
+	return new class {
+		public function execute( array $input ): array {
+			return array( 'success' => true, 'files' => array(
+				array( 'filename' => 'SOUL.md', 'path' => '/agents/' . ( 1 === $input['agent_id'] ? 'coordinator' : 'writer' ) . '/SOUL.md' ),
+			) );
+		}
+	};
+}
+
+$args = array( 'coordinator' );
+ob_start();
+require __DIR__ . '/../lib/read-opencode-subagent-graph.php';
+$graph = json_decode( ob_get_clean(), true, 512, JSON_THROW_ON_ERROR );
+
+if ( array( 'writer' ) !== $graph['nodes'][0]['subagents'] ||
+	'openai/gpt-5' !== $graph['nodes'][1]['model'] ||
+	'/agents/writer/skills/writer/SKILL.md' !== $graph['nodes'][1]['sources']['skills']['writer/SKILL.md'] ||
+	'/agents/writer/references/writer/context.md' !== $graph['nodes'][1]['sources']['references']['writer/context.md'] ||
+	array( 'writer/SKILL.md' ) !== $graph['nodes'][1]['skill_policy']['paths'] ) {
+	fwrite( STDERR, "FAIL: reader did not project the registered relationship and declared artifacts\n" );
+	exit( 1 );
+}
+
+echo "ok: Agents API subagents and Data Machine artifacts project into the graph\n";

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# Contract coverage for Data Machine coordinator graph -> OpenCode projection.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SITE_PATH="$TMP/site"
+AGENT_SLUG="coordinator"
+DRY_RUN=false
+RUNTIME=opencode
+mkdir -p "$SITE_PATH/.opencode/agents" "$TMP/identity"
+touch "$SITE_PATH/wp-config.php"
+printf '%s\n' '{"model":"preserve","mcp":{},"permission":{"read":"allow","skill":{"user-skill":"ask"}}}' > "$SITE_PATH/opencode.json"
+
+source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/lib/opencode-subagents.sh"
+log() { :; }
+warn() { printf '%s\n' "$*" >&2; }
+
+FAILED=0
+assert() { if "$@"; then printf '  ok   %s\n' "$*"; else printf '  FAIL %s\n' "$*"; FAILED=$((FAILED + 1)); fi; }
+assert_python() { local name="$1"; shift; if python3 - "$@"; then printf '  ok   %s\n' "$name"; else printf '  FAIL %s\n' "$name"; FAILED=$((FAILED + 1)); fi; }
+wp_cmd() { [ "$1" = eval-file ] && [ "$2" = "$SCRIPT_DIR/lib/read-opencode-subagent-graph.php" ] && [ "$3" = -- ] && [ "$4" = "$AGENT_SLUG" ]; cat "$TMP/graph.json"; }
+
+php "$SCRIPT_DIR/tests/opencode-subagents-reader.php"
+
+printf '# Writer identity\n\nWrite exact prose.\n' > "$TMP/identity/writer-soul.md"
+mkdir -p "$TMP/identity-review"
+printf '# Reviewer identity\n\nReport defects.\n' > "$TMP/identity-review/reviewer-soul.md"
+printf '# Researcher identity\n\nGather evidence.\n' > "$TMP/identity/researcher-soul.md"
+mkdir -p "$TMP/identity/skills/writer" "$TMP/identity/references/writer" "$TMP/identity-review/skills/reviewer" "$TMP/coordinator/skills/root" "$TMP/coordinator/references/root"
+printf '# Coordinator identity\n' > "$TMP/coordinator/SOUL.md"
+printf '%s\n' '---' 'name: editorial' '---' '' 'Follow the house style.' > "$TMP/identity/skills/writer/SKILL.md"
+printf 'Reference bytes\n\x00\xff' > "$TMP/identity/references/writer/context.bin"
+printf '%s\n' '---' 'name: review' '---' '' 'Use the review checklist.' > "$TMP/identity-review/skills/reviewer/SKILL.md"
+printf '%s\n' '---' 'name: root-skill' '---' '' 'Use root context.' > "$TMP/coordinator/skills/root/SKILL.md"
+printf 'Root reference bytes\n' > "$TMP/coordinator/references/root/context.md"
+
+write_graph() {
+  cat > "$TMP/graph.json" <<JSON
+{
+  "success": true,
+  "coordinator": "coordinator",
+  "nodes": [
+    {"slug":"coordinator","label":"Coordinator","description":"Routes work","subagents":["writer","reviewer","researcher"],"model":"","sources":{"instructions":{"SOUL.md":"$TMP/coordinator/SOUL.md"},"skills":{"root/SKILL.md":"$TMP/coordinator/skills/root/SKILL.md"},"references":{"root/context.md":"$TMP/coordinator/references/root/context.md"}},"tool_policy":{"default":"deny","allow":["datamachine/search","websearch"]},"skill_policy":{"paths":["root/SKILL.md"]}},
+    {"slug":"writer","label":"Writer","description":"Write implementation","subagents":["researcher"],"model":"openai/gpt-5","sources":{"instructions":{"SOUL.md":"$TMP/identity/writer-soul.md"},"skills":{"writer/SKILL.md":"$TMP/identity/skills/writer/SKILL.md"},"references":{"writer/context.bin":"$TMP/identity/references/writer/context.bin"}},"tool_policy":{"default":"deny","allow":["datamachine/search","bash"]},"skill_policy":{"paths":["writer/SKILL.md"]}},
+    {"slug":"reviewer","label":"Reviewer","description":"Review implementation","subagents":[],"model":"","sources":{"instructions":{"SOUL.md":"$TMP/identity-review/reviewer-soul.md"},"skills":{"reviewer/SKILL.md":"$TMP/identity-review/skills/reviewer/SKILL.md"},"references":{}},"tool_policy":{"default":"deny","allow":["datamachine/search"]},"skill_policy":{"paths":["reviewer/SKILL.md"]}},
+    {"slug":"researcher","label":"Researcher","description":"Research context","subagents":[],"model":"","sources":{"instructions":{"SOUL.md":"$TMP/identity/researcher-soul.md"},"skills":{},"references":{}},"tool_policy":{"default":"deny","allow":["webfetch"]},"skill_policy":{"paths":[]}}
+  ]
+}
+JSON
+}
+
+write_graph
+echo '==> coordinator plus three graph children'
+opencode_project_subagents
+assert test -f "$SITE_PATH/.opencode/agents/writer.md"
+assert test -f "$SITE_PATH/.opencode/agents/reviewer.md"
+assert test -f "$SITE_PATH/.opencode/agents/researcher.md"
+assert_python 'model, policy, skill allowlist, and child identity project' "$SITE_PATH/.opencode/agents/writer.md" <<'PY'
+import sys
+text = open(sys.argv[1]).read()
+assert 'description: "Write implementation"' in text
+assert 'mode: subagent' in text
+assert 'model: "openai/gpt-5"' in text
+assert '"*":"deny"' in text and '"bash":"allow"' in text
+assert 'datamachine/search' not in text
+assert '"skill":{"editorial":"allow"}' in text
+assert '"task":{"*":"deny","researcher":"allow"}' in text
+assert 'skills:' not in text
+assert '# Writer identity\n\nWrite exact prose.' in text
+PY
+assert_python 'source maps retain bytes and scope references to owning skill' "$TMP/identity/skills/writer/SKILL.md" "$SITE_PATH/.opencode/skills/editorial/SKILL.md" "$TMP/identity/references/writer/context.bin" "$SITE_PATH/.opencode/skills/editorial/references/context.bin" <<'PY'
+import sys
+# Mapping contract: each child owns one OpenCode skill directory. Source-map
+# paths stay below its skills/ or references/ branch, so matching basenames
+# never collide and every graph key remains recoverable from the destination.
+assert open(sys.argv[1], 'rb').read() == open(sys.argv[2], 'rb').read()
+assert open(sys.argv[3], 'rb').read() == open(sys.argv[4], 'rb').read()
+PY
+assert_python 'manifest records only managed files and task is limited to direct children' "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json" "$SITE_PATH/opencode.json" <<'PY'
+import json, sys
+manifest = json.load(open(sys.argv[1]))
+assert manifest['agents'] == ['agents/researcher.md', 'agents/reviewer.md', 'agents/writer.md']
+assert 'skills/editorial/SKILL.md' in manifest['artifacts']
+assert 'skills/editorial/references/context.bin' in manifest['artifacts']
+config = json.load(open(sys.argv[2]))
+assert config['model'] == 'preserve' and config['mcp'] == {}
+assert config['permission']['read'] == 'allow'
+assert config['permission']['task'] == {'*': 'deny', 'researcher': 'allow', 'reviewer': 'allow', 'writer': 'allow'}
+assert config['permission']['skill']['root-skill'] == 'allow'
+assert config['permission']['skill']['user-skill'] == 'ask'
+assert open(sys.argv[1].replace('.wp-coding-agents-subagents.json', 'skills/root-skill/SKILL.md'), 'rb').read().startswith(b'---\nname: root-skill\n')
+PY
+if command -v opencode >/dev/null 2>&1; then
+  (cd "$SITE_PATH" && opencode agent list --pure >/dev/null)
+  printf '  ok   OpenCode parses generated agent and skill files\n'
+fi
+
+echo '==> idempotency and stale managed removal'
+before="$(shasum "$SITE_PATH/.opencode/agents/writer.md" "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json")"
+opencode_project_subagents
+after="$(shasum "$SITE_PATH/.opencode/agents/writer.md" "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json")"
+[ "$before" = "$after" ] || FAILED=$((FAILED + 1))
+printf '  ok   repeated graph reconciliation is byte-stable\n'
+python3 - "$TMP/graph.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+data['nodes'] = [node for node in data['nodes'] if node['slug'] in ('coordinator', 'writer')]
+data['nodes'][0]['subagents'] = ['writer']
+data['nodes'][1]['subagents'] = []
+data['nodes'][0]['sources']['skills'] = {}
+data['nodes'][0]['sources']['references'] = {}
+data['nodes'][0]['skill_policy']['paths'] = []
+json.dump(data, open(p, 'w'))
+PY
+opencode_project_subagents
+assert test ! -e "$SITE_PATH/.opencode/agents/reviewer.md"
+assert test ! -e "$SITE_PATH/.opencode/agents/researcher.md"
+assert test ! -e "$SITE_PATH/.opencode/skills/review/SKILL.md"
+assert test -f "$SITE_PATH/.opencode/agents/writer.md"
+
+echo '==> malformed graph and user-owned collision reject without mutation'
+before="$(shasum "$SITE_PATH/.opencode/agents/writer.md")"
+printf '%s\n' '{"success":true,"coordinator":"coordinator","nodes":[{"slug":"bad_slug"}]}' > "$TMP/graph.json"
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+after="$(shasum "$SITE_PATH/.opencode/agents/writer.md")"
+[ "$before" = "$after" ] || FAILED=$((FAILED + 1))
+printf '  ok   malformed graph leaves managed state unchanged\n'
+rm "$SITE_PATH/.opencode/agents/writer.md"
+printf '%s\n' 'human configuration' > "$SITE_PATH/.opencode/agents/writer.md"
+write_graph
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+assert_python 'user-owned collision remains intact' "$SITE_PATH/.opencode/agents/writer.md" <<'PY'
+import sys
+assert open(sys.argv[1]).read() == 'human configuration\n'
+PY
+
+rm "$SITE_PATH/.opencode/agents/writer.md"
+write_graph
+python3 - "$TMP/graph.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+data['nodes'].append({
+    'slug': 'collision', 'label': 'Collision', 'description': 'Collision',
+    'subagents': [], 'model': '',
+    'sources': {'instructions': {'SOUL.md': data['nodes'][1]['sources']['instructions']['SOUL.md']}, 'skills': {}, 'references': {}},
+    'tool_policy': {'opencode': {'permission': {}}}, 'skill_policy': {'paths': []},
+})
+data['nodes'][0]['subagents'].append('collision')
+json.dump(data, open(p, 'w'))
+PY
+printf '%s\n' 'user-owned agent' > "$SITE_PATH/.opencode/agents/collision.md"
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+assert_python 'unmanaged agent collision remains intact' "$SITE_PATH/.opencode/agents/collision.md" <<'PY'
+import sys
+assert open(sys.argv[1]).read() == 'user-owned agent\n'
+PY
+
+echo '==> containment and nested child policies reject unsafe input'
+write_graph
+before="$(shasum "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json")"
+python3 - "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+data['artifacts'] = ['../outside']
+json.dump(data, open(p, 'w'))
+PY
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+printf '%s\n' '  ok   manifest traversal is rejected'
+rm "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json"
+write_graph
+ln -s "$TMP/identity/writer-soul.md" "$TMP/identity/skills/writer/link.md"
+python3 - "$TMP/graph.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+data['nodes'][1]['sources']['skills']['writer/link.md'] = data['nodes'][1]['sources']['skills']['writer/SKILL.md'].replace('SKILL.md', 'link.md')
+data['nodes'][1]['skill_policy']['paths'].append('writer/link.md')
+json.dump(data, open(p, 'w'))
+PY
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+printf '%s\n' '  ok   symlink source is rejected'
+
+write_graph
+python3 - "$TMP/graph.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+# The coordinator name collides with the writer's frontmatter name. This must
+# reject the complete graph before it can overwrite any generated artifact.
+root = data['nodes'][0]['sources']['skills']['root/SKILL.md']
+open(root, 'w').write('---\nname: editorial\n---\n')
+data['nodes'][0]['skill_policy']['paths'] = ['root/SKILL.md']
+json.dump(data, open(p, 'w'))
+PY
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+printf '%s\n' '  ok   graph-wide duplicate skill name is rejected'
+
+[ "$FAILED" -eq 0 ] || exit 1

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups; do
+for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -960,6 +960,7 @@ regenerate_agents_md() {
   # next normalize.
   if (cd "$SITE_PATH" && wp_run_as_service_user datamachine memory compose AGENTS.md >/dev/null 2>&1); then
     service_file_normalize_perms "$AGENTS_MD"
+    opencode_project_subagents
     if [ -f "$BACKUP" ] && cmp -s "$BACKUP" "$AGENTS_MD"; then
       log "  AGENTS.md unchanged"
       rm -f "$BACKUP" 2>/dev/null || true
@@ -1413,6 +1414,7 @@ regenerate_agents_md
 sync_claude_code_runtime
 sync_runtime_signature
 sync_runtime_instructions
+opencode_project_subagents
 update_chat_bridge_systemd
 update_chat_bridge_launchd
 update_datamachine_worker_service


### PR DESCRIPTION
Closes #355

## Summary
- Read the registered Agents API `subagents` relationship from persisted Data Machine agents.
- Project child identity, declared skills, and supporting references into managed OpenCode agents and skills.
- Restrict coordinator task dispatch and each agent skill access with OpenCode permissions.

## Validation
- `bash tests/opencode-subagents.sh`
- `bash tests/ci-coverage.sh`
- shell/PHP/Python syntax checks

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to inspect the existing Agents API and Data Machine contracts, implement the runtime projection, and add deterministic test coverage. Chris Huber reviewed the change and remains responsible for every line.